### PR TITLE
Restructure applet-tests as 3-way construction comparison harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,16 @@ python3 -m http.server  # then open http://localhost:PORT/view/test/...
 
 ## Three-way construction comparison harness
 
-Requires Linux + X11 + Docker + firefox + a `python3 -m http.server 8000` running
-at the repo root. Then run from the host:
+Requires Linux + X11 + Docker + a `python3 -m http.server 8000` running at the
+repo root. Both docker images must be built once (firefox runs in its own
+container, not on the host, so the user's regular firefox is never disturbed):
+
+```sh
+docker build -f Containerfile         -t euclid-applet:latest  .
+docker build -f Containerfile.firefox -t euclid-firefox:latest .
+```
+
+Then run the harness from the host:
 
 ```sh
 ./run_euclid_applet.sh
@@ -49,7 +57,7 @@ windows side by side:
    (`view/applet-tests/{type}/{construction}/original.html`)
 2. **UP-TO appletviewer** — same proposition trimmed to focus on the construction,
    in the Java applet (`view/applet-tests/{type}/{construction}/applet.html`)
-3. **TypeScript firefox kiosk** — same trimmed view in the TS port
+3. **TypeScript firefox (chromeless)** — same trimmed view in the TS port
    (`view/test/{type}/{sub}.html` from `localhost:8000`)
 
 Windows 2 and 3 should be visually equivalent at rest; any divergence is a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,20 +33,44 @@ npx webpack             # bundle to dist/bundle.js
 python3 -m http.server  # then open http://localhost:PORT/view/test/...
 ```
 
-## View the Java reference applet
+## Three-way construction comparison harness
 
-Requires Linux + X11. Run once per session to compare behavior:
+Requires Linux + X11 + Docker + firefox + a `python3 -m http.server 8000` running
+at the repo root. Then run from the host:
 
 ```sh
-./run-euclid-applet.sh
-# inside the container:
-cd /usr/src/app/view/euclid-html/booki
-appletviewer -J-Djava.security.manager \
-  -J-Djava.security.policy=/usr/src/app/view/permissive.policy \
-  propI1.html
+./run_euclid_applet.sh
 ```
 
-If Docker/X11 is unavailable, each proposition has a fallback `.gif` image alongside the HTML file.
+You pick a `{type};{construction}` entry from the menu and the script pops three
+windows side by side:
+
+1. **ORIGINAL appletviewer** — Joyce's full proposition in the Java applet
+   (`view/applet-tests/{type}/{construction}/original.html`)
+2. **UP-TO appletviewer** — same proposition trimmed to focus on the construction,
+   in the Java applet (`view/applet-tests/{type}/{construction}/applet.html`)
+3. **TypeScript firefox kiosk** — same trimmed view in the TS port
+   (`view/test/{type}/{sub}.html` from `localhost:8000`)
+
+Windows 2 and 3 should be visually equivalent at rest; any divergence is a
+porting bug in the TS element class. Window 1 carries the full surrounding
+proposition for context.
+
+Each per-construction folder under `view/applet-tests/` has exactly two files:
+
+- **`original.html`** — single-applet extraction of the source proposition,
+  unmodified except for the `codebase=../../..` path. Window #1 above.
+- **`applet.html`** — hand-translation of the TS test page back into Java applet
+  `<param>` format. Window #2 above. Carries a `<!-- TS: ... -->` header comment
+  pointing at the matching `view/test/...` page so the harness knows what to
+  open in firefox; this header is **load-bearing** — don't drop it.
+
+Adding a new construction is just dropping `original.html` and `applet.html`
+into the right folder; the script auto-discovers them on the next run, no edits
+needed.
+
+If Docker/X11 is unavailable, each proposition under `view/euclid-html/` has a
+fallback `.gif` image alongside the HTML file.
 
 ## Original HTML param format
 

--- a/Containerfile.firefox
+++ b/Containerfile.firefox
@@ -1,0 +1,41 @@
+# euclid-firefox — Ubuntu 20.04 + firefox + X11 client libs for the
+# three-way comparison harness in run_euclid_applet.sh.
+#
+# Build:  docker build -f Containerfile.firefox -t euclid-firefox:latest .
+# Run:    invoked by ./run_euclid_applet.sh, not directly
+#
+# Why a container? The host firefox does an X11 / dbus inter-instance
+# detection at startup that even MOZ_NO_REMOTE=1 + -no-remote -profile
+# can't fully escape on some distros, so launching against the user's
+# normal firefox instance triggers a "Close Firefox" dialog. Putting
+# firefox in its own pid + filesystem + X11-client namespace via docker
+# guarantees full isolation while still rendering on the host X server
+# through /tmp/.X11-unix.
+#
+# We pin to ubuntu:20.04 because it's the last LTS where `apt install
+# firefox` installs a real .deb instead of a transitional package that
+# pulls in snapd (which doesn't work cleanly inside containers).
+
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    firefox \
+    libgtk-3-0 \
+    libdbus-glib-1-2 \
+    libxt6 \
+    fonts-dejavu-core \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Don't bake a user into the image — `docker run --user "$(id -u):$(id -g)"`
+# at runtime gives the in-container process the same uid as the host user, so
+# the bind-mounted profile directory has matching ownership and firefox can
+# write to it without permission errors.
+#
+# HOME is set to a writable tmpfs path at runtime so firefox has somewhere to
+# stash its (small) per-run cache without needing a real user account.
+
+ENTRYPOINT []
+CMD ["firefox"]

--- a/README.md
+++ b/README.md
@@ -63,10 +63,15 @@ This Docker setup runs a preserved Java 8 environment for exploring classic geom
 
 ## How to Use
 
-1. **Build the image (once):**
+1. **Build the images (once):**
    ```
-   docker build -f Containerfile -t euclid-applet:latest .
+   docker build -f Containerfile         -t euclid-applet:latest  .
+   docker build -f Containerfile.firefox -t euclid-firefox:latest .
    ```
+   The first image (`euclid-applet`) provides Java 8 + appletviewer for the
+   two appletviewer windows. The second (`euclid-firefox`) provides firefox
+   for the third comparison window in `./run_euclid_applet.sh`. Both share
+   the `ubuntu:20.04` base layer so the second build is small.
 
 2. **Ensure X11 is running on your Linux host.**
    - If needed, allow Docker to access X:

--- a/doc/process.md
+++ b/doc/process.md
@@ -97,7 +97,14 @@ Step 8) is the trimmed up-to-construction version that mirrors the TS test page.
 
 ## Step 4 — View in appletviewer (optional but recommended)
 
