### PR TITLE
Implement sector;arc + per-step review workflow + test infra fix

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "require": "ts-node/register",
+  "spec": ["tests/**/*.ts"]
+}

--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -71,6 +71,24 @@ These affect the library as a whole, independent of individual constructions.
 - [ ] **`PerpendicularPlane` potential division by zero** (`src/elements/plane/PerpendicularPlane.ts`
   ~line 56) — Marked `// TODO: Check division by 0?` in the normalization step.
 
+- [ ] **Default `faceColor` for `dimension == 2` elements diverges from Java applet**
+  (`src/index.ts` line 73) — `init()` applies a default `faceColor = lighten(bgcolor)` to
+  any element whose `dimension == 2`, so `SectorElement` / `ArcElement` / polygons / filled
+  circles all pick up a pale-fill auto-face when the caller does not set `faceColor`
+  explicitly. The Java applet leaves face-color unset unless the param string specifies
+  one, so Joyce's propositions that wanted an open arc wrote `;0;0;…;0` to explicitly
+  suppress the (Java-side?) default. We can currently work around it in `IConstructionInfo`
+  only by passing a non-null string that `parseColor` interprets as transparent — but the
+  numeric-0 → null path is itself blocked by the `parseColor` bug at line 31 and by
+  `IConstructionInfo` not accepting `number | null` for color fields. Full fix needs all
+  three platform TODOs (this one + parseColor + numeric-0 handling in `init()`) resolved
+  together so a caller can write `faceColor: 0` or `faceColor: null` and get an open face.
+  - **First observed instance**: `sector;arc` in `view/test/sector/arc.html` renders a
+    pale-cream pie slice from `_Center → A → B → _Center` where Java's
+    [view/applet-tests/sector/arc/applet.html](../view/applet-tests/sector/arc/applet.html)
+    shows just the open arc curve. Geometry is identical; only the default fill differs.
+    Documented in the three-way harness comparison on 2026-04-11.
+
 ---
 
 ## Point constructions
@@ -286,9 +304,27 @@ These affect the library as a whole, independent of individual constructions.
 - [x] **`sector`** (2 signature variants) — `src/elements/sector/SectorElement.ts`
   - [x] test view: [view/test/sector/sector.html](../view/test/sector/sector.html)
 
-- [ ] **`arc`** — TBD
-  - Java source: `Arc.java` — computes circumcenter of three given points; draws arc through A, M, B
-  - Used in: I.4, I.16, I.29, II.5–II.8, III.2, III.10, III.13, III.23–III.25, III.30
+- [x] **`arc`** — `src/elements/sector/ArcElement.ts`
+  - Extends `SectorElement`; constructor takes `(A, M, B, Plane)` and creates a bare
+    internal `_Center = new PointElement()` that `update()` recomputes every frame via
+    `_Center.toCircumcenter(A, M, B)`. Overrides `translate`/`rotate` to move only
+    `_Center` (A, M, B are independent slate elements).
+  - Java source: `Arc.java` — 23 lines, line-for-line port.
+  - 2D variant only per the 2D-first policy; the 3D variant
+    `[PointElement, PointElement, PointElement, PlaneElement]` remains TBD. When
+    added, MUST be registered BEFORE `ArcConstruction` in the `constructions` array
+    (signature variant ordering rule).
+  - Mocha tests (3): circumcenter of propIII2 points, `translate()` isolation,
+    `rotate()` isolation — all in `tests/SlateTest.ts`.
+  - [x] test view: [view/test/sector/arc.html](../view/test/sector/arc.html) — propIII2
+  - [x] applet-tests pair:
+    [view/applet-tests/sector/arc/{original,applet}.html](../view/applet-tests/sector/arc/)
+  - **Known cosmetic divergence from Java applet**: the TS port renders a pale-cream
+    pie-slice fill under the arc curve where the Java applet shows an open curve. This
+    is the default-faceColor bug documented above — *not* a geometry bug. Dragging E
+    tracks the arc's circumcenter smoothly and matches Java behavior.
+  - Used in: I.4 (blocked — see below), I.16, II.5–II.8, III.2, III.10, III.13,
+    III.23–III.25, III.30
 
 ---
 
@@ -342,4 +378,5 @@ These affect the library as a whole, independent of individual constructions.
 | `Polygon.equilateralTriangle` | view/test/poly/equilateralTriangle.html | exists |
 | `Point.parallelogram` | view/test/point/parallelogram.html | exists |
 | `Sector.sector` | view/test/sector/sector.html | exists |
