### PR TITLE
 Implement point;parallelogram and add Java applet construction viewer

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -117,8 +117,10 @@ These affect the library as a whole, independent of individual constructions.
 - [x] **`perpendicular`** (5 signature variants) — `src/elements/point/Perpendicular*.ts`
   - [~] tested in [view/test/circumcenter_lineperp.html](../view/test/circumcenter_lineperp.html) — no standalone page
 
-- [ ] **`parallelogram`** — TBD
-  - Java source: construct `Slate.java` or `Geometry.java` (4th vertex: D = A + C − B)
+- [x] **`parallelogram`** — `src/elements/Constructions.ts` (`ParallelogramConstruction`, reuses `Layoff`)
+  - `new Layoff(C, A, B, A, B)` computes D′ = C + (B − A); factor=1 so it reduces to pure vector addition
+  - Java dispatch: `case 13: element[eCount] = new Layoff(P[0],P[1],P[2],P[1],P[2])`
+  - [x] test view: [view/test/point/parallelogram.html](../view/test/point/parallelogram.html) — based on propI28 params; shows the completed parallelogram ABCA→D′
   - Used in: I.28, I.30, I.32–I.36, I.37–I.41, I.42–I.43, all of Book II
 
 - [x] **`vertex`** — `src/elements/Constructions.ts` (`VertexConstruction`)
@@ -338,5 +340,6 @@ These affect the library as a whole, independent of individual constructions.
 | `Circle.circumcircle` | view/test/circle/circumcircle.html | exists |
 | `Polygon.triangle` | view/test/poly/triangle.html | compound |
 | `Polygon.equilateralTriangle` | view/test/poly/equilateralTriangle.html | exists |
+| `Point.parallelogram` | view/test/point/parallelogram.html | exists |
 | `Sector.sector` | view/test/sector/sector.html | exists |
 | All others | — | missing |

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,28 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-10 — Implemented point;parallelogram
+
+**Completed:**
+- Added `ParallelogramConstruction` to `src/elements/Constructions.ts` — reuses existing `Layoff`
+  class with `new Layoff(C, A, B, A, B)`, which computes D′ = C + (B − A)
+- Registered in `constructions` array
+- Wrote Mocha test (14 passing): verifies D′ = (190, 120) from propI28 input coordinates
+- Created `view/test/point/parallelogram.html` based on propI28 params; draws all four sides
+
+**Discovered:**
+- Java dispatch is `case 13: new Layoff(P[0],P[1],P[2],P[1],P[2])` — the direction vector CD
+  and length vector EF are both set to (A→B), so factor = AB/AB = 1 and the result is
+  pure vector addition: D′ = C + (B − A). No new element class needed.
+- Verifiable against propI28 e[5]; elements 1–4 are all free points and connect, both implemented.
+
+**Next session:**
+- `sector;arc` (20 uses) — needs `ArcElement.ts`; circumcenter of A,M,B then arc through them
+- `line;chord` (17 uses) — `Chord.java`
+- `polygon;parallelogram` (18 uses) — full polygon (4 vertices) using same D′ formula
+
+---
+
 ## 2026-04-10 — Implemented polygon;equilateralTriangle
 
 **Completed:**

--- a/run_euclid_applet.sh
+++ b/run_euclid_applet.sh
@@ -1,9 +1,65 @@
 #!/bin/bash
