### PR TITLE
Implement point;vertex and polygon;equilateralTriangle; improve test …

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -31,6 +31,16 @@ These affect the library as a whole, independent of individual constructions.
   has no `align` field; all elements get the same `defaultAlign`. The Java applet supports
   per-element label placement.
 
+- [ ] **Labels all use the same default orientation** (`src/elements/GeomElement.ts`) —
+  In the TypeScript port every label is drawn at the same position relative to its vertex
+  (currently below/at the default align direction). In the Java applet labels adapt to the
+  geometry: a vertex at the top of a figure gets its label *above* the dot, a bottom vertex
+  gets its label *below*, etc. Example: in the equilateral triangle test (propI10), the apex
+  label "C" should sit above the vertex point, but in the port it sits below, making it harder
+  to read and obscuring the vertex dot. Fix requires either: (a) a per-element `align` field in
+  `IConstructionInfo` so callers can override placement, or (b) a heuristic in `drawName` that
+  infers placement from the element's position relative to other elements.
+
 - [ ] **Highlight colors not settable via init()** — `GeomElement` has
   `nameHighlightColor`, `vertexHighlightColor`, `edgeHighlightColor`, `faceHighlightColor`
   properties but `IConstructionInfo` exposes no way to set them. Currently only settable
@@ -102,7 +112,7 @@ These affect the library as a whole, independent of individual constructions.
   - no dedicated test page
 
 - [x] **`circleSlider`** — `src/elements/point/CircleSlider.ts`
-  - [~] tested in [view/test/sector/index.html](../view/test/sector/index.html) — no standalone page
+  - [~] tested in [view/test/sector/sector.html](../view/test/sector/sector.html) — no standalone page
 
 - [x] **`perpendicular`** (5 signature variants) — `src/elements/point/Perpendicular*.ts`
   - [~] tested in [view/test/circumcenter_lineperp.html](../view/test/circumcenter_lineperp.html) — no standalone page
@@ -111,8 +121,10 @@ These affect the library as a whole, independent of individual constructions.
   - Java source: construct `Slate.java` or `Geometry.java` (4th vertex: D = A + C − B)
   - Used in: I.28, I.30, I.32–I.36, I.37–I.41, I.42–I.43, all of Book II
 
-- [ ] **`vertex`** — TBD
-  - Java source: `PolygonElement.java`
+- [x] **`vertex`** — `src/elements/Constructions.ts` (`VertexConstruction`)
+  - Returns `polygon.V[n-1]` (1-based index); no new element file needed
+  - Also added `PolygonElement` to `ConstructionTypes` enum and `validateSignature`
+  - [x] test view: [view/test/point/vertex.html](../view/test/point/vertex.html)
   - Used in: I.2, I.9–I.11, I.23–I.24, I.26, I.33–I.34, I.36, I.41–I.47, Book II, III.14, III.24–III.25
 
 - [ ] **`similar`** — TBD
@@ -216,7 +228,7 @@ These affect the library as a whole, independent of individual constructions.
 ## Polygon constructions
 
 - [x] **`triangle`** — `src/elements/polygon/PolygonElement.ts` (via `TrianglePolygonConstruction`)
-  - [~] test view: [view/test/poly/index.html](../view/test/poly/index.html) — tests triangle among other elements; no standalone triangle page
+  - [~] test view: [view/test/poly/triangle.html](../view/test/poly/triangle.html) — tests triangle among other elements; no standalone triangle page
 
 - [ ] **`quadrilateral`** — TBD
   - Java source: `PolygonElement.java`
@@ -230,8 +242,11 @@ These affect the library as a whole, independent of individual constructions.
   - Java source: `PolygonElement.java`
   - Used in: I.46–I.47, II.2–II.8, II.11
 