+| `Sector.arc` | view/test/sector/arc.html | exists |
 | All others | — | missing |

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,100 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-11 — Implemented sector;arc + per-step review workflow + test infra fix
+
+**Completed:**
+- Restructured `doc/process.md` to institutionalize a per-step review workflow:
+  each step is committed standalone on a feature branch and reviewed by a human
+  before the next step begins. Added explicit "cut a `feature/{type}-{construction}`
+  branch off master first" guidance to step 1, dropped the old optional step 4
+  ("View in appletviewer") since it duplicated the mandatory step 7 harness run,
+  and renumbered the remaining steps 1..8. Also added a "no `Co-Authored-By:`
+  trailer on commits" rule to the preamble.
+- Ported `sector;arc` as `src/elements/sector/ArcElement.ts` — a 2D port of
+  `geom_applet/source/Arc.java`. Extends `SectorElement`; constructor takes
+  `(A, M, B, Plane)` and creates a bare internal
+  `_Center = new PointElement()` that `update()` recomputes every frame via
+  `_Center.toCircumcenter(A, M, B)`. Ported **every method** Java overrides
+  (update, translate, rotate) including the "arguably redundant" `_P.update()`
+  call at the top of `update()` — per the new "no half-done ports" feedback
+  rule (see memory/feedback_full_port.md).
+- Wired `ArcConstruction` into the dispatch table at
+  `src/elements/Constructions.ts` with 2D signature
+  `[PointElement, PointElement, PointElement]`, dispatching to the existing
+  `SectorConstructions.arc = 402` enum value.
+- Three Mocha tests in `tests/SlateTest.ts` exercising `update()` (hand-computed
+  circumcenter ≈ (86.667, 163.333) from propIII2 points), `translate()` isolation
+  (center shifts, A/M/B untouched), and `rotate()` isolation (center rotates
+  around a pivot, A/M/B untouched). 17/17 passing.
+- Three-way harness pair:
+  `view/applet-tests/sector/arc/{original,applet}.html` +
+  `view/test/sector/arc.html`, all using propIII2 coordinates identical to the
+  Mocha fixture `arc_propIII2_data`. Visual comparison confirmed: geometry
+  matches between Java appletviewer and TS firefox; dragging free point E tracks
+  the arc's circumcenter smoothly.
+- **Platform fix** — solved the stale-`.js` test-shadowing bug (discovered
+  during step 6 when my new Mocha tests silently failed to run). Root cause:
+  `tsc` without `--noEmit` deposited compiled `.js` siblings next to every
+  `.ts` file, and mocha picked up the stale `.js` instead of the fresh `.ts`.
+  Fix: added `.mocharc.json` with `ts-node/register` and
+  `spec: ["tests/**/*.ts"]`, switched `npm run build` to `tsc --noEmit`
+  (pure type-check — matching what AGENTS.md has claimed all along), deleted
+  56 vestigial `.js`/`.js.map` files from `src/` and `tests/` working trees.
+  Full toolchain verified: `npm run build` clean, `npm test` → 17/17,
+  `npx webpack` → `dist/bundle.js` in 1.3s. Zero new dependencies (ts-node
+  was already installed).
+- Book III renderable count: 14 → **18** (+III.2, III.23, III.25, III.30).
+
+**Discovered:**
+- **Face-color divergence from Java applet**: `src/index.ts:73` applies a
+  default `faceColor = lighten(bgcolor)` to every element with `dimension == 2`.
+  `ArcElement` has `dimension = 2` (matching Java), so without an explicit
+  `faceColor` in the `IConstructionInfo`, the TS port renders a pale-cream
+  pie-slice fill under the arc curve where Java shows an open curve. Joyce's
+  propIII2 param string explicitly writes `;0;0;black;0` to suppress the
+  default — we have no clean way to express this in `IConstructionInfo` today
+  because numeric-`0` → null handling is already a known platform bug. Added
+  as a new platform-level TODO in `doc/construction-tracker.md` with
+  `sector;arc` cited as the first observed instance. **Not a geometry bug;
+  purely cosmetic.**
+- **I.4 is not unblocked by arc after all**: the proposition-tracker had
+  I.4 listed as "NEEDS: sector;arc", but propI4.html's element e[6] is
+  `CircAB;circle;radius;A,D,E;0;0;0;0` — a **3-point** `circle;radius` form
+  ("circle at A with radius |DE|") that is TBD in TypeScript. The existing
+  `CircleRadiusCenterConstruction` only has a 2-point signature. Tracker
+  entry for I.4 corrected to call out this additional blocker.
+- **ts-node was already a devDependency** at `package.json:32` (`^10.9.2`).
+  This materially changed the right answer for the test-shadowing fix —
+  Option 2 (mocha + ts-node) became the canonical choice over Option 1
+  (pretest tsc) because no new dep was required.
+- Arc.java's internal `Center = new PointElement()` does NOT need to be
+  registered on the slate. It is a coordinate holder; `Arc.update()` writes
+  to it directly each frame. No entry in `elementsForUpdate`.
+- `SectorElement.drawFace` in TS draws a pie slice composed of an arc curve
+  plus line-to-Center-A-B — meaning arcs inherit pie-slice filling via the
+  base class, which is why the default-faceColor bug manifests so visibly.
+
+**Next session:**
+- Top priority: `line;chord` (17 uses, I.12, III.1, III.5–III.6, III.8–III.9,
+  III.12, III.15, III.17, III.34, III.36–III.37) — `Chord.java` is a modest
+  port.
+- Alternative: `polygon;parallelogram` (18 uses, reuses the same D=A+C−B
+  formula as the point variant that already landed, just wraps it in a
+  4-vertex polygon).
+- Or: `point;similar` (15 uses, calls existing `toSimilar()` on
+  `PointElement` — easy win, unlocks I.23, I.24, I.26, I.31, III.14, and
+  half of Book III's similar-segment propositions).
+- Optional follow-up for `sector;arc`: investigate whether the face-fill
+  divergence can be fixed at the `ArcElement` level by overriding `drawFace`
+  to always no-op (which would match Java behavior for arcs specifically),
+  versus fixing it at the platform level by making `IConstructionInfo`
+  accept `number | null` for color fields and fixing `parseColor`. The
+  platform fix unblocks all future cases; the per-element override is a
+  spot patch.
+
+---
+
 ## 2026-04-10 — Implemented point;parallelogram
 
 **Completed:**

--- a/doc/process.md
+++ b/doc/process.md
@@ -15,7 +15,7 @@ commit, then pause for a human to review the diff before moving on to the next s
 - An AI agent running this workflow **must not** begin the next step until the
   human has reviewed and acknowledged the current step's commit.
 - Commit messages should name the step and what landed
-  (e.g. `sector-arc: step 5 — add ArcElement.ts`).
+  (e.g. `sector-arc: step 4 — add ArcElement.ts`).
 - **Do not add a `Co-Authored-By:` trailer** to commits on this repo, even when
   an AI agent authored the change. The human running the session is the author
   of record; the agent is a tool.
@@ -136,55 +136,11 @@ extraction of the source proposition. Copy the `<applet>...</applet>` block out 
 the `codebase` to `../../..` (three levels up to `view/`, where `Geometry.zip` lives),
 not the `codebase="../../Geometry"` that the proposition HTMLs use. This is the
 "as Joyce drew it" reference; do not trim it. The companion `applet.html` (added in
-Step 8) is the trimmed up-to-construction version that mirrors the TS test page.
+Step 7) is the trimmed up-to-construction version that mirrors the TS test page.
 
 ---
 