-cd /usr/src/app/view
-appletviewer \
-  -J-Djava.security.manager \
-  -J-Djava.security.policy=/usr/src/app/permissive.policy \
-  -J-Djava.security.debug=all \
-  -J-Dsun.applet.debug=true \
-  -J-Dsun.applet.verbose=true \
-  eulerline.html
+# Run the Java geometry applet for a specific construction test.
+# Each file in view/applet-tests/ is a stripped-down version of the
+# source proposition that inspired the TypeScript test view page.
+
+APPLET_DIR=/usr/src/app/view/applet-tests
+VIEWER_FLAGS=(
+  -J-Djava.security.manager
+  -J-Djava.security.policy=/usr/src/app/permissive.policy
+)
+
+declare -A ENTRIES
+ENTRIES=(
+  ["circle;radius           (Post.3)"]="circle-radius.html"
+  ["circle;circumcircle     (III.10)"]="circle-circumcircle.html"
+  ["line;bichord            (I.1)"]="line-bichord.html"
+  ["line;perpendicular      (Post.4)"]="line-perpendicular.html"
+  ["point;intersection      (Def I.2)"]="point-intersection.html"
+  ["point;foot              (lemma X.33)"]="point-foot.html"
+  ["point;circumcenter      (III.25a)"]="point-circumcenter.html"
+  ["point;vertex            (I.9)"]="point-vertex.html"
+  ["point;parallelogram     (I.28)"]="point-parallelogram.html"
+  ["polygon;equilateralTriangle (I.10)"]="poly-equilateralTriangle.html"
+  ["sector;sector           (Def III.10)"]="sector-sector.html"
+  ["euler line demo"]="eulerline.html"
+)
+
+# Build ordered list for display
+LABELS=(
+  "circle;radius           (Post.3)"
+  "circle;circumcircle     (III.10)"
+  "line;bichord            (I.1)"
+  "line;perpendicular      (Post.4)"
+  "point;intersection      (Def I.2)"
+  "point;foot              (lemma X.33)"
+  "point;circumcenter      (III.25a)"
+  "point;vertex            (I.9)"
+  "point;parallelogram     (I.28)"
+  "polygon;equilateralTriangle (I.10)"
+  "sector;sector           (Def III.10)"
+  "euler line demo"
+)
+
+echo ""
+echo "Euclid Applet — Construction Viewer"
+echo "====================================="
+PS3=$'\nSelect a construction (or Ctrl-C to quit): '
+
+select LABEL in "${LABELS[@]}"; do
+  FILE="${ENTRIES[$LABEL]}"
+  if [[ -z "$FILE" ]]; then
+    echo "Invalid selection."
+    continue
+  fi
+
+  if [[ "$FILE" == "eulerline.html" ]]; then
+    TARGET=/usr/src/app/view/eulerline.html
+  else
+    TARGET="$APPLET_DIR/$FILE"
+  fi
+
+  echo "Opening: $TARGET"
+  appletviewer "${VIEWER_FLAGS[@]}" "$TARGET"
+  break
+done

--- a/run_euclid_applet.sh
+++ b/run_euclid_applet.sh
@@ -45,6 +45,7 @@ echo ""
 echo "Euclid Applet — Construction Viewer"
 echo "====================================="
 PS3=$'\nSelect a construction (or Ctrl-C to quit): '
+COLUMNS=1
 
 select LABEL in "${LABELS[@]}"; do
   FILE="${ENTRIES[$LABEL]}"

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -555,11 +555,21 @@ export class ExtendConstruction extends LayoffConstruction {
     }
 }
 
-// TBD
 // point
 // parallelogram
-// points A, B, C
-// the 4th vertex D of a parallelogram ABCD given 3 vertices A, B, and C
+// points C, A, B
+// the 4th vertex D' of the parallelogram C-A-B-D' given 3 vertices C, A, B
+// D' = C + (B - A)  [reuses Layoff with equal direction and length vectors]
+export class ParallelogramConstruction extends Construction {
+    constructionMethod: AllConstructions = PointConstructions.parallelogram;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
+
+    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const [c, a, b] = params as [PointElement, PointElement, PointElement];
+        const g = new Layoff(c, a, b, a, b);
+        return [[g], g];
+    }
+}
 
 // TBD
 // point