-- [ ] **`equilateralTriangle`** — TBD
-  - Java source: `PolygonElement.java`
+- [x] **`equilateralTriangle`** — `src/elements/polygon/RegularPolygonElement.ts` (via `EquilateralTriangleConstruction`)
+  - 2D variant only (screen plane); 3D variant (`[PointElement, PointElement, PlaneElement]`) TBD
+  - Java source: `RegularPolygon.java` with n=3; theta=π/3, cos=0.5, sin=√3/2
+  - `update()`: V[2].to(V[0]).rotate(V[1], cos, sin, screen)
+  - [x] test view: [view/test/poly/equilateralTriangle.html](../view/test/poly/equilateralTriangle.html) — mirrors propI10 params
   - Used in: I.2, I.9–I.11, III.10, III.24
 
 - [ ] **`similar`** — TBD
@@ -267,7 +282,7 @@ These affect the library as a whole, independent of individual constructions.
 ## Sector constructions
 
 - [x] **`sector`** (2 signature variants) — `src/elements/sector/SectorElement.ts`
-  - [x] test view: [view/test/sector/index.html](../view/test/sector/index.html)
+  - [x] test view: [view/test/sector/sector.html](../view/test/sector/sector.html)
 
 - [ ] **`arc`** — TBD
   - Java source: `Arc.java` — computes circumcenter of three given points; draws arc through A, M, B
@@ -312,14 +327,16 @@ These affect the library as a whole, independent of individual constructions.
 | `Point.free` | (used in all pages) | implicit |
 | `Point.intersection` | view/test/point/intersection.html | exists |
 | `Point.foot` | view/test/point/foot.html | exists |
+| `Point.vertex` | view/test/point/vertex.html | exists |
 | `Point.circumcenter` | view/test/circumcenter_lineperp.html | compound |
-| `Point.circleSlider` | view/test/sector/index.html | compound |
+| `Point.circleSlider` | view/test/sector/sector.html | compound |
 | `Point.perpendicular` | view/test/circumcenter_lineperp.html | compound |
 | `Line.connect` | (used in all pages) | implicit |
 | `Line.perpendicular` | view/test/line/perpendicular.html | exists |
 | `Line.bichord` | view/test/line/bichord.html | exists |
 | `Circle.radius` | view/test/circle/circle.html | exists |
 | `Circle.circumcircle` | view/test/circle/circumcircle.html | exists |
-| `Polygon.triangle` | view/test/poly/index.html | compound |
-| `Sector.sector` | view/test/sector/index.html | exists |
+| `Polygon.triangle` | view/test/poly/triangle.html | compound |
+| `Polygon.equilateralTriangle` | view/test/poly/equilateralTriangle.html | exists |
+| `Sector.sector` | view/test/sector/sector.html | exists |
 | All others | — | missing |

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,54 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-10 — Implemented polygon;equilateralTriangle
+
+**Completed:**
+- Created `src/elements/polygon/RegularPolygonElement.ts` — port of `RegularPolygon.java` (n=3)
+- Added `EquilateralTriangleConstruction` to `Constructions.ts`; registered in `constructions` array
+- Wrote Mocha test (13 passing): equilateral side-length equality + apex above base
+- Created `view/test/poly/equilateralTriangle.html` mirroring propI10 params
+- Updated `doc/process.md` with "Identifying a verifiable proposition instance" guidance
+- I.9, I.10, I.11 are now fully renderable
+
+**Discovered:**
+- `RegularPolygon.java` builds all vertices iteratively: V[i] = V[i-2] rotated around V[i-1] by
+  θ = π(n-2)/n. For n=3 this runs once, placing the apex at A rotated 60° around B.
+- `PointElement.rotate(pivot, ac, as, plane?)` applies a 2D rotation matrix in screen coords
+  when `plane.isScreen` is true.
+- The 2D-first policy applies: signature `[PointElement, PointElement]` dispatches to screen plane
+  only. The 3D variant `[PointElement, PointElement, PlaneElement]` remains TBD.
+
+**Next session:**
+- `sector;arc` (20 uses) — needs `ArcElement.ts`; computes circumcenter of A,M,B and draws arc
+- `point;parallelogram` (48 uses) — D = A + C − B; very simple, no new element file needed
+- `line;chord` (17 uses) — `Chord.java`
+
+---
+
+## 2026-04-10 — Implemented point;vertex
+
+**Completed:**
+- Created feature branch `feature/point-vertex`
+- Added `PolygonElement` to `ConstructionTypes` enum in `src/elements/Constructions.ts`
+- Added `PolygonElement` case to `Construction.validateSignature`
+- Added `VertexConstruction` class — returns `polygon.V[n-1]` (1-based), no new element file needed
+- Registered `new VertexConstruction()` in the `constructions` array
+- Wrote Mocha test (12 passing)
+- Created `view/test/point/vertex.html` test page
+
+**Discovered:**
+- `vertex` uses the "preexists" pattern from Java — it aliases an existing vertex point under a new
+  name. `Slate.createElement` renames the element, so the old name is superseded by the new one.
+  This is intentional and matches the Java applet's behavior.
+- Adopted 2D-first policy: for constructions with both 2D and 3D variants, implement 2D first.
+
+**Next session:**
+- `point;parallelogram` (48 uses) — reuses `Layoff`, no new element file, very simple
+- `sector;arc` (20 uses) — needs `ArcElement.ts` extending `SectorElement`; implement 2D variant first
+
+---
+
 ## 2026-04-10 — Documentation created; project state surveyed
 
 **Completed:**