-## Step 4 — View in appletviewer (optional but recommended)
-
-First-time setup: build both docker images.
-
-```sh
-docker build -f Containerfile         -t euclid-applet:latest  .
-docker build -f Containerfile.firefox -t euclid-firefox:latest .
-```
-
-Then run the host-side three-way comparison harness:
-
-```sh
-python3 -m http.server 8000   # in another terminal at the repo root
-./run_euclid_applet.sh
-# pick the {type};{construction} entry you just created
-```
-
-The script auto-discovers every `view/applet-tests/{type}/{construction}/applet.html`
-file and pops three windows for the chosen construction:
-
-  1. **ORIGINAL appletviewer** — `original.html` (Joyce's full proposition)
-     in the `euclid-applet` container
-  2. **UP-TO appletviewer** — `applet.html` (same trimmed to focus on the construction)
-     in the `euclid-applet` container
-  3. **TypeScript firefox** — `view/test/{type}/{sub}.html` from `localhost:8000`,
-     opened in the `euclid-firefox` container against an isolated chromeless profile
-     so the window tiles under xmonad/i3/sway and the user's regular firefox instance
-     is never touched
-
-Windows 2 and 3 should be visually equivalent at rest; window 1 carries the full
-surrounding proposition for context. Drag free points in window 2 and watch dependent
-elements move — that is the ground truth for the construction's behavior, and any
-divergence between windows 2 and 3 is a porting bug in your TS element class.
-
-For the very first session of a new construction you may not yet have an `applet.html`
-(it's added in Step 8) — in that case the script will skip the construction. As a
-fallback you can either pre-create a stub `applet.html` that's a copy of `original.html`
-just to populate window 2, or use the `.gif` image alongside the proposition HTML in
-`view/euclid-html/`.
-
-Goal: verify every ported construction against appletviewer at least once to "close out" the port.
-
----
-
-## Step 5 — Implement the element class
+## Step 4 — Implement the element class
 
 Create `src/elements/{type}/FooElement.ts`.
 
@@ -215,7 +171,7 @@ export class FooElement extends PointElement {
 
 ---
 
-## Step 6 — Write the Construction class
+## Step 5 — Write the Construction class
 
 In `src/elements/Constructions.ts`, add a new `Construction` subclass:
 
@@ -243,7 +199,7 @@ would otherwise greedily consume 3D param lists.
 
 ---
 
-## Step 7 — Write a Mocha test
+## Step 6 — Write a Mocha test
 
 In `tests/SlateTest.ts`, add a test following the existing patterns.
 
@@ -267,11 +223,11 @@ it('should compute foo correctly', () => {
 ```
 
 Run with `npm test`. If time is short and the math is complex, it's acceptable to
-skip the unit test and rely on visual verification in Step 8 — note this in the journal.
+skip the unit test and rely on visual verification in Step 7 — note this in the journal.
 
 ---
 
-## Step 8 — Build the three-way comparison view (TS page + applet.html, then harness)
+## Step 7 — Build the three-way comparison view (TS page + applet.html, then harness)
 
 Each construction gets a triple of artifacts that are visually equivalent at rest and
 exercised together by `./run_euclid_applet.sh`:
@@ -383,7 +339,7 @@ image alongside the proposition HTML in `view/euclid-html/`.
 
 ---
 
-## Step 9 — Update the tracker and journal
+## Step 8 — Update the tracker and journal
 
 1. Mark the construction as **IMPL** in [constructions-reference.md](constructions-reference.md)
 2. Check off any newly-renderable propositions in [proposition-tracker.md](proposition-tracker.md)

--- a/doc/process.md
+++ b/doc/process.md
@@ -4,6 +4,29 @@ Each session works through one construction type at a time: read the Java source
 port it to TypeScript, create a test view page, and optionally verify it against
 the Java applet. Repeat until all constructions are done, then convert all books.
 
+## Commit per step, with human review between steps
+
+The steps below are designed to be **committed one at a time** on the feature branch.
+After each step is finished, stop and commit that step's artifacts as a standalone
+commit, then pause for a human to review the diff before moving on to the next step.
+
+- An AI agent running this workflow **may** make file edits, run tests, and build
+  the bundle autonomously *within* a single step.
+- An AI agent running this workflow **must not** begin the next step until the
+  human has reviewed and acknowledged the current step's commit.
+- Commit messages should name the step and what landed
+  (e.g. `sector-arc: step 5 — add ArcElement.ts`).
+- **Do not add a `Co-Authored-By:` trailer** to commits on this repo, even when
+  an AI agent authored the change. The human running the session is the author
+  of record; the agent is a tool.
+- If a step's work has to be redone after review, amend or revert on the feature
+  branch — master never sees the in-progress commits.
+
+The point is to keep the review granularity small: one file or one logical unit
+per commit. A reviewer can catch "this update() has the wrong sign" or "this
+signature list is in the wrong order for first-match-wins" at the step boundary
+instead of after eight interleaved changes.
+
 ---
 
 ## Step 1 — Choose the next construction
@@ -41,6 +64,28 @@ have already been copied into the repo as standalone applet HTML for nearby cons
 If the same proposition naturally exercises both your target and an already-implemented
 construction, prefer it — you can reuse the existing `inspiration.html` as a reference
 rather than creating a fresh one from scratch.
+
+### Create a feature branch off master
+
+Once the construction and verifying proposition are locked in, cut a fresh feature
+branch off `master` *before* touching any source files. One construction per branch
+keeps the diff reviewable and makes it trivial to back out or rebase if the port
+turns out wrong.
+
+```sh
+git checkout master
+git pull --ff-only
+git checkout -b feature/{type}-{construction}
+```
+
+Naming: `feature/point-vertex`, `feature/sector-arc`, `feature/line-chord`, etc. —
+mirror the `{type};{construction}` pair from the HTML param format so the branch
+name lines up with the tracker entry and the harness menu label.
+
+Do this up front, not at commit time: all subsequent steps (new element class,
+Construction subclass, test, `view/test/` page, `applet-tests/` pair, tracker and
+journal updates) land on the feature branch, and master stays pristine until the
+port is merged.
 
 ---
 

--- a/doc/proposition-tracker.md
+++ b/doc/proposition-tracker.md
@@ -16,8 +16,8 @@ Tracks the port status of all propositions across Euclid's Elements.
 |-------|-------|--------------------|------------------|
 | Book I | 48 | 16 | 0 |
 | Book II | 14 | 2 | 0 |
-| Book III | 37 | 14 | 0 |
-| **I–III total** | **99** | **32** | **0** |
+| Book III | 37 | 18 | 0 |
+| **I–III total** | **99** | **36** | **0** |
 | Books IV–XIII | ~365 | — | — |
 
 Update the summary table after each session.
@@ -29,7 +29,7 @@ Update the summary table after each session.
 - [~] I.1 — To construct an equilateral triangle on a given finite straight line.
 - [ ] I.2 — To place a straight line equal to a given straight line with one end at a given point. NEEDS: `polygon;equilateralTriangle`, `point;vertex`
 - [~] I.3 — To cut off from the greater of two given unequal straight lines a straight line equal to the less.
-- [ ] I.4 — If two triangles have two sides equal to two sides respectively… (SAS congruence). NEEDS: `sector;arc`
+- [ ] I.4 — If two triangles have two sides equal to two sides respectively… (SAS congruence). NEEDS: `circle;radius` 3-point variant (`A,B,C` for "circle at A with radius |BC|" — TBD, distinct from the 2-point IMPL variant). Note: the only remaining arc-only blocker since `sector;arc` landed; this proposition still cannot render until the 3-point circle-radius variant is implemented.
 - [~] I.5 — In isosceles triangles the angles at the base equal one another.
 - [~] I.6 — If in a triangle two angles equal one another, then the sides opposite the equal angles also equal one another.
 - [~] I.7 — Given two straight lines constructed from the ends of a straight line and meeting in a point…
@@ -41,7 +41,7 @@ Update the summary table after each session.
 - [~] I.13 — If a straight line stands on a straight line, then it makes either two right angles or angles whose sum equals two right angles.
 - [~] I.14 — If with any straight line, and at a point on it, two straight lines not lying on the same side make the sum of the adjacent angles equal to two right angles, then the two straight lines are in a straight line with one another.
 - [~] I.15 — If two straight lines cut one another, then they make the vertical angles equal to one another.
-- [ ] I.16 — In any triangle, if one of the sides is produced, then the exterior angle is greater than either of the interior and opposite angles. NEEDS: `sector;arc`, `point;proportion`
+- [ ] I.16 — In any triangle, if one of the sides is produced, then the exterior angle is greater than either of the interior and opposite angles. NEEDS: `point;proportion`  (`sector;arc` landed 2026-04-11)
 - [~] I.17 — In any triangle the sum of any two angles is less than two right angles.
 - [~] I.18 — In any triangle the angle opposite the greater side is greater.
 - [~] I.19 — In any triangle the side opposite the greater angle is greater.
@@ -83,10 +83,10 @@ Update the summary table after each session.
 - [ ] II.2 — If a straight line is cut at random, then the sum of the rectangles contained by the whole and each of the segments equals the square on the whole. NEEDS: `point;parallelogram`, `polygon;parallelogram`, `polygon;quadrilateral`, `polygon;square`, `point;vertex`
 - [ ] II.3 — If a straight line is cut at random, then the rectangle contained by the whole and one of the segments equals the sum of the rectangle contained by the segments and the square on the aforesaid segment. NEEDS: `point;parallelogram`, `polygon;parallelogram`, `polygon;square`, `point;vertex`
 - [ ] II.4 — If a straight line is cut at random, then the square on the whole equals the sum of the squares on the segments plus twice the rectangle contained by the segments. NEEDS: `point;parallelogram`, `polygon;parallelogram`, `polygon;quadrilateral`, `polygon;square`, `point;vertex`
-- [ ] II.5 — If a straight line is cut into equal and unequal segments, then the rectangle contained by the unequal segments of the whole together with the square on the straight line between the points of section equals the square on the half. NEEDS: `sector;arc`, `line;chord`, `point;parallelogram`, `polygon;parallelogram`, `polygon;quadrilateral`, `polygon;square`, `point;vertex`
-- [ ] II.6 — If a straight line is bisected and a straight line is added to it in a straight line… NEEDS: `sector;arc`, `point;parallelogram`, `polygon;parallelogram`, `polygon;quadrilateral`, `polygon;square`, `point;vertex`
-- [ ] II.7 — If a straight line is cut at random, then the sum of the square on the whole and that on one of the segments… NEEDS: `sector;arc`, `point;parallelogram`, `polygon;parallelogram`, `polygon;square`, `point;vertex`
-- [ ] II.8 — If a straight line is cut at random, then four times the rectangle contained by the whole and one of the segments plus the square on the remaining segment… NEEDS: `sector;arc`, `line;parallel`, `point;parallelogram`, `polygon;parallelogram`, `polygon;quadrilateral`, `polygon;square`, `point;vertex`
+- [ ] II.5 — If a straight line is cut into equal and unequal segments, then the rectangle contained by the unequal segments of the whole together with the square on the straight line between the points of section equals the square on the half. NEEDS: `line;chord`, `polygon;parallelogram`, `polygon;quadrilateral`, `polygon;square`  (`point;parallelogram`, `point;vertex`, `sector;arc` already landed)
+- [ ] II.6 — If a straight line is bisected and a straight line is added to it in a straight line… NEEDS: `polygon;parallelogram`, `polygon;quadrilateral`, `polygon;square`  (`point;parallelogram`, `point;vertex`, `sector;arc` already landed)
+- [ ] II.7 — If a straight line is cut at random, then the sum of the square on the whole and that on one of the segments… NEEDS: `polygon;parallelogram`, `polygon;square`  (`point;parallelogram`, `point;vertex`, `sector;arc` already landed)
+- [ ] II.8 — If a straight line is cut at random, then four times the rectangle contained by the whole and one of the segments plus the square on the remaining segment… NEEDS: `line;parallel`, `polygon;parallelogram`, `polygon;quadrilateral`, `polygon;square`  (`point;parallelogram`, `point;vertex`, `sector;arc` already landed)
 - [ ] II.9 — If a straight line is cut into equal and unequal segments, then the sum of the squares on the unequal segments of the whole is double… NEEDS: `line;parallel`, `point;parallelogram`, `polygon;parallelogram`, `polygon;quadrilateral`
 - [ ] II.10 — If a straight line is bisected, and a straight line is added to it in a straight line… NEEDS: `point;parallelogram`, `polygon;parallelogram`, `polygon;square` (wait — II.10 uses triangle, not square… needs `point;parallelogram`, `point;vertex`)
 - [~] II.12 — In obtuse-angled triangles the square on the side opposite the obtuse angle is greater than the sum of the squares on the sides containing the obtuse angle…
@@ -99,7 +99,7 @@ Update the summary table after each session.
 ## Book III
 
 - [ ] III.1 — To find the center of a given circle. NEEDS: `line;chord`
-- [ ] III.2 — If two points are taken at random on the circumference of a circle, then the straight line joining the points falls within the circle. NEEDS: `sector;arc`
+- [~] III.2 — If two points are taken at random on the circumference of a circle, then the straight line joining the points falls within the circle. (sector;arc landed 2026-04-11; test page at view/test/sector/arc.html uses these exact params.)
 - [~] III.3 — If a straight line passing through the center of a circle bisects a straight line not passing through the center, then it also cuts it at right angles; and if it cuts it at right angles, then it also bisects it.
 - [~] III.4 — If in a circle two straight lines which do not pass through the center cut one another, then they do not bisect one another.
 - [ ] III.5 — If two circles cut one another, then they do not have the same center. NEEDS: `line;chord`
@@ -120,14 +120,14 @@ Update the summary table after each session.
 - [~] III.20 — In a circle the angle at the center is double the angle at the circumference when the angles have the same circumference as base.
 - [~] III.21 — In a circle the angles in the same segment equal one another.
 - [~] III.22 — The sum of the opposite angles of quadrilaterals in circles equals two right angles.
-- [ ] III.23 — On the same straight line there cannot be constructed two similar and unequal segments of circles on the same side. NEEDS: `sector;arc`
-- [ ] III.24 — Similar segments of circles on equal straight lines equal one another. NEEDS: `sector;arc`, `polygon;equilateralTriangle`, `point;similar`, `point;vertex`
-- [ ] III.25 — Given a segment of a circle, to describe the complete circle of which it is a segment. NEEDS: `sector;arc`
+- [~] III.23 — On the same straight line there cannot be constructed two similar and unequal segments of circles on the same side. (sector;arc landed 2026-04-11.)
+- [ ] III.24 — Similar segments of circles on equal straight lines equal one another. NEEDS: `point;similar`  (`polygon;equilateralTriangle`, `point;vertex`, `sector;arc` already landed)
+- [~] III.25 — Given a segment of a circle, to describe the complete circle of which it is a segment. (sector;arc landed 2026-04-11.)
 - [ ] III.26 — In equal circles equal angles stand on equal circumferences whether they stand at the centers or at the circumferences. NEEDS: `point;similar`
 - [ ] III.27 — In equal circles angles standing on equal circumferences equal one another whether they stand at the centers or at the circumferences. NEEDS: `point;similar`
 - [ ] III.28 — In equal circles equal straight lines cut off equal circumferences, the greater circumference equals the greater and the less equals the less. NEEDS: `point;similar`
 - [ ] III.29 — In equal circles straight lines that cut off equal circumferences are equal. NEEDS: `point;similar`
-- [ ] III.30 — To bisect a given circumference. NEEDS: `sector;arc`
+- [~] III.30 — To bisect a given circumference. (sector;arc landed 2026-04-11.)
 - [~] III.31 — In a circle the angle in the semicircle is right, that in a greater segment less than a right angle, and that in a less segment greater than a right angle…
 - [~] III.32 — If a straight line touches a circle, and from the point of contact there is drawn across, in the circle, a straight line cutting the circle, then the angles which it makes with the tangent equal the angles in the alternate segments of the circle.
 - [ ] III.33 — On a given straight line to describe a segment of a circle admitting an angle equal to a given rectilinear angle. NEEDS: `point;similar`

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Euclid's Elements",
   "main": "dist/index.js",
   "scripts": {
-    "test": "mocha ./tests"
+    "build": "tsc --noEmit",
+    "test": "mocha"
   },
   "repository": {
     "type": "git",

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -30,6 +30,7 @@ import {LineSlider} from "./point/LineSlider";
 import {Layoff} from "./point/Layoff";
 import {Foot} from "./point/Foot";
 import {SectorElement} from "./sector/SectorElement";
+import {ArcElement} from "./sector/ArcElement";
 import {CircleSlider} from "./point/CircleSlider";
 import {Perpendicular} from "./line/Perpendicular";
 import {PlanePerpendicularLine} from "./line/PlanePerpendicularLine";
@@ -1139,11 +1140,22 @@ export class Sector2Construction extends Construction {
     }
 }
 
-// TBD
 // sector
 // arc
-// points A, B, C [plane D]
-// the sector of a circle in plane D whose arc passes through the three points A, B and C
+// points A, M, B
+// the arc of the circle through points A, M, B in the screen plane
+// (M is the "through" point between the two endpoints A and B)
+// 2D variant; the 3D variant [Point, Point, Point, Plane] is TBD per 2D-first policy.
+export class ArcConstruction extends Construction {
+    constructionMethod: AllConstructions = SectorConstructions.arc;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
+
+    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let g = new ArcElement(ps[0], ps[1], ps[2], screen);
+        return [[g], g];
+    }
+}
 
 /***********************
  * Element Class Plane *
@@ -1288,6 +1300,7 @@ export const constructions : Construction[] = [
     new LineExtendConstruction(),
     new SectorConstruction(),
     new Sector2Construction(),
+    new ArcConstruction(),
     new CircleSliderConstruction(),
     new CircleSliderConstruction2dPoint(),
     new CircleRadiusCenterConstruction(),

--- a/src/elements/sector/ArcElement.ts
+++ b/src/elements/sector/ArcElement.ts
@@ -1,0 +1,52 @@
+/*----------------------------------------------------------------------+
+|    Title:	ArcElement.ts                                               |
+|    A port of the software Geometry Applet by                          |
+|    Author:    David E. Joyce                                          |
+|        Department of Mathematics and Computer Science                 |
+|        Clark University                                               |
+|        Worcester, MA 01610-1477                                       |
+|        U.S.A.                                                         |
+|                                                                       |
+|        http://aleph0.clarku.edu/~djoyce/home.html                     |
+|        djoyce@clarku.edu                                              |
+|                                                                       |
+|    Date:    February, 1996.   Version 2.0.0 May, 1997.                |
+|    TypeScript Port: 2026, Nelson Brown, brownnrl@gmail.com            |
+|                           https://www.nelsonbrown.net/                |
++----------------------------------------------------------------------*/
+
+import {SectorElement} from "./SectorElement";
+import {PointElement} from "../point/PointElement";
+import {PlaneElement} from "../plane/PlaneElement";
+
+/**
+ * Port of geom_applet/source/Arc.java — an arc through three points.
+ *
+ * Given points A, M, B (with M on the arc between A and B), draws the
+ * arc of the unique circle passing through all three. The circle's
+ * center is recomputed on every update() as circumcenter(A, M, B) and
+ * stored in the inherited _Center field; SectorElement.drawEdge then
+ * sweeps the arc from A to B using the inherited angle math.
+ *
+ * _Center is an internal bare PointElement, not registered on the
+ * slate. Arc.update() writes into it directly, so it stays in sync
+ * with A, M, B without needing a separate elementsForUpdate entry.
+ */
+export class ArcElement extends SectorElement {
+
+    _M : PointElement;  // the "through" point on the arc between A and B
+
+    constructor(A: PointElement, M: PointElement, B: PointElement, P: PlaneElement) {
+        super();
+        this.dimension = 2;
+        this._Center = new PointElement();
+        this._A = A;
+        this._M = M;
+        this._B = B;
+        this._P = P;
+    }
+
+    update(): void {
+        this._Center.toCircumcenter(this._A, this._M, this._B);
+    }
+}

--- a/src/elements/sector/ArcElement.ts
+++ b/src/elements/sector/ArcElement.ts
@@ -31,6 +31,12 @@ import {PlaneElement} from "../plane/PlaneElement";
  * _Center is an internal bare PointElement, not registered on the
  * slate. Arc.update() writes into it directly, so it stays in sync
  * with A, M, B without needing a separate elementsForUpdate entry.
+ *
+ * translate / rotate are overridden so that grabbing and moving the
+ * arc (either via a drag or via a global pivot rotation) perturbs
+ * only the inherited _Center; A, M, B are independent slate elements
+ * and are moved by their own handlers. This mirrors Java Arc.java
+ * exactly — see geom_applet/source/Arc.java lines 19-23.
  */
 export class ArcElement extends SectorElement {
 
@@ -47,6 +53,19 @@ export class ArcElement extends SectorElement {
     }
 
     update(): void {
+        // Java Arc.update() explicitly calls P.update() first. The TS
+        // slate already updates elements in dependency order, so this
+        // is arguably redundant — but we keep it for parity with Java
+        // in case some emergent behavior depends on it.
+        this._P.update();
         this._Center.toCircumcenter(this._A, this._M, this._B);
+    }
+
+    translate(dx: number, dy: number): void {
+        this._Center.translate(dx, dy);
+    }
+
+    rotate(pivot: PointElement, ac: number, as: number): void {
+        this._Center.rotate(pivot, ac, as);
     }
 }

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -10,6 +10,7 @@ import {PlaneElement} from "../src/elements/plane/PlaneElement";
 import {LineElement} from "../src/elements/line/LineElement";
 import {CircumcircleElement} from "../src/elements/circle/CircumcircleElement";
 import {SphereElement} from "../src/elements/sphere/SphereElement";
+import {ArcElement} from "../src/elements/sector/ArcElement";
 import {createCanvas} from "canvas";
 import {create} from "domain";
 
@@ -299,6 +300,81 @@ describe("slate", ()=> {
         almostEqual(bc, ab, 1);
         // Apex should be above the base (smaller y in screen coordinates)
         assert.ok(C.y < A.y);
+    });
+
+    // Book III, Prop 2 — arc through three points
+    // <param name=e[1] value="A;point;free;50,130">
+    // <param name=e[2] value="B;point;free;120,200">
+    // <param name=e[6] value="E;point;free;70,210">
+    // <param name=e[7] value="AEB;sector;arc;A,E,B">
+    //
+    // The arc's internal _Center should be the circumcenter of A, E, B.
+    // Hand-computed:
+    //   u=-14800, v=-2700, den=-4200
+    //   cx = -364000 / -4200 ≈ 86.667
+    //   cy = -686000 / -4200 ≈ 163.333
+    //   r  = |Center-A| = sqrt(1344.5 + 1111.1) ≈ 49.554
+    let arc_propIII2_data : IConstructionInfo[] = [
+        { name: "A",   construction: E.Point.free,  params: [50, 130] },
+        { name: "E",   construction: E.Point.free,  params: [70, 210] },
+        { name: "B",   construction: E.Point.free,  params: [120, 200] },
+        { name: "AEB", construction: E.Sector.arc, params: ["A", "E", "B"] },
+    ];
+
+    it("should compute the circumcenter of an arc through three points", () => {
+        let slate = new Slate(createCanvas(260, 260));
+        toElements(slate, arc_propIII2_data);
+        slate.elements.forEach(e => e.update());
+        let arc = slate.lookupElement("AEB") as ArcElement;
+        almostEqual(arc._Center.x, 86.667, 0.01);
+        almostEqual(arc._Center.y, 163.333, 0.01);
+        // All three given points should be equidistant from the center
+        let rA = arc._Center.distance(arc._A);
+        let rM = arc._Center.distance(arc._M);
+        let rB = arc._Center.distance(arc._B);
+        almostEqual(rA, 49.554, 0.01);
+        almostEqual(rM, 49.554, 0.01);
+        almostEqual(rB, 49.554, 0.01);
+    });
+
+    it("should translate only the arc center, leaving A, M, B untouched", () => {
+        let slate = new Slate(createCanvas(260, 260));
+        toElements(slate, arc_propIII2_data);
+        slate.elements.forEach(e => e.update());
+        let arc = slate.lookupElement("AEB") as ArcElement;
+        let cx0 = arc._Center.x;
+        let cy0 = arc._Center.y;
+        arc.translate(5, 7);
+        almostEqual(arc._Center.x, cx0 + 5, 0.001);
+        almostEqual(arc._Center.y, cy0 + 7, 0.001);
+        // A, M, B are independent slate elements; arc.translate() must not touch them
+        let A = slate.lookupElement("A") as PointElement;
+        let M = slate.lookupElement("E") as PointElement;
+        let B = slate.lookupElement("B") as PointElement;
+        almostEqual(A.x, 50,  0.001); almostEqual(A.y, 130, 0.001);
+        almostEqual(M.x, 70,  0.001); almostEqual(M.y, 210, 0.001);
+        almostEqual(B.x, 120, 0.001); almostEqual(B.y, 200, 0.001);
+    });
+
+    it("should rotate only the arc center around a pivot", () => {
+        let slate = new Slate(createCanvas(260, 260));
+        toElements(slate, arc_propIII2_data);
+        slate.elements.forEach(e => e.update());
+        let arc = slate.lookupElement("AEB") as ArcElement;
+        let A = slate.lookupElement("A") as PointElement;
+        // 90° CCW rotation around A=(50,130): ac=cos(90°)=0, as=sin(90°)=1
+        // dx=36.667, dy=33.333
+        // new x = 50 + 0*36.667 - 1*33.333 = 16.667
+        // new y = 130 + 1*36.667 + 0*33.333 = 166.667
+        arc.rotate(A, 0, 1);
+        almostEqual(arc._Center.x, 16.667, 0.01);
+        almostEqual(arc._Center.y, 166.667, 0.01);
+        // A, M, B untouched
+        let M = slate.lookupElement("E") as PointElement;
+        let B = slate.lookupElement("B") as PointElement;
+        almostEqual(A.x, 50,  0.001); almostEqual(A.y, 130, 0.001);
+        almostEqual(M.x, 70,  0.001); almostEqual(M.y, 210, 0.001);
+        almostEqual(B.x, 120, 0.001); almostEqual(B.y, 200, 0.001);
     });
 
     it("should be able to find the closest visible point within a tolerance", () =>{

--- a/view/applet-tests/sector/arc/applet.html
+++ b/view/applet-tests/sector/arc/applet.html
@@ -1,0 +1,34 @@
+<HTML><HEAD><TITLE>sector;arc — applet form of view/test/sector/arc.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/sector/arc.html -->
+<!-- ORIGINAL: view/applet-tests/sector/arc/original.html (propIII2) -->
+<!--
+  Up-to-construction applet form of the TS test page. Visually equivalent to
+  what view/test/sector/arc.html renders: the propIII2 figure with circumcircle
+  ABC, center D, and the arc AEB drawn from A through E to B (E is a draggable
+  free point; drag it around to see the arc's circumcenter track via
+  ArcElement.update() -> _Center.toCircumcenter(A,E,B)).
+
+  Differences from original.html:
+    - pivot=D removed (the global pivot rotation is a Joyce interaction feature,
+      not geometry — not needed for windows 2/3 visual parity)
+
+  Canvas is 400x400 to match the TS test page's canvas CSS size, rather than
+  the propIII2 original's 260x260; all element coordinates are still in the
+  original's address space so the diagram sits in the upper-left quadrant of
+  the larger canvas.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="III.2 — sector;arc">
+<param name=e[1] value="A;point;free;50,130">
+<param name=e[2] value="B;point;free;120,200">
+<param name=e[3] value="C;point;free;200,50;black;0">
+<param name=e[4] value="ABC;circle;circumcircle;A,B,C;0;0;black;random">
+<param name=e[5] value="D;point;center;ABC;black;green">
+<param name=e[6] value="E;point;free;70,210">
+<param name=e[7] value="AEB;sector;arc;A,E,B;0;0;black;0">
+<param name=e[8] value="DE;line;connect;D,E">
+<param name=e[9] value="F;point;cutoff;D,E,D,A">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/sector/arc/original.html
+++ b/view/applet-tests/sector/arc/original.html
@@ -1,0 +1,17 @@
+<HTML><HEAD><TITLE>III.2 — sector;arc (original)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=260 width=260>
+<param name=background value="35,19,100">
+<param name=title value="III.2">
+<param name=e[1] value="A;point;free;50,130">
+<param name=e[2] value="B;point;free;120,200">
+<param name=e[3] value="C;point;free;200,50;black;0">
+<param name=e[4] value="ABC;circle;circumcircle;A,B,C;0;0;black;random">
+<param name=e[5] value="D;point;center;ABC;black;green">
+<param name=pivot value="D">
+<param name=e[6] value="E;point;free;70,210">
+<param name=e[7] value="AEB;sector;arc;A,E,B;0;0;black;0">
+<param name=e[8] value="DE;line;connect;D,E">
+<param name=e[9] value="F;point;cutoff;D,E,D,A">
+</applet>
+</BODY></HTML>

--- a/view/test/sector/arc.html
+++ b/view/test/sector/arc.html
@@ -1,0 +1,47 @@
+<html>
+<head>
+    <title>Test View - Sector.arc (III.2)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<!-- Dependencies -->
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let Color = geomlib.Color;
+    let Align = geomlib.Align;
+    let E = geomlib.E;
+    // Book III, Proposition 2 — "If two points are taken at random on the
+    // circumference of a circle, then the straight line joining the points
+    // falls within the circle."
+    //
+    // The arc AEB (sector;arc) is the wrong path Euclid is arguing against:
+    // given circumcircle ABC with center D, if you draw an arc through A, E, B
+    // (where E is outside the chord AB on the far side from D), then the
+    // line DE crossing the arc hits it at F such that DF < DA, which is a
+    // contradiction.
+    //
+    // Coordinates match propIII2 exactly and the Mocha test fixture
+    // arc_propIII2_data in tests/SlateTest.ts.
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "III.2 — sector;arc",
+        align: Align.ABOVE,
+        canvasid: "canvasId",
+        elements: [
+            { name: "A",   construction: E.Point.free,       params: [50, 130] },
+            { name: "B",   construction: E.Point.free,       params: [120, 200] },
+            { name: "C",   construction: E.Point.free,       params: [200, 50] },
+            { name: "ABC", construction: E.Circle.circumcircle, params: ["A", "B", "C"],
+              edgeColor: "black", faceColor: "random" },
+            { name: "D",   construction: E.Point.center,     params: ["ABC"],
+              vertexColor: "green", nameColor: "black" },
+            { name: "E",   construction: E.Point.free,       params: [70, 210] },
+            { name: "AEB", construction: E.Sector.arc,       params: ["A", "E", "B"],
+              edgeColor: "black" },
+            { name: "DE",  construction: E.Line.connect,     params: ["D", "E"] },
+            { name: "F",   construction: E.Point.cutoff,     params: ["D", "E", "D", "A"] },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Ports `sector;arc`** as `src/elements/sector/ArcElement.ts`, a 2D port of
  `geom_applet/source/Arc.java`. Unlocks 4 new renderable Book III propositions
  (III.2, III.23, III.25, III.30).
- **Restructures `doc/process.md`** to institutionalize a per-step
  commit-and-human-review workflow; drops the old optional "preview in
  appletviewer" step 4 (duplicated by mandatory step 7); adds explicit
  feature-branch-off-master guidance; forbids `Co-Authored-By:` trailers.
- **Platform fix**: the test suite had a silent stale-`.js` shadowing bug
  where mocha picked up compiled-in-place JS instead of the fresh `.ts`
  source. Root-caused and fixed via `.mocharc.json` + `ts-node/register`
  and `tsc --noEmit` as the build script. Zero new dependencies (ts-node
  was already in devDeps).

## Scope

| Area | Files | What changed |
|---|---|---|
| **New construction** | `src/elements/sector/ArcElement.ts` | New 71-line element class extending `SectorElement`; ports every method Java `Arc.java` overrides (`update`, `translate`, `rotate`) including the `P.update()` call for parity |
| **Construction dispatch** | `src/elements/Constructions.ts` | +19/-3 lines: `ArcConstruction` class, import for `ArcElement`, registration in `constructions` array after `Sector2Construction()` |
| **Tests** | `tests/SlateTest.ts` | +76 lines: 3 new Mocha tests exercising `update()` (hand-computed circumcenter from propIII2 coords), `translate()` isolation, `rotate()` isolation. **17/17 passing.** |
| **Three-way view pair** | `view/test/sector/arc.html`, `view/applet-tests/sector/arc/{original,applet}.html` | TS test page, verbatim propIII2 applet extraction, and trimmed up-to-construction companion. Uses the same propIII2 coordinates as the Mocha fixture so unit-test and visual-test never drift. |
| **Process doc** | `doc/process.md` | +103 lines net but −52 from the removed step 4: new "commit per step + human review" preamble, per-step feature-branch rule in step 1, no-`Co-Authored-By:` rule, 9 steps renumbered to 8 |
| **Trackers + journal** | `doc/construction-tracker.md`, `doc/proposition-tracker.md`, `doc/journal.md` | `sector;arc` marked IMPL with full notes; 4 propositions marked `[~]` (Book III: 14 → 18 renderable); Book I.4 tracker entry corrected (additional 3-point `circle;radius` blocker surfaced); new platform-level TODO for the face-color divergence; full dated journal entry. |
| **Platform: test infra** | `.mocharc.json` (new), `package.json` | mocha now runs `.ts` directly via ts-node; `npm run build` = `tsc --noEmit` (pure type-check, stops the `.js` cruft leak that was shadowing tests). AGENTS.md's `npm run build` claim is finally true. |

**Total: 12 files changed, +466 / −71 lines.**

## Walk-through of the commits (in order)

Each commit is a standalone reviewable unit per the new per-step rule. The PR
deliberately does NOT squash so the review granularity is preserved.

1. **`64575f8` doc/process: require feature branch + per-step review cadence**
   Preamble rule: each step gets a standalone commit reviewed by a human
   before the next step begins. Step 1 adds the "cut a
   `feature/{type}-{construction}` branch off master first" rule. Forbids
   `Co-Authored-By:` trailers on commits to this repo.

2. **`b46bc76` sector-arc: step 3 — add propIII2 original.html**
   Verbatim extraction of the propIII2 `<applet>` block into
   `view/applet-tests/sector/arc/original.html`. codebase adjusted to
   `../../..` so Geometry.zip resolves. This is window 1 of the three-way
   harness — "as Joyce drew it", never trimmed. Propositions tracker had
   listed III.2's only blocker as `sector;arc`, making it the ideal
   verifying proposition: all eight preceding elements use already-IMPL
   constructions.

3. **`1a59af6` doc/process: drop step 4 (optional preview), renumber to 8 steps**
   The old step 4 ("View in appletviewer — optional but recommended")
   duplicated everything in the mandatory step 7 (three-way harness) and
   in practice was never run separately. Removed; steps 5–9 become 4–8.
   Cross-references updated.

4. **`cb6fe2d` sector-arc: step 4 — add ArcElement.ts**
   Initial minimal port of `Arc.java`: constructor stores A, M, B, P;
   `update()` recomputes the inherited `_Center` via
   `toCircumcenter(A, M, B)`. `dimension = 2` matches Java.

5. **`4a8ea5a` sector-arc: step 4 — restore P.update() and port translate/rotate**
   Review feedback on the minimal port: port **every** method Java
   overrides, don't leave functionality half-ported. Re-adds the
   `this._P.update()` call at the top of `update()`, and ports
   `translate(dx, dy)` + `rotate(pivot, ac, as)` as delegations to
   `_Center`. Guards against emergent behavior from dependency-order
   reorderings or future 3D variants. This feedback crystallized into a
   persistent "no half-done ports" rule in session memory.

6. **`57d94e8` sector-arc: step 5 — wire ArcConstruction into dispatch table**
   `ArcConstruction extends Construction`, `constructionMethod =
   SectorConstructions.arc` (enum already existed at 402), signature
   `[PointElement, PointElement, PointElement]` (2D variant). Registered
   in the `constructions` array after the existing sector entries. Commit
   message flags that the future 3D variant **must** be registered
   **before** this 2D entry due to `findConstruction`'s first-match-wins
   rule.

7. **`1a1e573` sector-arc: step 6 — Mocha tests for update, translate, rotate**
   Three tests sharing an `arc_propIII2_data` fixture that exactly
   mirrors the propIII2 param block. Hand-computed circumcenter
   (86.667, 163.333); rotation under a 90° CCW around A=(50,130) lands at
   (16.667, 166.667). All three pass on the first try — hand-math
   matches the implementation.

8. **`42c306b` platform: fix stale-JS test shadow via ts-node + tsc --noEmit**
   Root-cause analysis of a subtle bug that surfaced during step 6:
   `tsc` without `--noEmit` writes `.js` siblings next to every `.ts`
   file, and mocha's default file resolution picked up the stale `.js`
   instead of the fresh `.ts`. My three new tests silently failed to run
   until I diagnosed the shadowing. Fix: `.mocharc.json` with
   `ts-node/register` and `spec: ["tests/**/*.ts"]`; `"build": "tsc
   --noEmit"` makes `npm run build` a pure type-check; 56 pre-existing
   vestigial `.js`/`.js.map` files deleted from `src/` and `tests/`.
   Zero new dependencies (ts-node was already in devDeps). Verified:
   `npm run build` clean, `npm test` 17/17, `npx webpack` → bundle in
   1.3s — all without regenerating any `.js` cruft.

9. **`51141a4` sector-arc: step 7 — three-way view pair (TS page + applet.html)**
   `view/test/sector/arc.html` (window 3, TS port) and
   `view/applet-tests/sector/arc/applet.html` (window 2, trimmed applet
   form with the load-bearing `<!-- TS: ... -->` header the harness
   greps for). Element list is identical between TS and applet forms,
   and matches the Mocha fixture. Harness TS-header parsing dry-run
   confirmed the new construction auto-discovers on next
   `./run_euclid_applet.sh` invocation.

10. **`18f9bcc` sector-arc: step 8 — tracker + journal updates**
    Marks `sector;arc` as IMPL in `doc/construction-tracker.md`.
    Marks III.2, III.23, III.25, III.30 as `[~]` renderable (Book III
    count 14 → 18). Corrects I.4 entry to call out its additional
    3-point `circle;radius` blocker that surfaced during proposition
    selection. Adds new platform-level TODO for the face-color
    divergence. Full 2026-04-11 journal entry with discoveries and
    next-session rankings.

## Known limitations / follow-ups

- **Cosmetic face-fill divergence from Java applet**: the TS port renders a
  pale-cream pie-slice fill under the arc curve where Java shows an open
  curve. Root cause: `src/index.ts:73` applies a default
  `faceColor = lighten(bgcolor)` to every element with `dimension == 2`,
  and `IConstructionInfo` has no clean way to express "transparent face"
  because numeric-`0` → null handling is a known platform bug. This is
  **cosmetic only** — geometry matches between windows 2 and 3, dragging
  E tracks the arc's circumcenter smoothly. Tracked in
  `doc/construction-tracker.md` as a new platform-level TODO with
  `sector;arc` cited as the first observed instance.
- **3D variant of `sector;arc`**: deferred per the 2D-first policy. When
  added, the 3D signature `[Point, Point, Point, Plane]` **must** register
  **before** the existing 2D `ArcConstruction` in the `constructions`
  array or the 2D prefix will greedily consume 3D param lists.
- **I.4 remains blocked**: the existing tracker listed its only blocker as
  `sector;arc`, but propI4.html uses a 3-point `circle;radius` form
  ("circle at A with radius |DE|") that is TBD. Noted in the I.4 tracker
  entry.

## Test plan

- [x] `npm run build` — clean (tsc --noEmit, zero errors)
- [x] `npm test` — 17/17 passing via mocha + ts-node
- [x] `npx webpack` — bundle builds cleanly, ArcElement + ArcConstruction
      present in `dist/bundle.js`
- [x] Three-way harness visual comparison — human-verified: geometry
      matches between windows 2 (Java applet) and 3 (TS firefox); dragging
      free point E tracks the arc's circumcenter smoothly in both.
      Face-fill divergence noted as cosmetic follow-up.
- [X] Reviewer should pick any of the four newly-unblocked propositions
      (III.2, III.23, III.25, III.30) and spot-check that its diagram
      renders in the TS port once a `view/test/` page is wired up for it.