@@ -1268,6 +1278,7 @@ export const constructions : Construction[] = [
     new FootPointConsturction(),
     new ExtendConstruction(),
     new CutoffConstruction(),
+    new ParallelogramConstruction(),
     new CircumcircleConstruction(),
     new CircumcircleConstruction2d(),
     new LineSliderConstruction(),

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -262,6 +262,22 @@ describe("slate", ()=> {
         almostEqual(V3.x, 250, 1); almostEqual(V3.y, 200, 1);
     });
 
+    it("should compute the 4th vertex of a parallelogram", () => {
+        // propI28: A(40,80), B(190,80), C(40,120) → D' = C + (B-A) = (190,120)
+        const data: IConstructionInfo[] = [
+            { name: "A",  construction: E.Point.free,          params: [40, 80] },
+            { name: "B",  construction: E.Point.free,          params: [190, 80] },
+            { name: "C",  construction: E.Point.free,          params: [40, 120] },
+            { name: "D'", construction: E.Point.parallelogram, params: ["C", "A", "B"] },
+        ];
+        const slate = new Slate(createCanvas(400, 300));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        const D = slate.lookupElement("D'") as PointElement;
+        almostEqual(D.x, 190, 1);
+        almostEqual(D.y, 120, 1);
+    });
+
     it("should produce an equilateral triangle", () => {
         const data: IConstructionInfo[] = [
             { name: "A",   construction: E.Point.free,               params: [40, 170] },

--- a/view/applet-tests/circle-circumcircle.html
+++ b/view/applet-tests/circle-circumcircle.html
@@ -1,0 +1,30 @@
+<HTML><HEAD><TITLE>III.10 — circle;circumcircle + point;center</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry archive=../Geometry.zip height=300 width=300>
+<param name=background value="35,19,100">
+<param name=title value="III.10">
+<param name=e[1] value="B;point;free;150,40">
+<param name=e[2] value="F;point;free;150,260">
+<param name=e[3] value="H;point;free;40,180">
+<param name=e[4] value="ABC;circle;circumcircle;B,F,H;0;0;black;random">
+<param name=e[5] value="P;point;center;ABC;black;green">
+<param name=e[6] value="G;point;circleSlider;ABC,210,150">
+<param name=e[7] value="HB;line;connect;H,B">
+<param name=e[8] value="BG;line;connect;B,G">
+<param name=e[9] value="K;point;midpoint;HB">
+<param name=e[10] value="L;point;midpoint;BG">
+<param name=e[11] value="S;point;midpoint;H,F;0;0">
+<param name=e[12] value="BHY;polygon;equilateralTriangle;B,H;0;0;0;0">
+<param name=e[13] value="Y;point;vertex;BHY,3;0;0">
+<param name=e[14] value="Z;point;intersection;H,Y,S,P;0;0">
+<param name=e[15] value="W;point;intersection;B,Y,L,P;0;0">
+<param name=e[16] value="X;point;intersection;F,Z,G,W;0;0">
+<param name=e[17] value="arcFG;sector;sector;X,F,G;0;0;black;0">
+<param name=e[18] value="arcGB;sector;sector;W,G,B;0;0;black;0">
+<param name=e[19] value="arcBH;sector;sector;Y,B,H;0;0;black;0">
+<param name=e[20] value="arcHF;sector;sector;Z,H,F;0;0;black;0">
+<param name=e[21] value="A;point;cutoff;P,K,P,B">
+<param name=e[22] value="C;point;extend;A,P,A,P">
+<param name=e[23] value="AC;line;connect;A,C">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/circle-circumcircle.html
+++ b/view/applet-tests/circle-circumcircle.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>III.10 — circle;circumcircle + point;center</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry archive=../Geometry.zip height=300 width=300>
+<applet code=Geometry codebase=.. archive=Geometry.zip height=300 width=300>
 <param name=background value="35,19,100">
 <param name=title value="III.10">
 <param name=e[1] value="B;point;free;150,40">

--- a/view/applet-tests/circle-radius.html
+++ b/view/applet-tests/circle-radius.html
@@ -1,0 +1,10 @@
+<HTML><HEAD><TITLE>Post.3 — circle;radius</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry archive=../Geometry.zip height=180 width=250>
+<param name=background value="35,19,100">
+<param name=title value="I.Post.3">
+<param name=e[1] value="A;point;free;125,90">
+<param name=e[2] value="B;point;free;170,120">
+<param name=e[3] value="circ;circle;radius;A,B;0;0;black;random">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/circle-radius.html
+++ b/view/applet-tests/circle-radius.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>Post.3 — circle;radius</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry archive=../Geometry.zip height=180 width=250>
+<applet code=Geometry codebase=.. archive=Geometry.zip height=180 width=250>
 <param name=background value="35,19,100">
 <param name=title value="I.Post.3">
 <param name=e[1] value="A;point;free;125,90">

--- a/view/applet-tests/line-bichord.html
+++ b/view/applet-tests/line-bichord.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>I.1 — line;bichord</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry archive=../Geometry.zip height=260 width=340>
+<applet code=Geometry codebase=.. archive=Geometry.zip height=260 width=340>
 <param name=background value="35,19,100">
 <param name=title value="I.1">
 <param name=e[1] value="A;point;free;125,130">

--- a/view/applet-tests/line-bichord.html
+++ b/view/applet-tests/line-bichord.html
@@ -1,0 +1,21 @@
+<HTML><HEAD><TITLE>I.1 — line;bichord</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry archive=../Geometry.zip height=260 width=340>
+<param name=background value="35,19,100">
+<param name=title value="I.1">
+<param name=e[1] value="A;point;free;125,130">
+<param name=e[2] value="B;point;free;215,130">
+<param name=e[3] value="AB;line;connect;A,B">
+<param name=e[4] value="Acirc;circle;radius;A,B">
+<param name=e[5] value="Bcirc;circle;radius;B,A">
+<param name=e[6] value="CD;line;bichord;Bcirc,Acirc;0;0;0">
+<param name=e[7] value="C;point;first;CD;black;green">
+<param name=e[8] value="AC;line;connect;A,C">
+<param name=e[9] value="BC;line;connect;B,C">
+<param name=e[10] value="AE;line;extend;AB,AB;0;0;0">
+<param name=e[11] value="E;point;last;AE;black;0">
+<param name=e[12] value="BD;line;extend;B,A,A,B;0;0;0">
+<param name=e[13] value="D;point;last;BD;black;0">
+<param name=e[14] value="ABC;polygon;triangle;A,B,C;0;0;0;random">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/line-perpendicular.html
+++ b/view/applet-tests/line-perpendicular.html
@@ -1,0 +1,19 @@
+<HTML><HEAD><TITLE>Post.4 — line;perpendicular</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry archive=../Geometry.zip height=160 width=310>
+<param name=background value="35,19,100">
+<param name=title value="Post.4">
+<param name=e[1] value="A;point;free;40,130">
+<param name=e[2] value="B;point;free;160,130">
+<param name=e[3] value="AB;line;connect;A,B">
+<param name=e[4] value="C;point;lineSlider;AB,90,130">
+<param name=e[5] value="D;point;perpendicular;C,B">
+<param name=e[6] value="CD;line;connect;C,D">
+<param name=e[7] value="E;point;free;160,40">
+<param name=e[8] value="F;point;free;270,130">
+<param name=e[9] value="EF;line;connect;E,F">
+<param name=e[10] value="G;point;lineSlider;EF,215,85">
+<param name=e[11] value="H;point;perpendicular;G,F">
+<param name=e[12] value="GH;line;connect;G,H">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/line-perpendicular.html
+++ b/view/applet-tests/line-perpendicular.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>Post.4 — line;perpendicular</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry archive=../Geometry.zip height=160 width=310>
+<applet code=Geometry codebase=.. archive=Geometry.zip height=160 width=310>
 <param name=background value="35,19,100">
 <param name=title value="Post.4">
 <param name=e[1] value="A;point;free;40,130">

--- a/view/applet-tests/point-circumcenter.html
+++ b/view/applet-tests/point-circumcenter.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>III.25a — point;circumcenter + line;perpendicular</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry archive=../Geometry.zip height=230 width=230>
+<applet code=Geometry codebase=.. archive=Geometry.zip height=230 width=230>
 <param name=background value="35,19,100">
 <param name=title value="III.25a">
 <param name=e[1] value="A;point;free;60,30">

--- a/view/applet-tests/point-circumcenter.html
+++ b/view/applet-tests/point-circumcenter.html
@@ -1,0 +1,20 @@
+<HTML><HEAD><TITLE>III.25a — point;circumcenter + line;perpendicular</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry archive=../Geometry.zip height=230 width=230>
+<param name=background value="35,19,100">
+<param name=title value="III.25a">
+<param name=e[1] value="A;point;free;60,30">
+<param name=e[2] value="C;point;free;60,200">
+<param name=e[3] value="AC;line;connect;A,C">
+<param name=e[4] value="D;point;midpoint;AC">
+<param name=e[5] value="DB;line;perpendicular;D,A;0;0;0">
+<param name=e[6] value="B;point;lineSlider;DB,30,115">
+<param name=e[7] value="E;point;circumcenter;A,B,C;black;green">
+<param name=e[8] value="BE;line;connect;B,E">
+<param name=e[9] value="AE;line;connect;A,E">
+<param name=e[10] value="CE;line;connect;C,E">
+<param name=e[11] value="ABC;sector;sector;E,A,C;0;0;black;random">
+<param name=e[12] value="AB;line;connect;A,B">
+<param name=e[13] value="ACE;polygon;triangle;A,C,E;0;0;0;background">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point-foot.html
+++ b/view/applet-tests/point-foot.html
@@ -1,0 +1,15 @@
+<HTML><HEAD><TITLE>Lemma X.33 — point;foot</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry archive=../Geometry.zip height=200 width=280>
+<param name=background value="35,19,100">
+<param name=title value="lemma for X.33">
+<param name=e[1] value="B;point;free;30,170">
+<param name=e[2] value="C;point;free;250,170">
+<param name=e[3] value="BCmid;point;midpoint;B,C;0;0">
+<param name=e[4] value="ABC;circle;radius;BCmid,B;0;0;0;0">
+<param name=e[5] value="A;point;circleSlider;ABC,120,40">
+<param name=e[6] value="M;point;foot;A,B,C">
+<param name=e[7] value="ABM;polygon;triangle;A,B,M;0;0;black;random">
+<param name=e[8] value="ACM;polygon;triangle;A,C,M;0;0;black;random">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point-foot.html
+++ b/view/applet-tests/point-foot.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>Lemma X.33 — point;foot</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry archive=../Geometry.zip height=200 width=280>
+<applet code=Geometry codebase=.. archive=Geometry.zip height=200 width=280>
 <param name=background value="35,19,100">
 <param name=title value="lemma for X.33">
 <param name=e[1] value="B;point;free;30,170">

--- a/view/applet-tests/point-intersection.html
+++ b/view/applet-tests/point-intersection.html
@@ -1,0 +1,22 @@
+<HTML><HEAD><TITLE>Def I.2 — point;intersection</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry archive=../Geometry.zip height=200 width=320>
+<param name=background value="35,19,100">
+<param name=title value="I.39">
+<param name=e[1] value="A;point;free;40,170;0">
+<param name=e[2] value="B;point;free;110,100;0">
+<param name=e[3] value="C;point;free;190,100;0">
+<param name=e[4] value="D;point;free;280,50;0">
+<param name=e[5] value="BC;line;connect;B,C">
+<param name=e[6] value="E';point;perpendicular;B,C;0;0">
+<param name=e[7] value="M;point;midpoint;A,B;0;0">
+<param name=e[8] value="E'';point;perpendicular;M,B;0;0">
+<param name=e[9] value="E;point;intersection;B,E',M,E'';0;0">
+<param name=e[10] value="AMB;sector;sector;E,B,A;0;0;black;0">
+<param name=e[11] value="F';point;perpendicular;C,B;0;0">
+<param name=e[12] value="N;point;midpoint;C,D;0;0">
+<param name=e[13] value="F'';point;perpendicular;N,C;0;0">
+<param name=e[14] value="F;point;intersection;C,F',N,F'';0;0">
+<param name=e[15] value="CND;sector;sector;F,C,D;0;0;black;0">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point-intersection.html
+++ b/view/applet-tests/point-intersection.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>Def I.2 — point;intersection</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry archive=../Geometry.zip height=200 width=320>
+<applet code=Geometry codebase=.. archive=Geometry.zip height=200 width=320>
 <param name=background value="35,19,100">
 <param name=title value="I.39">
 <param name=e[1] value="A;point;free;40,170;0">

--- a/view/applet-tests/point-parallelogram.html
+++ b/view/applet-tests/point-parallelogram.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>I.28 — point;parallelogram</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry archive=../Geometry.zip height=200 width=230>
+<applet code=Geometry codebase=.. archive=Geometry.zip height=200 width=230>
 <param name=background value="35,19,100">
 <param name=title value="I.28">
 <param name=e[1] value="A;point;free;40,80">

--- a/view/applet-tests/point-parallelogram.html
+++ b/view/applet-tests/point-parallelogram.html
@@ -1,0 +1,19 @@
+<HTML><HEAD><TITLE>I.28 — point;parallelogram</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry archive=../Geometry.zip height=200 width=230>
+<param name=background value="35,19,100">
+<param name=title value="I.28">
+<param name=e[1] value="A;point;free;40,80">
+<param name=e[2] value="B;point;free;190,80">
+<param name=e[3] value="AB;line;connect;A,B">
+<param name=e[4] value="C;point;free;40,120">
+<param name=e[5] value="D';point;parallelogram;C,A,B;0;0">
+<param name=e[6] value="D;point;lineSlider;C,D',190,40">
+<param name=e[7] value="CD;line;connect;C,D">
+<param name=e[8] value="E;point;free;70,40">
+<param name=e[9] value="F;point;free;130,170">
+<param name=e[10] value="EF;line;connect;E,F">
+<param name=e[11] value="G;point;intersection;A,B,E,F">
+<param name=e[12] value="H;point;intersection;C,D,E,F">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point-vertex.html
+++ b/view/applet-tests/point-vertex.html
@@ -1,0 +1,17 @@
+<HTML><HEAD><TITLE>I.9 — point;vertex + polygon;equilateralTriangle</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry archive=../Geometry.zip height=260 width=300>
+<param name=background value="35,19,100">
+<param name=title value="I.9">
+<param name=e[1] value="A;point;free;150,40">
+<param name=e[2] value="B;point;free;50,150">
+<param name=e[3] value="C;point;free;250,150">
+<param name=e[4] value="D;point;lineSlider;A,B,75,90">
+<param name=e[5] value="E;point;cutoff;A,C,A,D">
+<param name=e[6] value="AB;line;connect;A,B">
+<param name=e[7] value="AC;line;connect;A,C">
+<param name=e[8] value="EDF;polygon;equilateralTriangle;E,D;0;0;black;random">
+<param name=e[9] value="F;point;vertex;EDF,3;black;green">
+<param name=e[10] value="AF;line;connect;A,F">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point-vertex.html
+++ b/view/applet-tests/point-vertex.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>I.9 — point;vertex + polygon;equilateralTriangle</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry archive=../Geometry.zip height=260 width=300>
+<applet code=Geometry codebase=.. archive=Geometry.zip height=260 width=300>
 <param name=background value="35,19,100">
 <param name=title value="I.9">
 <param name=e[1] value="A;point;free;150,40">

--- a/view/applet-tests/poly-equilateralTriangle.html
+++ b/view/applet-tests/poly-equilateralTriangle.html
@@ -1,0 +1,13 @@
+<HTML><HEAD><TITLE>I.10 — polygon;equilateralTriangle + point;vertex</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry archive=../Geometry.zip height=200 width=240>
+<param name=background value="35,19,100">
+<param name=title value="I.10">
+<param name=e[1] value="A;point;free;40,170">
+<param name=e[2] value="B;point;free;200,170">
+<param name=e[3] value="ABC;polygon;equilateralTriangle;A,B;0;0;black;random">
+<param name=e[4] value="C;point;vertex;ABC,3">
+<param name=e[5] value="D;point;midpoint;A,B;black;green">
+<param name=e[6] value="CD;line;connect;C,D">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/poly-equilateralTriangle.html
+++ b/view/applet-tests/poly-equilateralTriangle.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>I.10 — polygon;equilateralTriangle + point;vertex</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry archive=../Geometry.zip height=200 width=240>
+<applet code=Geometry codebase=.. archive=Geometry.zip height=200 width=240>
 <param name=background value="35,19,100">
 <param name=title value="I.10">
 <param name=e[1] value="A;point;free;40,170">

--- a/view/applet-tests/sector-sector.html
+++ b/view/applet-tests/sector-sector.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>Def III.10 — sector;sector</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry archive=../Geometry.zip height=240 width=300>
+<applet code=Geometry codebase=.. archive=Geometry.zip height=240 width=300>
 <param name=background value="35,19,100">
 <param name=title value="III.Def.10">
 <param name=e[1] value="A;point;free;150,120;black;green">

--- a/view/applet-tests/sector-sector.html
+++ b/view/applet-tests/sector-sector.html
@@ -1,0 +1,14 @@
+<HTML><HEAD><TITLE>Def III.10 — sector;sector</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry archive=../Geometry.zip height=240 width=300>
+<param name=background value="35,19,100">
+<param name=title value="III.Def.10">
+<param name=e[1] value="A;point;free;150,120;black;green">
+<param name=e[2] value="B;point;free;150,30">
+<param name=e[3] value="Acirc;circle;radius;A,B;0;0;black;random">
+<param name=e[4] value="C;point;circleSlider;Acirc,40,130">
+<param name=e[5] value="sect;sector;sector;A,B,C;0;0;0;random">
+<param name=e[6] value="AB;line;connect;A,B">
+<param name=e[7] value="AC;line;connect;A,C">
+</applet>
+</BODY></HTML>

--- a/view/test/point/parallelogram.html
+++ b/view/test/point/parallelogram.html
@@ -1,0 +1,45 @@
+<html>
+<head><title>Test View - Point.parallelogram (I.28)</title></head>
+<body>
+<canvas id="canvasId" style="width:360px; height:240px;"></canvas>
+<script src="../../../../dist/bundle.js" type="text/javascript"></script>
+
+<!--applet code=Geometry codebase="../../Geometry" archive=Geometry.zip width=360 height=240>
+<img src="../../euclid-html/booki/propI28.gif" alt="java applet or image">
+<param name=background value="35,19,100">
+<param name=title value="I.28">
+<param name=e[1] value="A;point;free;40,80">
+<param name=e[2] value="B;point;free;190,80">
+<param name=e[3] value="AB;line;connect;A,B">
+<param name=e[4] value="C;point;free;40,120">
+<param name=e[5] value="D';point;parallelogram;C,A,B;0;0">
+</applet-->
+
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "I.28 — point;parallelogram: D' = C + (B − A)",
+        canvasid: "canvasId",
+        elements: [
+            { name: "A",  construction: E.Point.free,          params: [40, 80],
+              nameColor: "black", vertexColor: "black" },
+            { name: "B",  construction: E.Point.free,          params: [190, 80],
+              nameColor: "black", vertexColor: "black" },
+            { name: "C",  construction: E.Point.free,          params: [40, 120],
+              nameColor: "black", vertexColor: "black" },
+            { name: "D'", construction: E.Point.parallelogram, params: ["C", "A", "B"],
+              nameColor: "black", vertexColor: "green" },
+            { name: "AB", construction: E.Line.connect,        params: ["A", "B"],
+              edgeColor: "black" },
+            { name: "AC", construction: E.Line.connect,        params: ["A", "C"],
+              edgeColor: "black" },
+            { name: "BD'",construction: E.Line.connect,        params: ["B", "D'"],
+              edgeColor: "black" },
+            { name: "CD'",construction: E.Line.connect,        params: ["C", "D'"],
+              edgeColor: "black" },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Implement `point;parallelogram` and add Java applet construction viewer

**Branch:** `parallelogram-construction` → `master`

---

### Summary

- Implements `point;parallelogram` — computes the 4th vertex of a parallelogram given three vertices using the existing `Layoff` class. No new element file required; `new Layoff(C, A, B, A, B)` reduces to `D′ = C + (B − A)`, matching Java dispatch `case 13` exactly.
- Adds `view/applet-tests/` — a collection of self-contained Java applet HTML files, one per implemented construction, each drawn from the source proposition that inspired the TypeScript test. Resolves the class-loading path by setting `codebase=..` so `Geometry.zip` is found in `view/`.
- Updates `run_euclid_applet.sh` with an interactive `select` menu (one entry per line) so any construction can be opened in the Java applet from inside the Docker container in one step.

---

### Changes

**New source**
- `src/elements/Constructions.ts` — added `ParallelogramConstruction` class after the `CutoffConstruction`/`ExtendConstruction` group; registered in the `constructions` array
- `tests/SlateTest.ts` — new test: verifies D′ = (190, 120) from propI28 coordinates A(40,80), B(190,80), C(40,120); 14 tests passing

**New test view page**
- `view/test/point/parallelogram.html` — based on propI28 params; draws all four sides of the completed parallelogram so dragging A, B, or C visibly updates D′

**New applet-tests infrastructure**
- `view/applet-tests/` — 11 HTML files, one per implemented construction, each using `codebase=.. archive=Geometry.zip` to resolve `view/Geometry.zip`:

| File | Construction | Source |
|---|---|---|
| `circle-radius.html` | `circle;radius` | Post.3 |
| `circle-circumcircle.html` | `circle;circumcircle`, `point;center` | III.10 |
| `line-bichord.html` | `line;bichord` | I.1 |
| `line-perpendicular.html` | `line;perpendicular` | Post.4 |
| `point-intersection.html` | `point;intersection` | Def I.2 |
| `point-foot.html` | `point;foot` | Lemma X.33 |
| `point-circumcenter.html` | `point;circumcenter` | III.25a |
| `point-vertex.html` | `point;vertex` | I.9 |
| `point-parallelogram.html` | `point;parallelogram` | I.28 |
| `poly-equilateralTriangle.html` | `polygon;equilateralTriangle` | I.10 |
| `sector-sector.html` | `sector;sector` | Def III.10 |

**Updated script**
- `run_euclid_applet.sh` — replaced hardcoded `eulerline.html` launch with a `select` menu listing all constructions; `COLUMNS=1` forces one entry per line

**Documentation**
- `doc/construction-tracker.md` — `point;parallelogram` marked implemented; test view added to coverage table
- `doc/journal.md` — session entry appended

---

### Test plan

- [x] `npx tsc && npm test` — 14 tests pass
- [x] `./start_java8_container.sh` → `./run_euclid_applet.sh` → select `point;parallelogram (I.28)` → applet opens, drag A/B/C, verify D′ tracks as 4th parallelogram vertex
- [x] Repeat for at least one other entry (e.g. `polygon;equilateralTriangle (I.10)`) to confirm `codebase=..` fix works for all files
- [x] Open `view/test/point/parallelogram.html` in browser after `npx webpack` — four-sided parallelogram visible, D′ in green