--- a/doc/process.md
+++ b/doc/process.md
@@ -14,6 +14,28 @@ TBD construction (sorted by Books I–III usage count at the bottom of that file
 Also check [proposition-tracker.md](proposition-tracker.md) to see which propositions
 will become renderable once the construction is done — this gives useful test cases.
 
+### Identifying a verifiable proposition instance
+
+Before locking in a construction choice, verify that at least one Book I–III proposition
+exists where the target construction appears and every element *before* it in the param list
+uses only already-implemented constructions.
+
+Search method:
+
+```sh
+grep -rl ";constructionname;" view/euclid-html/
+```
+
+For each candidate file, read the `<param name=e[N]>` lines in order. Starting from e[1],
+check each construction type against the implementation tracker. Stop at the first element
+that hits a TBD construction. If the target construction appears *before* that TBD element,
+you have a verifiable test case. If not, consider whether the element directly before the
+target is also something worth implementing first (the "unlock chain").
+
+A proposition where the target construction is the *only* TBD construction is the ideal case.
+If no such proposition exists for Books I–III, note this in the journal and rely on the
+standalone test view page for visual verification instead.
+
 ---
 
 ## Step 2 — Read the Java source
@@ -170,6 +192,10 @@ skip the unit test and rely on visual verification in Step 8 — note this in th
 ## Step 8 — Create the test view page
 
 Create `view/test/{super_type}/{sub_type}.html`.
+
+Where possible, use the params from a verifiable proposition instance (identified in Step 1)
+as the test view, rather than a synthetic example. This lets you compare directly against
+the Java applet GIF or appletviewer output.
 
 The naming convention:
 - `{super_type}` = element category: `point`, `line`, `circle`, `poly`, `sector`, `plane`, `sphere`

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -35,6 +35,7 @@ import {Perpendicular} from "./line/Perpendicular";
 import {PlanePerpendicularLine} from "./line/PlanePerpendicularLine";
 import {Bichord} from "./line/Bichord";
 import {PolygonElement} from "./polygon/PolygonElement";
+import {RegularPolygonElement} from "./polygon/RegularPolygonElement";
 import {SphereElement} from "./sphere/SphereElement";
 
 export enum ConstructionTypes {
@@ -42,7 +43,8 @@ export enum ConstructionTypes {
     PointElement,
     CircleElement,
     PlaneElement,
-    SphereElement
+    SphereElement,
+    PolygonElement
 }
 
 export enum PointConstructions {
@@ -215,6 +217,11 @@ export abstract class Construction {
                     break;
                 case ConstructionTypes.SphereElement:
                     // TODO:
+                    break;
+                case ConstructionTypes.PolygonElement:
+                    if (!(param instanceof PolygonElement)) {
+                        return false;
+                    }
                     break;
                 default:
                     return false;
@@ -986,6 +993,22 @@ export class TrianglePolygonConstruction extends PolyConstruction {
 }
 
 
+// point
+// vertex
+// polygon A, integer n
+// the nth vertex (1-based) of polygon A
+export class VertexConstruction extends Construction {
+    constructionMethod: AllConstructions = PointConstructions.vertex;
+    signature: ConstructionTypes[] = [ct.PolygonElement, ct.Integer];
+
+    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const poly = params[0] as PolygonElement;
+        const n    = params[1] as number;
+        const vertex = poly.V[n - 1];
+        return [[vertex], vertex];
+    }
+}
+
 // TBD
 // polygon
 // quadrilateral
@@ -1004,11 +1027,20 @@ export class TrianglePolygonConstruction extends PolyConstruction {
 // points A, B, C, D, E, F
 // the hexagon given 6 vertices
 
-// TBD
 // polygon
 // equilateralTriangle
-// points A, B [plane C]
-// the equilateral triangle on a side AB in plane C
+// points A, B [plane C = screen]
+// the equilateral triangle on side AB in the screen plane (2D variant)
+export class EquilateralTriangleConstruction extends Construction {
+    constructionMethod: AllConstructions = PolygonConstructions.equilateralTriangle;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement];
+
+    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const [a, b] = params as [PointElement, PointElement];
+        const g = new RegularPolygonElement(a, b, screen, 3);
+        return [[g], g];
+    }
+}
 
 // TBD
 // polygon
@@ -1260,6 +1292,8 @@ export const constructions : Construction[] = [
     new LinePerpendicular5Construction(),
     new BichordConstruction(),
     new TrianglePolygonConstruction(),
+    new EquilateralTriangleConstruction(),
+    new VertexConstruction(),
     new PerpendicularPlaneConstruction(),
     new SphereRadiusConstruction()
 ];

--- a/src/elements/polygon/RegularPolygonElement.ts
+++ b/src/elements/polygon/RegularPolygonElement.ts
@@ -1,0 +1,60 @@
+/*----------------------------------------------------------------------+
+|    Title:	RegularPolygonElement.ts                                    |
+|    A port of the software Geometry Applet by                          |
+|    Author:    David E. Joyce                                          |
+|        Department of Mathematics and Computer Science                 |
+|        Clark University                                               |
+|        Worcester, MA 01610-1477                                       |
+|        U.S.A.                                                         |
+|                                                                       |
+|        http://aleph0.clarku.edu/~djoyce/home.html                     |
+|        djoyce@clarku.edu                                              |
+|                                                                       |
+|    Date:    February, 1996.   Version 2.0.0 May, 1997.                |
+|    TypeScript Port: 2019, Nelson Brown, brownnrl@gmail.com            |
+|                           https://www.nelsonbrown.net/                |
++----------------------------------------------------------------------*/
+
+import {PolygonElement} from "./PolygonElement";
+import {PointElement} from "../point/PointElement";
+import {PlaneElement} from "../plane/PlaneElement";
+
+export class RegularPolygonElement extends PolygonElement {
+
+    private _cos: number;
+    private _sin: number;
+    private _P: PlaneElement;
+
+    constructor(A: PointElement, B: PointElement, plane: PlaneElement, n: number) {
+        super();
+        this._P = plane;
+        const theta = Math.PI * (n - 2) / n;
+        this._cos = Math.cos(theta);
+        this._sin = Math.sin(theta);
+        this.V = new Array(n);
+        this.V[0] = A;
+        this.V[1] = B;
+        for (let i = 2; i < n; i++) {
+            this.V[i] = new PointElement({ AP: plane });
+        }
+    }
+
+    update(): void {
+        for (let i = 2; i < this.V.length; i++) {
+            this.V[i].to(this.V[i - 2]);
+            this.V[i].rotate(this.V[i - 1], this._cos, this._sin, this._P);
+        }
+    }
+
+    translate(dx: number, dy: number): void {
+        for (let i = 2; i < this.V.length; i++) {
+            this.V[i].translate(dx, dy);
+        }
+    }
+
+    rotate(pivot: PointElement, ac: number, as: number): void {
+        for (let i = 2; i < this.V.length; i++) {
+            this.V[i].rotate(pivot, ac, as, this._P);
+        }
+    }
+}

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -241,6 +241,50 @@ describe("slate", ()=> {
         assert.equal(B.y, 100);
     });
 
+    it("should return the nth vertex of a triangle", () => {
+        const data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [100, 50] },
+            { name: "B", construction: E.Point.free, params: [50, 200] },
+            { name: "C", construction: E.Point.free, params: [250, 200] },
+            { name: "T", construction: E.Polygon.triangle, params: ["A", "B", "C"] },
+            { name: "V1", construction: E.Point.vertex, params: ["T", 1] },
+            { name: "V2", construction: E.Point.vertex, params: ["T", 2] },
+            { name: "V3", construction: E.Point.vertex, params: ["T", 3] },
+        ];
+        let slate = new Slate(createCanvas(400, 300));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let V1 = slate.lookupElement("V1") as PointElement;
+        let V2 = slate.lookupElement("V2") as PointElement;
+        let V3 = slate.lookupElement("V3") as PointElement;
+        almostEqual(V1.x, 100, 1); almostEqual(V1.y, 50, 1);
+        almostEqual(V2.x, 50, 1);  almostEqual(V2.y, 200, 1);
+        almostEqual(V3.x, 250, 1); almostEqual(V3.y, 200, 1);
+    });
+
+    it("should produce an equilateral triangle", () => {
+        const data: IConstructionInfo[] = [
+            { name: "A",   construction: E.Point.free,               params: [40, 170] },
+            { name: "B",   construction: E.Point.free,               params: [200, 170] },
+            { name: "ABC", construction: E.Polygon.equilateralTriangle, params: ["A", "B"] },
+            { name: "C",   construction: E.Point.vertex,             params: ["ABC", 3] },
+        ];
+        const slate = new Slate(createCanvas(400, 300));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        const A = slate.lookupElement("A") as PointElement;
+        const B = slate.lookupElement("B") as PointElement;
+        const C = slate.lookupElement("C") as PointElement;
+        // All three sides must be equal length (equilateral)
+        const ab = Math.hypot(B.x - A.x, B.y - A.y);
+        const ac = Math.hypot(C.x - A.x, C.y - A.y);
+        const bc = Math.hypot(C.x - B.x, C.y - B.y);
+        almostEqual(ac, ab, 1);
+        almostEqual(bc, ab, 1);
+        // Apex should be above the base (smaller y in screen coordinates)
+        assert.ok(C.y < A.y);
+    });
+
     it("should be able to find the closest visible point within a tolerance", () =>{
         let slate : Slate = new Slate(createCanvas(200,200));
         let elms = toElements(slate, connected_line_data);

--- a/view/test/circle/circle.html
+++ b/view/test/circle/circle.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>Test View</title>
+    <title>Test View - Circle.radius (Post.3)</title>
 </head>
 <body>
 <canvas id="canvasId" style="width:600px; height: 600px;"></canvas>
@@ -13,7 +13,7 @@
     let E = geomlib.E;
     geomlib.init({
         background: '#ffe9cd',
-        title: "Post.1",
+        title: "Post.3 — To describe a circle with any center and distance",
         align: Align.ABOVE,
         canvasid: "canvasId",
         elements: [

--- a/view/test/circle/circumcircle.html
+++ b/view/test/circle/circumcircle.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>Test View: Circumcircle</title>
+    <title>Test View - Circle.circumcircle (III.10)</title>
 </head>
 <body>
 <canvas id="canvasId" style="width:600px; height: 600px;"></canvas>
@@ -30,7 +30,7 @@
     ]
     geomlib.init({
         background: '#ffe9cd',
-        title: "Post.1",
+        title: "III.10 — A circle does not cut a circle at more than two points",
         align: Align.ABOVE,
         canvasid: "canvasId",
         elements:  circle_center_circumcircle_data })

--- a/view/test/circumcenter_lineperp.html
+++ b/view/test/circumcenter_lineperp.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>Test View : circumcenter and line</title>
+    <title>Test View - Point.circumcenter + Line.perpendicular (III.25a)</title>
 </head>
 <body>
 <canvas id="canvasId" style="width:200px; height: 200px;"></canvas>
@@ -22,7 +22,7 @@
     ]
     geomlib.init({
         background: '#ffe9cd',
-        title: "propIII25",
+        title: "III.25a — Given a segment of a circle, to describe the complete circle",
         align: Align.ABOVE,
         canvasid: "canvasId",
         elements: elems    })

--- a/view/test/line/bichord.html
+++ b/view/test/line/bichord.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>Test View</title>
+    <title>Test View - Line.bichord (I.1)</title>
 </head>
 <body>
 <canvas id="canvasId" style="width:600px; height: 600px;"></canvas>
@@ -13,7 +13,7 @@
     let E = geomlib.E;
     geomlib.init({
         background: '#ffe9cd',
-        title: "Post.1",
+        title: "I.1 — To construct an equilateral triangle on a given finite straight line",
         align: Align.ABOVE,
         canvasid: "canvasId",
         elements: [

--- a/view/test/line/perpendicular.html
+++ b/view/test/line/perpendicular.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>Test View</title>
+    <title>Test View - Line.perpendicular (Post.4)</title>
 </head>
 <body>
 <canvas id="canvasId" style="width:600px; height: 600px;"></canvas>
@@ -13,7 +13,7 @@
     let E = geomlib.E;
     geomlib.init({
         background: '#ffe9cd',
-        title: "Post.1",
+        title: "Post.4 — All right angles equal one another",
         align: Align.ABOVE,
         canvasid: "canvasId",
         elements: [

--- a/view/test/point/foot.html
+++ b/view/test/point/foot.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>Test View - Foot</title>
+    <title>Test View - Point.foot (lemma for X.33)</title>
 </head>
 <body>
 <canvas id="canvasId" style="width:400px; height: 400px;"></canvas>

--- a/view/test/point/intersection.html
+++ b/view/test/point/intersection.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>Test View - Intersection</title>
+    <title>Test View - Point.intersection (Def I.2)</title>
 </head>
 <body>
 <canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
@@ -35,7 +35,7 @@
     ]
     geomlib.init({
         background: '#ffe9cd',
-        title: "lemma for X.33",
+        title: "Def I.2 — The ends of a line are points",
         align: Align.ABOVE,
         canvasid: "canvasId",
         elements: intersection_data

--- a/view/test/point/vertex.html
+++ b/view/test/point/vertex.html
@@ -1,0 +1,48 @@
+<html>
+<head>
+    <title>Test View - point;vertex</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:360px; height:300px;"></canvas>
+<script src="../../../../dist/bundle.js" type="text/javascript"></script>
+
+<!-- Reference: propI9.html (Book I, Proposition 9) extracts the apex F of an equilateral
+     triangle EDF using vertex;3. Here we use a plain triangle so no TBD constructions
+     are needed. Drag any vertex and watch V1/V2/V3 follow their respective points. -->
+<!--applet code=Geometry codebase="../../Geometry" archive=Geometry.zip height=300 width=360>
+<img src="../../booki/propI9.gif" alt="java applet or image">
+<param name=background value="35,19,100">
+<param name=title value="point;vertex">
+<param name=e[1] value="A;point;free;150,40">
+<param name=e[2] value="B;point;free;50,150">
+<param name=e[3] value="C;point;free;250,150">
+<param name=e[4] value="T;polygon;triangle;A,B,C;0;0;black;0">
+<param name=e[5] value="V1;point;vertex;T,1;black">
+<param name=e[6] value="V2;point;vertex;T,2;black">
+<param name=e[7] value="V3;point;vertex;T,3;black">
+</applet-->
+
+<script type="text/javascript">
+    let E = geomlib.E;
+    let Align = geomlib.Align;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "point;vertex — extract vertices from a triangle",
+        canvasid: "canvasId",
+        elements: [
+            { name: "A", construction: E.Point.free, params: [150, 40] },
+            { name: "B", construction: E.Point.free, params: [50, 150] },
+            { name: "C", construction: E.Point.free, params: [250, 150] },
+            { name: "T", construction: E.Polygon.triangle, params: ["A", "B", "C"],
+              edgeColor: "black" },
+            { name: "V1", construction: E.Point.vertex, params: ["T", 1],
+              nameColor: "red", vertexColor: "red" },
+            { name: "V2", construction: E.Point.vertex, params: ["T", 2],
+              nameColor: "blue", vertexColor: "blue" },
+            { name: "V3", construction: E.Point.vertex, params: ["T", 3],
+              nameColor: "green", vertexColor: "green" },
+        ]
+    });
+</script>
+</body>
+</html>

--- a/view/test/poly/equilateralTriangle.html
+++ b/view/test/poly/equilateralTriangle.html
@@ -1,0 +1,40 @@
+<html>
+<head><title>Test View - polygon;equilateralTriangle (propI10)</title></head>
+<body>
+<canvas id="canvasId" style="width:360px; height:280px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+
+<!--applet code=Geometry codebase="../../Geometry" archive=Geometry.zip width=360 height=280>
+<img src="../../euclid-html/booki/propI10.gif" alt="java applet or image">
+<param name=background value="35,19,100">
+<param name=title value="I.10">
+<param name=e[1] value="A;point;free;40,170">
+<param name=e[2] value="B;point;free;200,170">
+<param name=e[3] value="ABC;polygon;equilateralTriangle;A,B;0;0;black;random">
+<param name=e[4] value="C;point;vertex;ABC,3;black;green">
+<param name=e[5] value="D;point;midpoint;A,B;black;green">
+<param name=e[6] value="CD;line;connect;C,D;0;0;blue">
+</applet-->
+
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "I.10 — Bisect a finite straight line",
+        canvasid: "canvasId",
+        elements: [
+            { name: "A",   construction: E.Point.free,                  params: [40, 170] },
+            { name: "B",   construction: E.Point.free,                  params: [200, 170] },
+            { name: "ABC", construction: E.Polygon.equilateralTriangle,  params: ["A", "B"],
+              edgeColor: "black" },
+            { name: "C",   construction: E.Point.vertex,                params: ["ABC", 3],
+              nameColor: "black", vertexColor: "green" },
+            { name: "D",   construction: E.Point.midpoint,              params: ["A", "B"],
+              nameColor: "black", vertexColor: "green" },
+            { name: "CD",  construction: E.Line.connect,                params: ["C", "D"],
+              edgeColor: "blue" },
+        ]
+    });
+</script>
+</body>
+</html>

--- a/view/test/poly/triangle.html
+++ b/view/test/poly/triangle.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>Test View</title>
+    <title>Test View - Polygon.triangle (Def I.19)</title>
 </head>
 <body>
 <canvas id="canvasId" style="width:200px; height: 200px;"></canvas>
@@ -13,7 +13,7 @@
     let E = geomlib.E;
     geomlib.init({
         background: '#ffe9cd',
-        title: "Post.1",
+        title: "Def I.19 — Trilateral figures",
         align: Align.ABOVE,
         canvasid: "canvasId",
         elements: [

--- a/view/test/sector/sector.html
+++ b/view/test/sector/sector.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>Test View</title>
+    <title>Test View - Sector.sector (Def III.10)</title>
 </head>
 <body>
 <canvas id="canvasId" style="width:600px; height: 600px;"></canvas>
@@ -13,7 +13,7 @@
     let E = geomlib.E;
     geomlib.init({
         background: '#ffe9cd',
-        title: "Post.1",
+        title: "Def III.10 — A sector of a circle",
         align: Align.ABOVE,
         canvasid: "canvasId",
         elements: [


### PR DESCRIPTION
## Pull Request: Implement `point;vertex` and `polygon;equilateralTriangle`

**Branch:** `feature/point-vertex` → `master`

---

### Summary

- Implements `point;vertex` — returns the nth vertex (1-based) of a polygon by aliasing the existing `PolygonElement.V[n-1]` under a new name. No new element file needed; uses the "preexists" pattern from the Java applet.
- Implements `polygon;equilateralTriangle` — ports `RegularPolygon.java` (n=3) as a new `RegularPolygonElement` class. The apex is computed by rotating vertex A around vertex B by 60°, matching the Java iterative formula exactly.
- Both constructions are registered in the `constructions` array in `Constructions.ts` and covered by new Mocha tests (13 passing total).
- Together these make propositions **I.9, I.10, and I.11** fully renderable, and unblock dozens more in Books I–II that depend on `vertex` to name polygon vertices.

---

### Changes

**New source files**
- `src/elements/polygon/RegularPolygonElement.ts` — port of `RegularPolygon.java`; `update()` runs `V[i].to(V[i-2]).rotate(V[i-1], cos, sin, screen)` for i ≥ 2

**Modified source files**
- `src/elements/Constructions.ts` — added `PolygonElement` to `ConstructionTypes` enum; added `VertexConstruction` and `EquilateralTriangleConstruction` classes; registered both in the `constructions` array
- `tests/SlateTest.ts` — two new tests: vertex coordinate assertions on a triangle, and equilateral side-length equality + apex-above-base check

**New test view pages**
- `view/test/point/vertex.html` — based on I.9 params
- `view/test/poly/equilateralTriangle.html` — mirrors propI10 params (compare against `propI10.gif`)

**Test view housekeeping**
- `git mv view/test/poly/index.html → triangle.html` (was testing `Polygon.triangle`)
- `git mv view/test/sector/index.html → sector.html` (was testing `Sector.sector`)
- All test view `<title>` tags and `title:` init fields updated to reference the source proposition or definition: Post.3, Post.4, I.1, Def I.2, Def I.19, Def III.10, III.10, III.25a, lemma for X.33

**Documentation**
- `doc/process.md` — added "Identifying a verifiable proposition instance" sub-section to Step 1; Step 8 now says to use proposition params for test view pages where possible
- `doc/construction-tracker.md` — `point;vertex` and `polygon;equilateralTriangle` marked implemented; new platform-level TODO added for label orientation (all labels use the same default offset; Java applet adapts placement to geometry)
- `doc/journal.md` — two session entries appended

---

### Test plan

- [X] `npx tsc && npm test` — 13 tests pass
- [X] `npx webpack && python3 -m http.server 8080`
- [X] Open `view/test/poly/equilateralTriangle.html` and compare against `view/euclid-html/booki/propI10.gif` — triangle apex above AB, bisector CD vertical, D at midpoint
- [X] Drag A and B — triangle stays equilateral, CD bisects AB
- [X] Open `view/test/point/vertex.html` — V1/V2/V3 labels sit on correct triangle vertices