-Run the host-side three-way comparison harness:
+First-time setup: build both docker images.
+
+```sh
+docker build -f Containerfile         -t euclid-applet:latest  .
+docker build -f Containerfile.firefox -t euclid-firefox:latest .
+```
+
+Then run the host-side three-way comparison harness:
 
 ```sh
 python3 -m http.server 8000   # in another terminal at the repo root
@@ -109,8 +116,13 @@ The script auto-discovers every `view/applet-tests/{type}/{construction}/applet.
 file and pops three windows for the chosen construction:
 
   1. **ORIGINAL appletviewer** — `original.html` (Joyce's full proposition)
+     in the `euclid-applet` container
   2. **UP-TO appletviewer** — `applet.html` (same trimmed to focus on the construction)
-  3. **TypeScript firefox kiosk** — `view/test/{type}/{sub}.html` from `localhost:8000`
+     in the `euclid-applet` container
+  3. **TypeScript firefox** — `view/test/{type}/{sub}.html` from `localhost:8000`,
+     opened in the `euclid-firefox` container against an isolated chromeless profile
+     so the window tiles under xmonad/i3/sway and the user's regular firefox instance
+     is never touched
 
 Windows 2 and 3 should be visually equivalent at rest; window 1 carries the full
 surrounding proposition for context. Drag free points in window 2 and watch dependent
@@ -307,8 +319,10 @@ python3 -m http.server 8000
 
 The harness auto-discovers your new `applet.html` on the next run (no script edits) and
 spawns three windows in parallel: `original.html` in appletviewer (containerised),
-`applet.html` in appletviewer (containerised), and the TS test page in firefox kiosk
-mode against `localhost:8000`.
+`applet.html` in appletviewer (containerised), and the TS test page in firefox against
+`localhost:8000` (also containerised — the `euclid-firefox` image — using an isolated
+chromeless profile that hides the tab bar, nav bar, and titlebar so it tiles cleanly
+under xmonad/i3/sway and never disturbs the user's regular host firefox).
 
 Compare:
 - **Window 2 vs window 3** — must be visually identical at rest. Drag a free point in

--- a/doc/process.md
+++ b/doc/process.md
@@ -36,6 +36,12 @@ A proposition where the target construction is the *only* TBD construction is th
 If no such proposition exists for Books I–III, note this in the journal and rely on the
 standalone test view page for visual verification instead.
 
+Before locking in your pick, run `ls view/applet-tests/{type}/` to see which propositions
+have already been copied into the repo as standalone applet HTML for nearby constructions.
+If the same proposition naturally exercises both your target and an already-implemented
+construction, prefer it — you can reuse the existing `inspiration.html` as a reference
+rather than creating a fresh one from scratch.
+
 ---
 
 ## Step 2 — Read the Java source
@@ -78,25 +84,44 @@ Numeric `0` means transparent/hidden; `random` means a random color.
 > to its two endpoint `PointElement`s in `Slate.convertParams`. The construction
 > signature must match the post-expansion types.
 
+**Save an `original.html` into applet-tests.** Once you have picked the proposition,
+create `view/applet-tests/{type}/{construction}/original.html` — a single-applet
+extraction of the source proposition. Copy the `<applet>...</applet>` block out of
+`view/euclid-html/{book}/propXX.html` verbatim, wrap it in `<HTML><BODY>`, and adjust
+the `codebase` to `../../..` (three levels up to `view/`, where `Geometry.zip` lives),
+not the `codebase="../../Geometry"` that the proposition HTMLs use. This is the
+"as Joyce drew it" reference; do not trim it. The companion `applet.html` (added in
+Step 8) is the trimmed up-to-construction version that mirrors the TS test page.
+
 ---
 
 ## Step 4 — View in appletviewer (optional but recommended)
 
-Run the Docker Java 8 container to see the original behavior:
+Run the host-side three-way comparison harness:
 
 ```sh
-./run-euclid-applet.sh
-# inside the container:
-cd /usr/src/app/view/euclid-html/booki
-appletviewer -J-Djava.security.manager \
-  -J-Djava.security.policy=/usr/src/app/view/permissive.policy \
-  propI1.html
+python3 -m http.server 8000   # in another terminal at the repo root
+./run_euclid_applet.sh
+# pick the {type};{construction} entry you just created
 ```
 
-Drag the free points and observe which elements move and how.
-This is the ground truth for the construction's behavior.
+The script auto-discovers every `view/applet-tests/{type}/{construction}/applet.html`
+file and pops three windows for the chosen construction:
 
-If Docker/X11 is unavailable, fall back to the `.gif` static image alongside the HTML.
+  1. **ORIGINAL appletviewer** — `original.html` (Joyce's full proposition)
+  2. **UP-TO appletviewer** — `applet.html` (same trimmed to focus on the construction)
+  3. **TypeScript firefox kiosk** — `view/test/{type}/{sub}.html` from `localhost:8000`
+
+Windows 2 and 3 should be visually equivalent at rest; window 1 carries the full
+surrounding proposition for context. Drag free points in window 2 and watch dependent
+elements move — that is the ground truth for the construction's behavior, and any
+divergence between windows 2 and 3 is a porting bug in your TS element class.
+
+For the very first session of a new construction you may not yet have an `applet.html`
+(it's added in Step 8) — in that case the script will skip the construction. As a
+fallback you can either pre-create a stub `applet.html` that's a copy of `original.html`
+just to populate window 2, or use the `.gif` image alongside the proposition HTML in
+`view/euclid-html/`.
 
 Goal: verify every ported construction against appletviewer at least once to "close out" the port.
 
@@ -189,20 +214,28 @@ skip the unit test and rely on visual verification in Step 8 — note this in th
 
 ---
 
-## Step 8 — Create the test view page
+## Step 8 — Build the three-way comparison view (TS page + applet.html, then harness)
 
-Create `view/test/{super_type}/{sub_type}.html`.
+Each construction gets a triple of artifacts that are visually equivalent at rest and
+exercised together by `./run_euclid_applet.sh`:
 
-Where possible, use the params from a verifiable proposition instance (identified in Step 1)
-as the test view, rather than a synthetic example. This lets you compare directly against
-the Java applet GIF or appletviewer output.
+1. **Window 1 — `original.html`** — already saved in Step 3, the unmodified source
+   proposition extracted to a single applet.
+2. **Window 2 — `applet.html`** (this step) — the same view trimmed to focus on the
+   construction, in Java applet `<param>` form.
+3. **Window 3 — `view/test/{type}/{sub}.html`** (this step) — the same view in the
+   TypeScript port.
 
-The naming convention:
+Windows 2 and 3 must render the same diagram at rest. Any divergence is a porting bug
+in the TS element class, *not* something to paper over by tweaking `applet.html`.
+
+### 8a. Create the TypeScript test view page
+
+Create `view/test/{super_type}/{sub_type}.html`. Where possible, use the params from a
+verifiable proposition instance (identified in Step 1) so the visual matches a real
+proposition's diagram. Naming convention:
 - `{super_type}` = element category: `point`, `line`, `circle`, `poly`, `sector`, `plane`, `sphere`
 - `{sub_type}` = construction name: `parallelogram`, `chord`, `arc`, etc.
-
-**Always preserve the original Java `<applet>` block as an HTML comment** above the
-TypeScript block. This keeps the original param format visible for reference:
 
 ```html
 <html>
@@ -210,15 +243,6 @@ TypeScript block. This keeps the original param format visible for reference:
 <body>
 <canvas id="canvasId" style="width:400px; height:400px;"></canvas>
 <script src="../../../../dist/bundle.js" type="text/javascript"></script>
-
-<!--applet code=Geometry codebase="../../Geometry" archive=Geometry.zip width=340 height=260>
-<img src="../booki/propI1.gif" alt="java applet or image">
-<param name=background value="35,19,100">
-<param name=e[1] value="A;point;free;60,100">
-<param name=e[2] value="B;point;free;140,100">
-<param name=e[3] value="F;point;foo;A,B">
-</applet-->
-
 <script type="text/javascript">
     let E = geomlib.E;
     let Align = geomlib.Align;
@@ -237,16 +261,66 @@ TypeScript block. This keeps the original param format visible for reference:
 </html>
 ```
 
-Rebuild and verify visually:
+Rebuild the bundle (`npx webpack`) so the page can render — the harness in 8c uses
+the live `dist/bundle.js`.
 
-```sh
-npx webpack
-python3 -m http.server
-# open http://localhost:PORT/view/test/point/foo.html
+### 8b. Create the applet.html companion
+
+Hand-translate the TS `geomlib.init({ elements: [...] })` block back into Java applet
+`<param>` format and save it as `view/applet-tests/{type}/{construction}/applet.html`.
+This file is window 2 of the harness; it must produce the same diagram as the TS test
+page in 8a using identical free-point coordinates.
+
+```html
+<HTML><HEAD><TITLE>{type};{construction} — applet form of view/test/{type}/{sub}.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS:       view/test/{type}/{sub}.html -->
+<!-- ORIGINAL: view/applet-tests/{type}/{construction}/original.html (propXX) -->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="...">
+<param name=e[1] value="A;point;free;60,100">
+<param name=e[2] value="B;point;free;140,100">
+<param name=e[3] value="F;point;foo;A,B">
+</applet>
+</BODY></HTML>
 ```
 
-Compare the diagram against appletviewer or the `.gif` image. Drag the free points
-and verify that dependent elements update correctly.
+The `<!-- TS: ... -->` header line is **load-bearing**: `run_euclid_applet.sh` greps it
+out to know which TS page to open in firefox. Use a single space after `TS:` and a
+repo-relative path (no leading `./` or `/`). The `<!-- ORIGINAL: ... -->` line is
+informational only — the harness finds `original.html` by sibling-file convention.
+
+The `codebase=../../..` resolves three levels up to `view/`, where `Geometry.zip` lives.
+This is different from the `codebase="../../Geometry"` used by the proposition HTMLs in
+`view/euclid-html/` — don't copy that path verbatim.
+
+### 8c. Run the three-way harness and verify all three windows agree
+
+Start a static dev server at the repo root in another terminal, then run the harness:
+
+```sh
+python3 -m http.server 8000
+./run_euclid_applet.sh
+# pick the {type};{construction} entry you just added
+```
+
+The harness auto-discovers your new `applet.html` on the next run (no script edits) and
+spawns three windows in parallel: `original.html` in appletviewer (containerised),
+`applet.html` in appletviewer (containerised), and the TS test page in firefox kiosk
+mode against `localhost:8000`.
+
+Compare:
+- **Window 2 vs window 3** — must be visually identical at rest. Drag a free point in
+  one and the other should track. If they diverge, debug the TS element class.
+- **Window 1 vs window 2** — window 1 carries the full surrounding proposition for
+  context; window 2 strips it down to just the construction. Use this to sanity-check
+  that the `applet.html` trim didn't lose anything semantically important.
+
+Press Ctrl-C in the harness terminal to teardown all three windows.
+
+If Docker/X11 is unavailable, fall back to comparing the TS page against the `.gif`
+image alongside the proposition HTML in `view/euclid-html/`.
 
 ---
 

--- a/rebuild_images.sh
+++ b/rebuild_images.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Rebuild both docker images used by run_euclid_applet.sh:
+#
+#   - euclid-applet:latest   (Java 8 + appletviewer + X11 libs)
+#   - euclid-firefox:latest  (Ubuntu 20.04 + firefox + X11 libs)
+#
+# Any extra arguments are passed through to `docker build`, so common
+# options work as expected:
+#
+#   ./rebuild_images.sh                 # normal rebuild (uses cache)
+#   ./rebuild_images.sh --no-cache      # force a from-scratch rebuild
+#   ./rebuild_images.sh --pull          # also pull a fresh ubuntu:20.04 base
+#   ./rebuild_images.sh --pull --no-cache
+#
+# Run from anywhere — the script cd's to its own directory first so the
+# build context is always the repo root.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: 'docker' not found in PATH." >&2
+  exit 1
+fi
+
+EXTRA_ARGS=("$@")
+
+echo ""
+echo "Rebuilding euclid-applet:latest and euclid-firefox:latest"
+[[ ${#EXTRA_ARGS[@]} -gt 0 ]] && echo "Extra docker build args: ${EXTRA_ARGS[*]}"
+
+echo ""
+echo "===================================================================="
+echo "  [1/2] euclid-applet:latest  (from Containerfile)"
+echo "===================================================================="
+docker build "${EXTRA_ARGS[@]}" -f Containerfile -t euclid-applet:latest "$REPO_ROOT"
+
+echo ""
+echo "===================================================================="
+echo "  [2/2] euclid-firefox:latest  (from Containerfile.firefox)"
+echo "===================================================================="
+docker build "${EXTRA_ARGS[@]}" -f Containerfile.firefox -t euclid-firefox:latest "$REPO_ROOT"
+
+echo ""
+echo "===================================================================="
+echo "  Done. Both images rebuilt:"
+docker image ls --filter 'reference=euclid-applet:latest' --filter 'reference=euclid-firefox:latest' \
+  --format 'table {{.Repository}}:{{.Tag}}\t{{.Size}}\t{{.CreatedSince}}'
+echo "===================================================================="

--- a/run_euclid_applet.sh
+++ b/run_euclid_applet.sh
@@ -9,9 +9,10 @@
 #                         appletviewer (the original trimmed to focus on the
 #                         construction, visually equivalent to the TS test
 #                         page below).
-#   3. UP-TO TypeScript — view/test/{type}/{sub}.html opened in firefox kiosk
-#                         mode against http://localhost:8000/ (the TS port of
-#                         the same up-to-construction view).
+#   3. UP-TO TypeScript — view/test/{type}/{sub}.html opened in firefox
+#                         (against http://localhost:8000/) using a chromeless
+#                         profile, so the window tiles cleanly under WMs like
+#                         xmonad/i3/sway. The TS port of the same view.
 #
 # This makes a triple A/B/C visual comparison: how Joyce drew it (1),
 # how the port reproduces it in the original Java engine (2), and how the
@@ -25,10 +26,15 @@
 # files into the right folder.
 #
 # REQUIREMENTS (host side):
-#   - docker (with the euclid-applet:latest image already built)
+#   - docker
+#   - both images built:
+#       docker build -f Containerfile          -t euclid-applet:latest  .
+#       docker build -f Containerfile.firefox  -t euclid-firefox:latest .
 #   - X11 server with `xhost +local:docker` accepted
-#   - firefox in $PATH
 #   - python3 -m http.server already running at the repo root on :8000
+#
+# Note: firefox runs in its own euclid-firefox container (not on the host),
+# so the user's regular firefox instance is never disturbed.
 
 set -e
 
@@ -36,7 +42,8 @@ REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 APPLET_DIR_HOST="$REPO_ROOT/view/applet-tests"
 APPLET_DIR_CONT=/usr/src/app/view/applet-tests
 HTTP_BASE=http://localhost:8000
-DOCKER_IMAGE=euclid-applet:latest
+APPLET_IMAGE=euclid-applet:latest
+FIREFOX_IMAGE=euclid-firefox:latest
 VIEWER_FLAGS='-J-Djava.security.manager -J-Djava.security.policy=/usr/src/app/permissive.policy'
 
 # ----------------------------------------------------------------------
@@ -47,7 +54,6 @@ require() {
   command -v "$1" >/dev/null 2>&1 || { echo "ERROR: '$1' is required but not found in PATH." >&2; exit 1; }
 }
 require docker
-require firefox
 require curl
 
 if ! curl -s -o /dev/null --connect-timeout 1 "$HTTP_BASE/" ; then
@@ -65,9 +71,15 @@ EOF
   exit 1
 fi
 
-if ! docker image inspect "$DOCKER_IMAGE" >/dev/null 2>&1; then
-  echo "ERROR: Docker image '$DOCKER_IMAGE' not found. Build it first:" >&2
-  echo "    docker build -f Containerfile -t $DOCKER_IMAGE ." >&2
+if ! docker image inspect "$APPLET_IMAGE" >/dev/null 2>&1; then
+  echo "ERROR: Docker image '$APPLET_IMAGE' not found. Build it first:" >&2
+  echo "    docker build -f Containerfile -t $APPLET_IMAGE ." >&2
+  exit 1
+fi
+
+if ! docker image inspect "$FIREFOX_IMAGE" >/dev/null 2>&1; then
+  echo "ERROR: Docker image '$FIREFOX_IMAGE' not found. Build it first:" >&2
+  echo "    docker build -f Containerfile.firefox -t $FIREFOX_IMAGE ." >&2
   exit 1
 fi
 
@@ -143,7 +155,7 @@ echo "Euclid 3-way construction comparison"
 echo "====================================="
 echo "  1. ORIGINAL  — Joyce's full proposition in Java appletviewer"
 echo "  2. UP-TO     — same trimmed to focus on this construction (Java)"
-echo "  3. TS        — same in the TypeScript port (firefox kiosk)"
+echo "  3. TS        — same in the TypeScript port (chromeless firefox)"
 echo ""
 PS3=$'\nSelect a construction (or Ctrl-C to quit): '
 COLUMNS=1
@@ -171,7 +183,6 @@ echo ""
 # Spawn the three windows
 # ----------------------------------------------------------------------
 
-PIDS=()
 CONTAINERS=()
 
 cleanup() {
@@ -179,9 +190,6 @@ cleanup() {
   echo "Cleaning up..."
   for cid in "${CONTAINERS[@]}"; do
     docker stop "$cid" >/dev/null 2>&1 || true
-  done
-  for pid in "${PIDS[@]}"; do
-    kill "$pid" >/dev/null 2>&1 || true
   done
 }
 trap cleanup EXIT INT TERM
@@ -195,12 +203,13 @@ run_appletviewer() {
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     -v "$REPO_ROOT":/usr/src/app \
     -w /usr/src/app \
-    "$DOCKER_IMAGE" \
+    "$APPLET_IMAGE" \
     bash -c "appletviewer $VIEWER_FLAGS $container_path" >/dev/null
 }
 
 ORIG_CONTAINER="euclid-orig-$$"
 APPLET_CONTAINER="euclid-applet-$$"
+FIREFOX_CONTAINER="euclid-firefox-$$"
 
 echo "Starting ORIGINAL appletviewer..."
 run_appletviewer "$ORIG_CONTAINER" "$APPLET_DIR_CONT/$ORIG_REL"
@@ -210,20 +219,92 @@ echo "Starting UP-TO appletviewer..."
 run_appletviewer "$APPLET_CONTAINER" "$APPLET_DIR_CONT/$APPLET_REL"
 CONTAINERS+=("$APPLET_CONTAINER")
 
-echo "Starting firefox kiosk for TS view..."
-firefox --new-window --kiosk "$HTTP_BASE/$TS_REL" >/dev/null 2>&1 &
-PIDS+=($!)
+# ----------------------------------------------------------------------
+# Firefox runs in its own euclid-firefox container so the user's regular
+# firefox instance is never disturbed (no "Close Firefox" dialog, no
+# profile collision, no MOZ_NO_REMOTE escape-hatch needed). The chromeless
+# profile is created on the host and bind-mounted into the container at
+# /profile so the userChrome.css customizations apply.
+# ----------------------------------------------------------------------
+
+FF_PROFILE_DIR_HOST="${XDG_CACHE_HOME:-$HOME/.cache}/euclid-harness/firefox-profile"
+FF_PROFILE_DIR_CONT=/profile
+
+if [[ ! -d "$FF_PROFILE_DIR_HOST" ]]; then
+  mkdir -p "$FF_PROFILE_DIR_HOST/chrome"
+  cat >"$FF_PROFILE_DIR_HOST/chrome/userChrome.css" <<'CSS_EOF'
+/* Hide tab bar, nav/url bar, bookmarks bar, and titlebar so the firefox
+   window content is just the rendered page — application-style view without
+   firefox requesting fullscreen (which tiling WMs honor by floating the
+   window on top of everything else). */
+#TabsToolbar,
+#nav-bar,
+#PersonalToolbar,
+#titlebar {
+  visibility: collapse !important;
+}
+CSS_EOF
+  cat >"$FF_PROFILE_DIR_HOST/user.js" <<'PREFS_EOF'
+// Allow userChrome.css to take effect (Firefox 69+ requires this opt-in).
+user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true);
+// Don't restore previous session — we always pass an explicit URL.
+user_pref("browser.sessionstore.resume_from_crash", false);
+user_pref("browser.startup.page", 0);
+// Suppress the "default browser" prompt and other first-run noise.
+user_pref("browser.shell.checkDefaultBrowser", false);
+user_pref("browser.startup.homepage_override.mstone", "ignore");
+PREFS_EOF
+fi
+
+# Drop a stale lock file from a previous interrupted run.
+rm -f "$FF_PROFILE_DIR_HOST/.parentlock" "$FF_PROFILE_DIR_HOST/lock" 2>/dev/null
+
+echo "Starting firefox in container (chromeless profile) for TS view..."
+echo "  profile: $FF_PROFILE_DIR_HOST"
+
+# --network host: lets the container reach the host's python http.server
+#                 on localhost:8000 directly (no need for host.docker.internal).
+# --user $UID:$GID: matches host uid so the bind-mounted profile dir has
+#                   compatible ownership and firefox can write to it.
+# HOME=/tmp: gives firefox a writable scratch dir without needing a real
+#            user account inside the container.
+docker run --rm -d \
+  --name "$FIREFOX_CONTAINER" \
+  --network host \
+  --user "$(id -u):$(id -g)" \
+  -e DISPLAY="$DISPLAY" \
+  -e HOME=/tmp \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  -v "$FF_PROFILE_DIR_HOST":"$FF_PROFILE_DIR_CONT" \
+  "$FIREFOX_IMAGE" \
+  firefox -profile "$FF_PROFILE_DIR_CONT" "$HTTP_BASE/$TS_REL" >/dev/null
+
+CONTAINERS+=("$FIREFOX_CONTAINER")
+
+# Give firefox a moment to either show a window or exit. If the container
+# died immediately, dump its logs so the user can see why.
+sleep 2
+if ! docker ps --format '{{.Names}}' | grep -qE "^${FIREFOX_CONTAINER}\$"; then
+  echo "" >&2
+  echo "ERROR: firefox container exited within 2s of launch. Logs were:" >&2
+  echo "----" >&2
+  docker logs "$FIREFOX_CONTAINER" 2>&1 || true
+  echo "----" >&2
+  echo "" >&2
+  echo "Common causes:" >&2
+  echo "  - Profile dir corrupted: rm -rf $FF_PROFILE_DIR_HOST and retry" >&2
+  echo "  - X11 not reachable from docker: check \`xhost\` output" >&2
+  exit 1
+fi
 
 echo ""
 echo "Three windows launched. Press Ctrl-C in this terminal to close them."
 echo ""
 
-# Wait for any of: both containers to exit, or firefox to exit, or signal.
+# Wait until any of the three containers exits, then teardown via the trap.
 while true; do
-  if ! docker ps --format '{{.Names}}' | grep -qE "^($ORIG_CONTAINER|$APPLET_CONTAINER)\$"; then
-    break
-  fi
-  if ! kill -0 "${PIDS[0]}" >/dev/null 2>&1; then
+  running=$(docker ps --format '{{.Names}}' | grep -cE "^($ORIG_CONTAINER|$APPLET_CONTAINER|$FIREFOX_CONTAINER)\$" || true)
+  if [[ "$running" -lt 3 ]]; then
     break
   fi
   sleep 2

--- a/run_euclid_applet.sh
+++ b/run_euclid_applet.sh
@@ -1,66 +1,230 @@
 #!/bin/bash
-# Run the Java geometry applet for a specific construction test.
-# Each file in view/applet-tests/ is a stripped-down version of the
-# source proposition that inspired the TypeScript test view page.
+# Three-way comparison harness for the Euclid TypeScript port.
+#
+# For a chosen construction, opens THREE windows side by side:
+#
+#   1. ORIGINAL applet  — view/applet-tests/{type}/{cons}/original.html in
+#                         appletviewer (Java port of the original Joyce work).
+#   2. UP-TO applet     — view/applet-tests/{type}/{cons}/applet.html in
+#                         appletviewer (the original trimmed to focus on the
+#                         construction, visually equivalent to the TS test
+#                         page below).
+#   3. UP-TO TypeScript — view/test/{type}/{sub}.html opened in firefox kiosk
+#                         mode against http://localhost:8000/ (the TS port of
+#                         the same up-to-construction view).
+#
+# This makes a triple A/B/C visual comparison: how Joyce drew it (1),
+# how the port reproduces it in the original Java engine (2), and how the
+# TypeScript port renders the same params (3). Windows 2 and 3 should be
+# pixel-equivalent at rest; window 1 carries the full surrounding proposition
+# and is just there for context.
+#
+# The script auto-discovers every view/applet-tests/{type}/{cons}/applet.html
+# and reads the matching TS path from a `<!-- TS: ... -->` header comment in
+# the file, so adding a new construction is just a matter of dropping the two
+# files into the right folder.
+#
+# REQUIREMENTS (host side):
+#   - docker (with the euclid-applet:latest image already built)
+#   - X11 server with `xhost +local:docker` accepted
+#   - firefox in $PATH
+#   - python3 -m http.server already running at the repo root on :8000
 
-APPLET_DIR=/usr/src/app/view/applet-tests
-VIEWER_FLAGS=(
-  -J-Djava.security.manager
-  -J-Djava.security.policy=/usr/src/app/permissive.policy
-)
+set -e
 
-declare -A ENTRIES
-ENTRIES=(
-  ["circle;radius           (Post.3)"]="circle-radius.html"
-  ["circle;circumcircle     (III.10)"]="circle-circumcircle.html"
-  ["line;bichord            (I.1)"]="line-bichord.html"
-  ["line;perpendicular      (Post.4)"]="line-perpendicular.html"
-  ["point;intersection      (Def I.2)"]="point-intersection.html"
-  ["point;foot              (lemma X.33)"]="point-foot.html"
-  ["point;circumcenter      (III.25a)"]="point-circumcenter.html"
-  ["point;vertex            (I.9)"]="point-vertex.html"
-  ["point;parallelogram     (I.28)"]="point-parallelogram.html"
-  ["polygon;equilateralTriangle (I.10)"]="poly-equilateralTriangle.html"
-  ["sector;sector           (Def III.10)"]="sector-sector.html"
-  ["euler line demo"]="eulerline.html"
-)
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+APPLET_DIR_HOST="$REPO_ROOT/view/applet-tests"
+APPLET_DIR_CONT=/usr/src/app/view/applet-tests
+HTTP_BASE=http://localhost:8000
+DOCKER_IMAGE=euclid-applet:latest
+VIEWER_FLAGS='-J-Djava.security.manager -J-Djava.security.policy=/usr/src/app/permissive.policy'
 
-# Build ordered list for display
-LABELS=(
-  "circle;radius           (Post.3)"
-  "circle;circumcircle     (III.10)"
-  "line;bichord            (I.1)"
-  "line;perpendicular      (Post.4)"
-  "point;intersection      (Def I.2)"
-  "point;foot              (lemma X.33)"
-  "point;circumcenter      (III.25a)"
-  "point;vertex            (I.9)"
-  "point;parallelogram     (I.28)"
-  "polygon;equilateralTriangle (I.10)"
-  "sector;sector           (Def III.10)"
-  "euler line demo"
-)
+# ----------------------------------------------------------------------
+# Preflight checks
+# ----------------------------------------------------------------------
 
-echo ""
-echo "Euclid Applet — Construction Viewer"
-echo "====================================="
-PS3=$'\nSelect a construction (or Ctrl-C to quit): '
-COLUMNS=1
+require() {
+  command -v "$1" >/dev/null 2>&1 || { echo "ERROR: '$1' is required but not found in PATH." >&2; exit 1; }
+}
+require docker
+require firefox
+require curl
 
-select LABEL in "${LABELS[@]}"; do
-  FILE="${ENTRIES[$LABEL]}"
-  if [[ -z "$FILE" ]]; then
-    echo "Invalid selection."
+if ! curl -s -o /dev/null --connect-timeout 1 "$HTTP_BASE/" ; then
+  cat >&2 <<EOF
+ERROR: $HTTP_BASE/ is not responding.
+
+This script assumes a static dev server is already serving the repo root on
+port 8000. Start one in another terminal first:
+
+    cd $REPO_ROOT
+    python3 -m http.server 8000
+
+then re-run this script.
+EOF
+  exit 1
+fi
+
+if ! docker image inspect "$DOCKER_IMAGE" >/dev/null 2>&1; then
+  echo "ERROR: Docker image '$DOCKER_IMAGE' not found. Build it first:" >&2
+  echo "    docker build -f Containerfile -t $DOCKER_IMAGE ." >&2
+  exit 1
+fi
+
+# Allow the docker user to talk to the host X server.
+xhost +local:docker >/dev/null
+
+# ----------------------------------------------------------------------
+# Auto-discover constructions: every folder under applet-tests/ that has
+# an applet.html file is a valid construction. Read the TS path out of the
+# applet.html's `<!-- TS: ... -->` header comment.
+# ----------------------------------------------------------------------
+
+mapfile -t APPLET_FILES < <(cd "$APPLET_DIR_HOST" && find . -mindepth 3 -maxdepth 3 -type f -name 'applet.html' | sort)
+
+if [[ ${#APPLET_FILES[@]} -eq 0 ]]; then
+  echo "ERROR: No applet.html files found under $APPLET_DIR_HOST" >&2
+  exit 1
+fi
+
+LABELS=()
+declare -A APPLET_PATH_REL
+declare -A ORIGINAL_PATH_REL
+declare -A TS_PATH_REL
+
+for rel in "${APPLET_FILES[@]}"; do
+  rel="${rel#./}"                       # point/parallelogram/applet.html
+  type="${rel%%/*}"                     # point
+  rest="${rel#*/}"                      # parallelogram/applet.html
+  cons="${rest%%/*}"                    # parallelogram
+
+  applet_full="$APPLET_DIR_HOST/$rel"
+  original_rel="$type/$cons/original.html"
+  original_full="$APPLET_DIR_HOST/$original_rel"
+
+  if [[ ! -f "$original_full" ]]; then
+    echo "WARN: $rel has no sibling original.html — skipping" >&2
     continue
   fi
 
-  if [[ "$FILE" == "eulerline.html" ]]; then
-    TARGET=/usr/src/app/view/eulerline.html
-  else
-    TARGET="$APPLET_DIR/$FILE"
+  # Pull the TS path out of the applet.html header.
+  # Format expected: <!-- TS: view/test/point/parallelogram.html -->
+  ts_rel=$(grep -oE '<!--[[:space:]]*TS:[[:space:]]*[^[:space:]]+' "$applet_full" \
+           | head -n1 \
+           | sed -E 's/<!--[[:space:]]*TS:[[:space:]]*//')
+  if [[ -z "$ts_rel" ]]; then
+    echo "WARN: $rel has no '<!-- TS: ... -->' header comment — skipping" >&2
+    continue
+  fi
+  ts_full="$REPO_ROOT/$ts_rel"
+  if [[ ! -f "$ts_full" ]]; then
+    echo "WARN: $rel declares TS=$ts_rel but that file does not exist — skipping" >&2
+    continue
   fi
 
-  echo "Opening: $TARGET"
-  appletviewer "${VIEWER_FLAGS[@]}" "$TARGET"
+  label=$(printf '%-7s ;%s' "$type" "$cons")
+  LABELS+=("$label")
+  APPLET_PATH_REL["$label"]="$rel"
+  ORIGINAL_PATH_REL["$label"]="$original_rel"
+  TS_PATH_REL["$label"]="$ts_rel"
+done
+
+if [[ ${#LABELS[@]} -eq 0 ]]; then
+  echo "ERROR: No usable applet.html files (with TS header + sibling original.html)." >&2
+  exit 1
+fi
+
+# ----------------------------------------------------------------------
+# Picker
+# ----------------------------------------------------------------------
+
+echo ""
+echo "Euclid 3-way construction comparison"
+echo "====================================="
+echo "  1. ORIGINAL  — Joyce's full proposition in Java appletviewer"
+echo "  2. UP-TO     — same trimmed to focus on this construction (Java)"
+echo "  3. TS        — same in the TypeScript port (firefox kiosk)"
+echo ""
+PS3=$'\nSelect a construction (or Ctrl-C to quit): '
+COLUMNS=1
+
+select CHOICE in "${LABELS[@]}"; do
+  if [[ -z "$CHOICE" ]]; then
+    echo "Invalid selection."
+    continue
+  fi
   break
+done
+
+APPLET_REL="${APPLET_PATH_REL[$CHOICE]}"
+ORIG_REL="${ORIGINAL_PATH_REL[$CHOICE]}"
+TS_REL="${TS_PATH_REL[$CHOICE]}"
+
+echo ""
+echo "Selected: $CHOICE"
+echo "  ORIGINAL: $APPLET_DIR_CONT/$ORIG_REL"
+echo "  UP-TO   : $APPLET_DIR_CONT/$APPLET_REL"
+echo "  TS      : $HTTP_BASE/$TS_REL"
+echo ""
+
+# ----------------------------------------------------------------------
+# Spawn the three windows
+# ----------------------------------------------------------------------
+
+PIDS=()
+CONTAINERS=()
+
+cleanup() {
+  echo ""
+  echo "Cleaning up..."
+  for cid in "${CONTAINERS[@]}"; do
+    docker stop "$cid" >/dev/null 2>&1 || true
+  done
+  for pid in "${PIDS[@]}"; do
+    kill "$pid" >/dev/null 2>&1 || true
+  done
+}
+trap cleanup EXIT INT TERM
+
+run_appletviewer() {
+  local name="$1"
+  local container_path="$2"
+  docker run --rm -d \
+    --name "$name" \
+    -e DISPLAY="$DISPLAY" \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -v "$REPO_ROOT":/usr/src/app \
+    -w /usr/src/app \
+    "$DOCKER_IMAGE" \
+    bash -c "appletviewer $VIEWER_FLAGS $container_path" >/dev/null
+}
+
+ORIG_CONTAINER="euclid-orig-$$"
+APPLET_CONTAINER="euclid-applet-$$"
+
+echo "Starting ORIGINAL appletviewer..."
+run_appletviewer "$ORIG_CONTAINER" "$APPLET_DIR_CONT/$ORIG_REL"
+CONTAINERS+=("$ORIG_CONTAINER")
+
+echo "Starting UP-TO appletviewer..."
+run_appletviewer "$APPLET_CONTAINER" "$APPLET_DIR_CONT/$APPLET_REL"
+CONTAINERS+=("$APPLET_CONTAINER")
+
+echo "Starting firefox kiosk for TS view..."
+firefox --new-window --kiosk "$HTTP_BASE/$TS_REL" >/dev/null 2>&1 &
+PIDS+=($!)
+
+echo ""
+echo "Three windows launched. Press Ctrl-C in this terminal to close them."
+echo ""
+
+# Wait for any of: both containers to exit, or firefox to exit, or signal.
+while true; do
+  if ! docker ps --format '{{.Names}}' | grep -qE "^($ORIG_CONTAINER|$APPLET_CONTAINER)\$"; then
+    break
+  fi
+  if ! kill -0 "${PIDS[0]}" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
 done

--- a/view/applet-tests/circle/circumcircle/applet.html
+++ b/view/applet-tests/circle/circumcircle/applet.html
@@ -1,0 +1,18 @@
+<HTML><HEAD><TITLE>circle;circumcircle — applet form of view/test/circle/circumcircle.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS:       view/test/circle/circumcircle.html -->
+<!-- ORIGINAL: view/applet-tests/circle/circumcircle/original.html (propIII10) -->
+<!--
+  Up-to-construction applet form of the TS test page, so the Java applet
+  output can be A/B compared with the TypeScript port.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=300 width=300>
+<param name=background value="35,19,100">
+<param name=title value="III.10">
+<param name=e[1] value="B;point;free;150,40">
+<param name=e[2] value="F;point;free;110,100">
+<param name=e[3] value="H;point;free;190,100">
+<param name=e[4] value="ABC;circle;circumcircle;B,F,H;0;0;black;random">
+<param name=e[5] value="P;point;center;ABC;black;green">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/circle/circumcircle/original.html
+++ b/view/applet-tests/circle/circumcircle/original.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>III.10 — circle;circumcircle + point;center</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry codebase=.. archive=Geometry.zip height=300 width=300>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=300 width=300>
 <param name=background value="35,19,100">
 <param name=title value="III.10">
 <param name=e[1] value="B;point;free;150,40">

--- a/view/applet-tests/circle/radius/applet.html
+++ b/view/applet-tests/circle/radius/applet.html
@@ -1,0 +1,17 @@
+<HTML><HEAD><TITLE>circle;radius — applet form of view/test/circle/circle.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS:       view/test/circle/circle.html -->
+<!-- ORIGINAL: view/applet-tests/circle/radius/original.html (Post.3) -->
+<!--
+  Up-to-construction applet form of the TS test page. Visually equivalent to
+  what view/test/circle/circle.html renders: two free points A and B, and a
+  single circle C with center B and radius |BA|.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="Post.3">
+<param name=e[1] value="A;point;free;200,200">
+<param name=e[2] value="B;point;free;200,300">
+<param name=e[3] value="C;circle;radius;B,A">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/circle/radius/original.html
+++ b/view/applet-tests/circle/radius/original.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>Post.3 — circle;radius</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry codebase=.. archive=Geometry.zip height=180 width=250>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=180 width=250>
 <param name=background value="35,19,100">
 <param name=title value="I.Post.3">
 <param name=e[1] value="A;point;free;125,90">

--- a/view/applet-tests/line/bichord/applet.html
+++ b/view/applet-tests/line/bichord/applet.html
@@ -1,0 +1,18 @@
+<HTML><HEAD><TITLE>line;bichord — applet form of view/test/line/bichord.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS:       view/test/line/bichord.html -->
+<!-- ORIGINAL: view/applet-tests/line/bichord/original.html (propI1) -->
+<!--
+  Up-to-construction applet form of the TS test page.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=300 width=340>
+<param name=background value="35,19,100">
+<param name=title value="I.1">
+<param name=e[1] value="A;point;free;125,130">
+<param name=e[2] value="B;point;free;215,130">
+<param name=e[3] value="AB;line;connect;A,B;0">
+<param name=e[4] value="Acirc;circle;radius;A,B">
+<param name=e[5] value="Bcirc;circle;radius;B,A">
+<param name=e[6] value="CD;line;bichord;Bcirc,Acirc">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/line/bichord/original.html
+++ b/view/applet-tests/line/bichord/original.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>I.1 — line;bichord</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry codebase=.. archive=Geometry.zip height=260 width=340>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=260 width=340>
 <param name=background value="35,19,100">
 <param name=title value="I.1">
 <param name=e[1] value="A;point;free;125,130">

--- a/view/applet-tests/line/perpendicular/applet.html
+++ b/view/applet-tests/line/perpendicular/applet.html
@@ -1,0 +1,20 @@
+<HTML><HEAD><TITLE>line;perpendicular — applet form of view/test/line/perpendicular.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS:       view/test/line/perpendicular.html -->
+<!-- ORIGINAL: view/applet-tests/line/perpendicular/original.html (Post.4) -->
+<!--
+  Up-to-construction applet form of the TS test page. The CD connect line
+  and the second EFGH perpendicular pair are present in the original Post.4
+  figure but commented out in the TS test page; we mirror the active TS
+  subset here.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=200 width=310>
+<param name=background value="35,19,100">
+<param name=title value="Post.4">
+<param name=e[1] value="A;point;free;40,130">
+<param name=e[2] value="B;point;free;160,130">
+<param name=e[3] value="AB;line;connect;A,B">
+<param name=e[4] value="C;point;lineSlider;A,B,90,130">
+<param name=e[5] value="D;point;perpendicular;C,B">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/line/perpendicular/original.html
+++ b/view/applet-tests/line/perpendicular/original.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>Post.4 — line;perpendicular</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry codebase=.. archive=Geometry.zip height=160 width=310>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=160 width=310>
 <param name=background value="35,19,100">
 <param name=title value="Post.4">
 <param name=e[1] value="A;point;free;40,130">

--- a/view/applet-tests/point/circumcenter/applet.html
+++ b/view/applet-tests/point/circumcenter/applet.html
@@ -1,0 +1,22 @@
+<HTML><HEAD><TITLE>point;circumcenter — applet form of view/test/circumcenter_lineperp.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS:       view/test/circumcenter_lineperp.html -->
+<!-- ORIGINAL: view/applet-tests/point/circumcenter/original.html (III.25a) -->
+<!--
+  Up-to-construction applet form of the TS test page. Visually equivalent to
+  what view/test/circumcenter_lineperp.html renders: a chord AC, its midpoint
+  D, the perpendicular bisector DB, a slider B along DB, and the circumcenter
+  E of triangle ABC.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=200 height=200>
+<param name=background value="35,19,100">
+<param name=title value="III.25a">
+<param name=e[1] value="A;point;free;60,30">
+<param name=e[2] value="C;point;free;60,200">
+<param name=e[3] value="AC;line;connect;A,C">
+<param name=e[4] value="D;point;midpoint;AC">
+<param name=e[5] value="DB;line;perpendicular;D,A">
+<param name=e[6] value="B;point;lineSlider;DB,30,115">
+<param name=e[7] value="E;point;circumcenter;A,B,C">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point/circumcenter/original.html
+++ b/view/applet-tests/point/circumcenter/original.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>III.25a — point;circumcenter + line;perpendicular</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry codebase=.. archive=Geometry.zip height=230 width=230>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=230 width=230>
 <param name=background value="35,19,100">
 <param name=title value="III.25a">
 <param name=e[1] value="A;point;free;60,30">

--- a/view/applet-tests/point/foot/applet.html
+++ b/view/applet-tests/point/foot/applet.html
@@ -1,0 +1,20 @@
+<HTML><HEAD><TITLE>point;foot — applet form of view/test/point/foot.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS:       view/test/point/foot.html -->
+<!-- ORIGINAL: view/applet-tests/point/foot/original.html (lemma X.33) -->
+<!--
+  Up-to-construction applet form of the TS test page. The two ABM/ACM
+  triangles from the lemma X.33 original are commented out in the TS port
+  (polygons not yet implemented at the time); we match the active TS subset.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=300 width=400>
+<param name=background value="35,19,100">
+<param name=title value="lemma for X.33">
+<param name=e[1] value="B;point;free;30,170">
+<param name=e[2] value="C;point;free;250,170">
+<param name=e[3] value="BCmid;point;midpoint;B,C;0;0">
+<param name=e[4] value="ABC;circle;radius;BCmid,B;0;0;0;0">
+<param name=e[5] value="A;point;circleSlider;ABC,120,40">
+<param name=e[6] value="M;point;foot;A,B,C">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point/foot/original.html
+++ b/view/applet-tests/point/foot/original.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>Lemma X.33 — point;foot</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry codebase=.. archive=Geometry.zip height=200 width=280>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=200 width=280>
 <param name=background value="35,19,100">
 <param name=title value="lemma for X.33">
 <param name=e[1] value="B;point;free;30,170">

--- a/view/applet-tests/point/intersection/applet.html
+++ b/view/applet-tests/point/intersection/applet.html
@@ -1,0 +1,22 @@
+<HTML><HEAD><TITLE>point;intersection — applet form of view/test/point/intersection.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS:       view/test/point/intersection.html -->
+<!-- ORIGINAL: view/applet-tests/point/intersection/original.html (propI39) -->
+<!--
+  Up-to-construction applet form of the TS test page. The TS test page omits
+  the trailing D/F'/N/F''/F/CND elements that the propI39 original carries;
+  we mirror only the active TS subset here.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=300 width=400>
+<param name=background value="35,19,100">
+<param name=title value="Def I.2">
+<param name=e[1] value="A;point;free;40,70">
+<param name=e[2] value="B;point;free;110,100">
+<param name=e[3] value="C;point;free;190,100">
+<param name=e[4] value="BC;line;connect;B,C">
+<param name=e[5] value="E';point;perpendicular;B,C">
+<param name=e[6] value="M;point;midpoint;A,B">
+<param name=e[7] value="E'';point;perpendicular;M,B">
+<param name=e[8] value="E;point;intersection;B,E',M,E''">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point/intersection/original.html
+++ b/view/applet-tests/point/intersection/original.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>Def I.2 — point;intersection</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry codebase=.. archive=Geometry.zip height=200 width=320>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=200 width=320>
 <param name=background value="35,19,100">
 <param name=title value="I.39">
 <param name=e[1] value="A;point;free;40,170;0">

--- a/view/applet-tests/point/parallelogram/applet.html
+++ b/view/applet-tests/point/parallelogram/applet.html
@@ -1,0 +1,23 @@
+<HTML><HEAD><TITLE>point;parallelogram — applet form of view/test/point/parallelogram.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS:       view/test/point/parallelogram.html -->
+<!-- ORIGINAL: view/applet-tests/point/parallelogram/original.html (propI28) -->
+<!--
+  Up-to-construction applet form of the TS test page. Trims the propI28
+  original's lineSlider/EFGH transversal/intersections down to just the four
+  parallelogram vertices A, B, C, D' and the connecting sides — same subset
+  the TS test page renders.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=240 width=360>
+<param name=background value="35,19,100">
+<param name=title value="I.28">
+<param name=e[1] value="A;point;free;40,80">
+<param name=e[2] value="B;point;free;190,80">
+<param name=e[3] value="C;point;free;40,120">
+<param name=e[4] value="D';point;parallelogram;C,A,B;0;0">
+<param name=e[5] value="AB;line;connect;A,B">
+<param name=e[6] value="AC;line;connect;A,C">
+<param name=e[7] value="BD';line;connect;B,D'">
+<param name=e[8] value="CD';line;connect;C,D'">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point/parallelogram/original.html
+++ b/view/applet-tests/point/parallelogram/original.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>I.28 — point;parallelogram</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry codebase=.. archive=Geometry.zip height=200 width=230>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=200 width=230>
 <param name=background value="35,19,100">
 <param name=title value="I.28">
 <param name=e[1] value="A;point;free;40,80">

--- a/view/applet-tests/point/vertex/applet.html
+++ b/view/applet-tests/point/vertex/applet.html
@@ -1,0 +1,20 @@
+<HTML><HEAD><TITLE>point;vertex — applet form of view/test/point/vertex.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS:       view/test/point/vertex.html -->
+<!-- ORIGINAL: view/applet-tests/point/vertex/original.html (propI9) -->
+<!--
+  Up-to-construction applet form of the TS test page. Uses a plain triangle
+  (not equilateralTriangle) so the test doesn't depend on a second construction.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=300 width=360>
+<param name=background value="35,19,100">
+<param name=title value="point;vertex">
+<param name=e[1] value="A;point;free;150,40">
+<param name=e[2] value="B;point;free;50,150">
+<param name=e[3] value="C;point;free;250,150">
+<param name=e[4] value="T;polygon;triangle;A,B,C;0;0;black;0">
+<param name=e[5] value="V1;point;vertex;T,1;black">
+<param name=e[6] value="V2;point;vertex;T,2;black">
+<param name=e[7] value="V3;point;vertex;T,3;black">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point/vertex/original.html
+++ b/view/applet-tests/point/vertex/original.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>I.9 — point;vertex + polygon;equilateralTriangle</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry codebase=.. archive=Geometry.zip height=260 width=300>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=260 width=300>
 <param name=background value="35,19,100">
 <param name=title value="I.9">
 <param name=e[1] value="A;point;free;150,40">

--- a/view/applet-tests/poly/equilateralTriangle/applet.html
+++ b/view/applet-tests/poly/equilateralTriangle/applet.html
@@ -1,0 +1,18 @@
+<HTML><HEAD><TITLE>polygon;equilateralTriangle — applet form of view/test/poly/equilateralTriangle.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS:       view/test/poly/equilateralTriangle.html -->
+<!-- ORIGINAL: view/applet-tests/poly/equilateralTriangle/original.html (propI10) -->
+<!--
+  Up-to-construction applet form of the TS test page (which itself mirrors propI10).
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=280 width=360>
+<param name=background value="35,19,100">
+<param name=title value="I.10">
+<param name=e[1] value="A;point;free;40,170">
+<param name=e[2] value="B;point;free;200,170">
+<param name=e[3] value="ABC;polygon;equilateralTriangle;A,B;0;0;black;random">
+<param name=e[4] value="C;point;vertex;ABC,3;black;green">
+<param name=e[5] value="D;point;midpoint;A,B;black;green">
+<param name=e[6] value="CD;line;connect;C,D;0;0;blue">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/poly/equilateralTriangle/original.html
+++ b/view/applet-tests/poly/equilateralTriangle/original.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>I.10 — polygon;equilateralTriangle + point;vertex</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry codebase=.. archive=Geometry.zip height=200 width=240>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=200 width=240>
 <param name=background value="35,19,100">
 <param name=title value="I.10">
 <param name=e[1] value="A;point;free;40,170">

--- a/view/applet-tests/sector/sector/applet.html
+++ b/view/applet-tests/sector/sector/applet.html
@@ -1,0 +1,20 @@
+<HTML><HEAD><TITLE>sector;sector — applet form of view/test/sector/sector.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS:       view/test/sector/sector.html -->
+<!-- ORIGINAL: view/applet-tests/sector/sector/original.html (Def III.10) -->
+<!--
+  Up-to-construction applet form of the TS test page. Visually equivalent to
+  what view/test/sector/sector.html renders: a circle filled with a random
+  faceColor, with a half-sector E (also random faceColor) drawn from A through
+  B to D so the circle splits into two filled halves.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="Def III.10">
+<param name=e[1] value="A;point;free;200,200">
+<param name=e[2] value="B;point;free;200,300">
+<param name=e[3] value="C;circle;radius;B,A;0;0;0;random">
+<param name=e[4] value="D;point;circleSlider;C,200,400">
+<param name=e[5] value="E;sector;sector;B,A,D;0;0;0;random">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/sector/sector/original.html
+++ b/view/applet-tests/sector/sector/original.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>Def III.10 — sector;sector</TITLE></HEAD>
 <BODY BGCOLOR=ffe9cd>
-<applet code=Geometry codebase=.. archive=Geometry.zip height=240 width=300>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=240 width=300>
 <param name=background value="35,19,100">
 <param name=title value="III.Def.10">
 <param name=e[1] value="A;point;free;150,120;black;green">


### PR DESCRIPTION
## Summary

Reorganize `view/applet-tests/` into per-construction folders and replace `run_euclid_applet.sh` with a host-side three-way comparison harness that opens an A/B/C visual diff across **(1) the original Joyce proposition in appletviewer**, **(2) the same trimmed to focus on the construction in appletviewer**, and **(3) the TypeScript port in firefox**, with all three running in dedicated docker containers so the user's host firefox is never touched.

The motivation: when porting a construction from the Java applet to TypeScript, we want to see all three views side-by-side so any visual divergence between window 2 (Java applet, trimmed) and window 3 (TS port) is immediately obvious as a porting bug.

## What changed

### New per-folder layout

`view/applet-tests/` was a flat directory of 11 stripped-down proposition files. It's now 11 per-construction folders, each holding exactly two artifacts:

```
view/applet-tests/{type}/{construction}/
├── original.html   # single-applet extraction of the source proposition
└── applet.html     # hand-translation of the matching view/test/ page back
                    # into Java applet <param> form
```

`applet.html` carries a **load-bearing** header comment so the harness knows which TS page to open in firefox:

```html
<!-- TS:       view/test/point/parallelogram.html -->
<!-- ORIGINAL: view/applet-tests/point/parallelogram/original.html (propI28) -->
```

The `TS:` line is a repo-relative path with no leading `./` or `/`. This indirection lets the layout handle two paths that don't follow the `{type}/{construction}.html` convention:

- `circle/radius/` → `view/test/circle/circle.html`
- `point/circumcenter/` → `view/test/circumcenter_lineperp.html`

All 11 flat files are detected as `git mv` renames into `original.html` (80–94% similarity; the rest is the `codebase=../../..` path fix needed because the files moved two levels deeper).

### Three of eleven `applet.html` files are fresh hand-translations

`circle/radius`, `point/circumcenter`, and `sector/sector` had no `<!--applet ... -->` comment block in their TS test pages — the elements are defined inline in the `geomlib.init({elements: [...]})` JS block. Their `applet.html` files were hand-translated from the JS to mirror what the TS port actually renders.

### New `Containerfile.firefox` — firefox runs in its own container

To avoid disturbing the user's running firefox instance, the harness launches firefox inside its own docker container instead of on the host. The new image is Ubuntu 20.04 + firefox + GTK/X11 client libs (20.04 specifically because that's the last LTS where `apt install firefox` is a real `.deb` instead of a snap-transitional package, and snaps don't work cleanly inside containers).

The container is run with:

- `--network host` so it can reach the host's `python3 -m http.server 8000` on `localhost:8000` directly
- `--user "$(id -u):$(id -g)"` so the bind-mounted chromeless profile dir at `~/.cache/euclid-harness/firefox-profile` has matching ownership
- `-e HOME=/tmp` so firefox has a writable scratch dir without needing a real user account in the image
- `-v /tmp/.X11-unix:/tmp/.X11-unix` and `-e DISPLAY=$DISPLAY` for X11 forwarding (same as the appletviewer containers)

The chromeless `userChrome.css` (collapses `#TabsToolbar`, `#nav-bar`, `#PersonalToolbar`, `#titlebar`) is created on the host on first run and bind-mounted into the container, so the harness firefox window has no browser chrome and tiles cleanly under xmonad/i3/sway. Earlier attempts at host-side launches (`--kiosk`, then `MOZ_NO_REMOTE=1 -no-remote -profile`) ran into either fullscreen-overlay behavior in tiling WMs or "Close Firefox" inter-instance dialogs — running firefox in its own pid + filesystem + X11-client namespace bypasses both classes of problem.

### New `rebuild_images.sh` — single-command rebuild of both images

```sh
./rebuild_images.sh                  # normal rebuild (uses cache)
./rebuild_images.sh --no-cache       # force from-scratch rebuild of both
./rebuild_images.sh --pull           # also re-pull ubuntu:20.04 base
./rebuild_images.sh --pull --no-cache  # full clean rebuild
```

Wraps both `docker build` invocations, passes through any extra flags, and prints a final `docker image ls` summary showing both images' sizes and ages. The two images share the `ubuntu:20.04` base layer so the second build is small.

### Host-side `run_euclid_applet.sh` rewrite

Was: an in-container `select` picker that ran a single `appletviewer`.
Now: a host-side orchestration harness that:

1. **Preflight** — checks `docker` and `curl` are in `$PATH`; verifies `http://localhost:8000/` is responding (fails with instructions, does *not* auto-start the http.server); checks both `euclid-applet:latest` and `euclid-firefox:latest` images are built; runs `xhost +local:docker`.
2. **Auto-discovery** — globs `view/applet-tests/*/*/applet.html`, parses the `<!-- TS: ... -->` header out of each, verifies the TS file and sibling `original.html` both exist; warn-and-skip otherwise.
3. **Picker** — `select` menu of `{type};{construction}` labels.
4. **Three docker containers in parallel:**
   - `euclid-applet` running `appletviewer original.html`
   - `euclid-applet` running `appletviewer applet.html`
   - `euclid-firefox` running `firefox -profile /profile <URL>` against the chromeless profile
5. **Cleanup** — `trap EXIT INT TERM` runs `docker stop` on all three containers. Polls until any of them exits, then tears the rest down via the trap. No host PIDs to track.

Adding a new construction is now just dropping `original.html` and `applet.html` into the right folder — the harness picks them up automatically with no script edits.

### `doc/process.md` rewrites

The per-session porting workflow grew from 9 mostly-Java-side steps into a 9-step process that explicitly threads the harness through:

- **Step 3** — now also instructs creating `original.html` from the source proposition (single-applet extraction with `codebase=../../..`).
- **Step 4** — now invokes the three-way harness with prerequisites (build both docker images, start `python3 -m http.server`) and a fallback for the very first session of a new construction (when `applet.html` doesn't yet exist).
- **Step 8** — combined what was previously two separate steps (test view page in 8a, applet.html companion in 8b) into one step framed around the three-way artifact set, with a final 8c sub-section that runs the harness and verifies all three windows agree.
- **Step 9** — renumbered from old Step 10 (tracker + journal update); content unchanged.

### `AGENTS.md` and `README.md` updates

`AGENTS.md`'s "View the Java reference applet" section is replaced with "Three-way construction comparison harness" — documents the prerequisites (docker + X11 + http.server + xhost), the three-image setup, the per-folder layout, and the load-bearing TS header convention.

`README.md`'s Docker section now walks through building both images, with a note that the second build is cheap because the two share the `ubuntu:20.04` base layer.

## Stats

- **2 commits** (`c1b5852` + `4378abe`), **28 files changed**, **+789 / −109**
- 11 `*.html` files renamed from flat layout into `view/applet-tests/{type}/{construction}/original.html`
- 11 new `view/applet-tests/{type}/{construction}/applet.html` files
- 2 new top-level files: [`Containerfile.firefox`](Containerfile.firefox), [`rebuild_images.sh`](rebuild_images.sh)
- 4 docs touched: [`AGENTS.md`](AGENTS.md), [`README.md`](README.md), [`doc/process.md`](doc/process.md), [`run_euclid_applet.sh`](run_euclid_applet.sh)

## Test plan

- [x] `bash -n run_euclid_applet.sh` and `bash -n rebuild_images.sh` parse cleanly
- [x] `find view/applet-tests -type f` shows exactly 22 files (11 `original.html` + 11 `applet.html`), no orphans at the flat level
- [x] Every `applet.html` has a parseable `<!-- TS: ... -->` header pointing at an existing file under `view/test/`, and a sibling `original.html` in the same folder
- [x] `./rebuild_images.sh` builds both `euclid-applet:latest` and `euclid-firefox:latest` cleanly and prints the final `docker image ls` summary
- [x] On a host with Docker + X11 + `python3 -m http.server 8000` running at the repo root: `./run_euclid_applet.sh` → pick `point;parallelogram` → three windows open → drag a free point in the appletviewer `applet.html` window and confirm the firefox window tracks the same way
- [x] Repeat the manual smoke test for one of the three hand-translated entries (`sector;sector` is the most visually distinctive — should show a circle filled with two random-color half-sectors, matching the TS test page's screenshot)
- [x] Confirm the user's regular host firefox is unaffected: `pgrep -af firefox` on the host shows only the user's normal firefox processes; the harness firefox appears only in `docker ps` as the `euclid-firefox-<pid>` container
- [x] Press Ctrl-C in the harness terminal and confirm all three Docker containers are torn down

## Out of scope / known limitations

- **Minor rendering differences** between window 2 (Java appletviewer) and window 3 (TS port) were observed during smoke testing for some constructions — most likely color / transparency / face-fill handling in the TS port. These are real porting bugs in the TS element classes, but they're out of scope for this branch (which is structural — the harness exists to *find* these, not fix them). They'll be tackled in follow-up branches now that the comparison loop is in place.
- Some `original.html` files (`circle/radius`, `line/perpendicular`, `sector/sector`, `point/intersection`) derive from postulate / definition pseudo-pages rather than proper `propXX.html` files. They were that way in the pre-existing flat layout — left alone, just renamed. Tightening these to verbatim extractions of real propositions is a separate pass.
- The `euclid-firefox` image pins `ubuntu:20.04` for the firefox `.deb`. When Mozilla eventually drops `.deb` support entirely or 20.04 reaches EOL, this image will need to migrate to a different base (debian-bookworm with `firefox-esr` is the most likely candidate).
