### PR TITLE
Feature/line chord

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -202,9 +202,27 @@ These affect the library as a whole, independent of individual constructions.
   - Java source: `ParallelP.java`
   - Used in: I.22, I.27, I.37–I.40, II.8–II.9, II.11
 
-- [ ] **`chord`** — TBD
-  - Java source: `Chord.java`
-  - Used in: I.12, II.5, II.14, III.1, III.5–III.6, III.8–III.9, III.12, III.15, III.17, III.34, III.36–III.37
+- [x] **`chord`** — `src/elements/line/Chord.ts`
+  - Extends `LineElement`; constructor takes `(D, E, C)` where D/E are the two
+    `PointElement` endpoints of the input line (post-`LineElement` expansion)
+    and C is the `CircleElement`. Allocates internal `_A`/`_B` PointElements
+    sharing `C.AP` as the chord's own endpoints.
+  - Java source: `Chord.java` — 23 lines, line-for-line port. `update()`:
+    project center to line (foot of ⊥), compute half-chord length
+    `s = √(r² − d²)`, derive `A` from D via vector formula, then
+    `B := 2·foot − A` (reflection trick). NaN-sentinels both endpoints
+    when `d² > r²` (line misses circle).
+  - 2D variant only per the 2D-first policy; `Chord.java` has only one
+    signature so there is no 3D variant to defer.
+  - Mocha tests (4): `update()` against propI12 hand-computed expectations
+    (chord.A ≈ (82.540, 180), chord.B ≈ (237.460, 180), both on the circle),
+    `d² > r²` NaN-path, `translate()` isolation, `rotate()` isolation —
+    all in `tests/SlateTest.ts`.
+  - [x] test view: [view/test/line/chord.html](../view/test/line/chord.html) — full propI12
+  - [x] applet-tests pair:
+    [view/applet-tests/line/chord/{original,applet}.html](../view/applet-tests/line/chord/)
+  - Used in: I.12, II.5, II.14, III.1, III.5–III.6, III.8–III.9, III.10
+    (no longer blocked), III.12, III.15, III.17, III.34, III.36–III.37
 
 - [ ] **`angleBisector`** — TBD
   - Java source: `AngleDivider.java`

--- a/doc/constructions-reference.md
+++ b/doc/constructions-reference.md
@@ -69,7 +69,7 @@ must reflect these post-expansion types, not the raw HTML param count.
 | `perpendicular` | IMPL | `Perpendicular.java` | Various (5 signature variants) | Line perpendicular to another | ~16 | I.11 |
 | `bichord` | IMPL | `Bichord.java` | `Circle A, Circle B` | Line connecting two circle intersections | ~19 | I.1 |
 | `parallel` | **TBD** | `ParallelP.java` | `Point A, Point B, Point C` | Line through C parallel to line AB | ~14 | I.22 |
-| `chord` | **TBD** | `Chord.java` | `Circle A, Point B, Point C` | Chord of circle A between points B and C | ~17 | I.12 |
+| `chord` | IMPL | `Chord.java` | `Point B, Point C, Circle A` | Chord of circle A cut by line BC | ~17 | I.12 |
 | `angleBisector` | **TBD** | `AngleDivider.java` | `Point A, B, C [, Plane]` | Bisector of angle ∠ABC | 0 | — |
 | `angleDivider` | **TBD** | `AngleDivider.java` | `Point A, B, C [, Plane], int n` | 1/n division of ∠ABC as a line | 0 | — |
 | `foot` | **TBD** | `PlaneFoot.java` | `Point A, Plane B` | Perpendicular from A to plane B | solid only | — |
@@ -158,7 +158,7 @@ Implementing higher-priority constructions unlocks the most propositions.
 | 2 | `point;parallelogram` | 48 | I.28, I.30, I.32–I.36, I.37–I.41, II.1–II.11 |
 | 3 | `polygon;parallelogram` | 18 | I.34, I.35, II.1–II.11 |
 | 4 | `sector;arc` | 20 | I.4, I.16, I.29, II.5–II.8, III.2, III.23–III.25, III.30 |
-| 5 | `line;chord` | 17 | I.12, III.1, III.5, III.6, III.8–III.9, III.12, III.15, III.17 |
+| ~~5~~ | ~~`line;chord`~~ — IMPL 2026-04-11 | 17 | I.12, III.1, III.5, III.6, III.8–III.9, III.10, III.12, III.15, III.17, III.36, III.37 |
 | 6 | `polygon;quadrilateral` | 11 | I.43–I.45, II.2, II.4–II.6, II.8–II.9, II.14 |
 | 7 | `polygon;square` | 10 | I.46, I.47, II.2–II.4, II.5–II.8, II.11 |
 | 8 | `point;similar` | 15 | I.23, I.24, I.26, I.31, I.42, I.44, I.45, III.14, III.24–III.29, III.33–III.34 |

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,117 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-11 — Implemented line;chord + tsconfig noEmit hardening
+
+**Completed:**
+- Ported `line;chord` as `src/elements/line/Chord.ts` — a 2D port of
+  `geom_applet/source/Chord.java` (23-line file). Extends `LineElement`;
+  constructor takes `(D, E, C)` where D/E are the two `PointElement`
+  endpoints of the input line (post-`LineElement` expansion) and C is the
+  `CircleElement`. Allocates internal `_A`/`_B` PointElements sharing
+  `C.AP` as the chord's own endpoints. Ported every method Java overrides
+  (`update`, `translate`, `rotate`) per the no-half-done-ports rule. The
+  Java→TS adjustment for `C.radius2()` → `this.C.radius2` (TS getter).
+- `update()` ports the seven-line Java algorithm verbatim: project center
+  to line via `_B.toLine(D, E, false)`, half-chord length `s = √(r² − d²)`,
+  derive `_A` from D via `_A.to(D).minus(_B).times(factor).plus(_B)`, then
+  `_B := 2·foot − _A` (the reflection trick that gives the second
+  intersection). NaN-sentinels both endpoints when `d² > r²` (line misses
+  circle). Fallback to E when D coincides with the foot (factor explodes
+  past 1e10).
+- Wired `ChordConstruction` into `src/elements/Constructions.ts` with the
+  post-expansion signature `[PointElement, PointElement, CircleElement]`,
+  dispatching to the existing `LineConstructions.chord = 105` enum value.
+  Registered next to `BichordConstruction` in the `constructions` array.
+- Four Mocha tests in `tests/SlateTest.ts`: `update()` against propI12
+  hand-computed expectations (chord.A ≈ (82.540, 180), chord.B ≈
+  (237.460, 180), both endpoints on the circle within 0.001), `d² > r²`
+  NaN-path (shifted C far above the line), `translate()` isolation
+  (chord endpoints shift, inputs untouched), `rotate()` isolation
+  (90° CCW around input A). 17/17 → **21/21 passing**.
+- Three-way harness pair:
+  `view/applet-tests/line/chord/{original,applet}.html` +
+  `view/test/line/chord.html`, all using full propI12 (15 elements:
+  free A/B/C/D, line AB, circle EFG, chord EG, midpoint H, perpendicular
+  CH, chord FF' along CH, F apex). The test page exercises `line;chord`
+  twice — once with line AB cutting circle EFG, once with line CH cutting
+  the same circle — providing a built-in cross-check.
+- **Platform fix** — added `"noEmit": true` to `tsconfig.json`'s
+  `compilerOptions` as a hardening measure. The 2026-04-11 sector-arc
+  fix had relied on `npm run build` passing `--noEmit` and on
+  `.mocharc.json` forcing ts-node, but neither stops VS Code's TypeScript
+  language server from running its own background `tsc` and emitting
+  sourceMap-enabled `.js` siblings into `src/` and `tests/`. Those
+  shadow the `.ts` files via Node's require resolution and silently
+  break mocha runs. Discovered the recurrence while running step 6 of
+  this port: 56 stale `.js` files dated 19:34 (before this session
+  began) blocked all four new chord tests with "Construction not found"
+  — ts-node never saw the updated `Constructions.ts` because Node's
+  require found `Constructions.js` first. Deleting the 56 files unblocked
+  the run; setting `noEmit: true` at the tsconfig level prevents any
+  `tsc` invocation (CLI, VS Code TS server, anything that reads
+  `tsconfig.json`) from re-emitting them. Webpack's ts-loader is
+  unaffected (it emits to `dist/bundle.js` via its own pipeline), and
+  ts-node compiles in-memory and is unaffected. This is a strictly
+  stronger fix than the 2026-04-11 mitigation, which it supersedes.
+- Book I renderable count: 16 → **17** (+I.12). Book III renderable
+  count: 18 → **29** (+III.1, III.5, III.6, III.8, III.9, III.10,
+  III.12, III.15, III.17, III.36, III.37). I–III total: 36 → **48**.
+
+**Discovered:**
+- **Proposition-tracker NEEDS-line bug for `point;similar`**: during the
+  startup-protocol top-5 menu computation, I cross-checked the tracker's
+  "I.23/I.24/I.26/I.31 NEEDS `point;similar`" lines against the actual
+  HTML param lists. propI23.html uses `polygon;similar` (e[12]) and
+  propI31.html uses `line;similar` (e[7]) — neither is the `point;similar`
+  variant. Same class of error as the I.4 correction in the prior
+  2026-04-11 entry: the tracker's NEEDS lines drifted from what the
+  actual proposition HTMLs reference. Out of scope for this branch
+  (see federated-splashing-adleman.md plan), but worth fixing in the
+  next session that touches the proposition tracker, especially since
+  it materially affects whether `point;similar` is the right "next port"
+  pick (no clean Book I–III verifier exists for it as written).
+- **Stale `.js` shadow recurs without tsconfig-level prevention**:
+  the previous session's `npm run build` → `tsc --noEmit` change and
+  `.mocharc.json` ts-node registration are necessary but not sufficient.
+  Anything that reads `tsconfig.json` and runs `tsc` (notably the VS
+  Code TS language server) will keep emitting `.js` siblings unless
+  the *config itself* says noEmit. Now that the config is hardened, the
+  manual cleanup step from the 2026-04-11 sector-arc session shouldn't
+  be needed again.
+- Chord.java's `factor < 1e10` fallback branch handles the degenerate
+  case where the input line endpoint D coincides with the perpendicular
+  foot of the circle's center — `D.distance(B) ≈ 0` makes `factor`
+  blow up, so the code reaches for E instead. Worth knowing but
+  unlikely to bite in practice; left as a verbatim port.
+- The `B := 2·foot − A` reflection trick at the end of `update()` is
+  the cleanest way to get the second chord endpoint without recomputing
+  the foot or running the vector formula twice. Bichord doesn't need
+  this trick because it computes both intersections symmetrically by
+  rotating around the circle center; chord computes one endpoint and
+  reflects.
+
+**Next session:**
+- Top priority: `polygon;parallelogram` (18 I–III uses, sole-TBD verifier
+  in I.34, reuses the D=A+C−B formula from `point;parallelogram` already
+  landed via Layoff). Expected to be a wrap-the-formula-in-a-4-vertex-
+  polygon job, not a fresh algorithmic port.
+- Alternative: `polygon;square` (10 uses, I.47 viable since e[1]–e[6]
+  are all IMPL even though full-prop rendering still needs `line;foot`
+  later). Pattern matches `equilateralTriangle`'s `RegularPolygonElement`
+  with n=4.
+- Alternative: `line;parallel` (9 uses, I.22 clean verifier with all
+  preceding elements IMPL). New `ParallelP.java` port to a new
+  `src/elements/line/ParallelLine.ts`.
+- Deferred / not recommended yet: `point;similar` (15 uses but no clean
+  Book I–III verifier — the prop-tracker NEEDS lines are incorrect, see
+  Discovered above). Either fix the prop-tracker first, or build a
+  standalone test page rather than relying on a verifying proposition.
+- Also worth correcting in a future tracker-touching session: the
+  I.31 NEEDS line should say `line;similar`, not `point;similar`.
+
+---
+
 ## 2026-04-11 — Implemented sector;arc + per-step review workflow + test infra fix
 
 **Completed:**

--- a/doc/process.md
+++ b/doc/process.md
@@ -347,11 +347,106 @@ image alongside the proposition HTML in `view/euclid-html/`.
 
 ---
 
-## Step 8 — Update the tracker and journal
+## Step 8 — Update the tracker and journal, then draft the PR body
 
 1. Mark the construction as **IMPL** in [constructions-reference.md](constructions-reference.md)
 2. Check off any newly-renderable propositions in [proposition-tracker.md](proposition-tracker.md)
-3. Append a dated entry to [journal.md](journal.md)
+3. Mark the construction as **IMPL** in [construction-tracker.md](construction-tracker.md) and link the
+   test view + applet-tests pair, the same way the existing IMPL entries do
+4. Append a dated entry to [journal.md](journal.md) following the
+   `Completed / Discovered / Next session` template at the top of that file
+5. Commit the four doc updates as `{type}-{construction}: step 8 — tracker + journal updates`
+6. **Draft the pull request body** (see below). The agent generates the
+   markdown; the human pushes the branch and opens the PR on GitHub.
+   Do NOT use `git push` or `gh pr create` from the agent — pushing a branch
+   and opening a PR are shared-state actions that the human owns.
+
+### Pull request body template
+
+After the step 8 commit lands, the agent should output a single fenced
+markdown block — ready for the human to copy directly into GitHub's PR
+description field. The block should be a self-contained summary of what
+the branch ships, structured as follows:
+
+````markdown
+## Summary
+
+One sentence naming the construction ported, the verifying proposition,
+and the headline impact (e.g. "Adds `line;chord` (port of `Chord.java`),
+verified end-to-end against propI12; unlocks 12 new renderable
+propositions across Books I and III.").
+
+## What's in this branch
+
+A bulleted list of the per-step commits, each in the form
+`<short-sha> <commit subject>` so a reviewer can scan the history at a
+glance. Include any out-of-band commits (e.g. a platform hardening
+commit landed mid-port) and call out *why* they're in this branch
+rather than a separate one.
+
+## Construction details
+
+- **Element class**: `src/elements/{type}/{Name}Element.ts` (or the file
+  the port lives in if it's not a standalone class) — one sentence on
+  what it extends and what its `update()` does.
+- **Construction class**: `{Name}Construction` in
+  `src/elements/Constructions.ts` — note the post-`LineElement`-expansion
+  signature and any 2D/3D variant ordering hazard.
+- **Java source**: `geom_applet/source/{Name}.java` (line count, fidelity
+  of port — line-for-line vs. structural rewrite vs. anything else).
+
+## Tests
+
+- Mocha test count delta (e.g. "17 → 21 passing") and a one-line
+  description of each new test.
+- Note any test cases that exercise NaN sentinels, degenerate cases,
+  or `translate`/`rotate` isolation.
+
+## Verification
+
+Tick boxes the human can check off when reviewing:
+
+- [ ] `npm run build` clean
+- [ ] `npm test` passes (N/N)
+- [ ] `npx webpack` rebuilds `dist/bundle.js`
+- [ ] Three-way harness (`./run_euclid_applet.sh` → pick `{type};{construction}`)
+      shows windows 2 and 3 visually identical at rest
+- [ ] Drag interactions on key free points behave as expected
+      (call out the specific drags that exercise the construction)
+
+## Newly renderable propositions
+
+A flat list (or short table) of every proposition flipped from `[ ]` to
+`[~]` in `doc/proposition-tracker.md` by this PR, plus the updated
+Book-by-Book summary counts so a reviewer can sanity-check the deltas.
+
+## Discovered / out of scope
+
+Anything found while doing the port that *isn't* fixed in this branch:
+proposition-tracker NEEDS-line drift, platform bugs, follow-up
+opportunities, etc. Each item should say what was found and why it's
+deferred. Mirrors the journal entry's `Discovered` section but trimmed
+to the parts a reviewer needs to know about.
+````
+
+Style notes for the agent:
+
+- Keep the body under ~200 lines. Long PRs are fine; a long *PR body* just
+  duplicates the journal entry. The journal is the canonical record;
+  the PR body is the reviewer's index into it.
+- Always wrap the whole block in a fenced ` ```markdown ` tag so the human
+  can lift it cleanly. Don't include any prose outside the fence.
+- Reference commits by short SHA (`git log --oneline master..HEAD`),
+  files by repo-relative path. Skip the `Co-Authored-By:` trailer — same
+  rule as commits on this repo.
+- If the harness check was not performed (e.g. Docker/X11 unavailable
+  in the agent's environment), mark its checkbox as `[ ]` and add a
+  one-line note explaining what fallback was used (e.g. compared
+  against the `.gif` snapshot in `view/euclid-html/{book}/`).
+
+After the agent prints the PR body block, it should stop. The human runs
+`git push -u origin feature/{type}-{construction}` and creates the PR
+themselves on GitHub, pasting the body block into the description.
 
 ---
 

--- a/doc/proposition-tracker.md
+++ b/doc/proposition-tracker.md
@@ -14,10 +14,10 @@ Tracks the port status of all propositions across Euclid's Elements.
 
 | Scope | Total | Renderable (`[~]`) | Complete (`[x]`) |
 |-------|-------|--------------------|------------------|
-| Book I | 48 | 16 | 0 |
+| Book I | 48 | 17 | 0 |
 | Book II | 14 | 2 | 0 |
-| Book III | 37 | 18 | 0 |
-| **I–III total** | **99** | **36** | **0** |
+| Book III | 37 | 29 | 0 |
+| **I–III total** | **99** | **48** | **0** |
 | Books IV–XIII | ~365 | — | — |
 
 Update the summary table after each session.
@@ -37,7 +37,7 @@ Update the summary table after each session.
 - [ ] I.9 — To bisect a given rectilinear angle. NEEDS: `polygon;equilateralTriangle`, `point;vertex`
 - [ ] I.10 — To bisect a given finite straight line. NEEDS: `polygon;equilateralTriangle`, `point;vertex`
 - [ ] I.11 — To draw a straight line at right angles to a given straight line from a given point on it. NEEDS: `polygon;equilateralTriangle`, `point;vertex`
-- [ ] I.12 — To draw a straight line perpendicular to a given infinite straight line from a given point not on it. NEEDS: `line;chord`
+- [~] I.12 — To draw a straight line perpendicular to a given infinite straight line from a given point not on it. (`line;chord` landed 2026-04-11; test page at view/test/line/chord.html uses these exact params.)
 - [~] I.13 — If a straight line stands on a straight line, then it makes either two right angles or angles whose sum equals two right angles.
 - [~] I.14 — If with any straight line, and at a point on it, two straight lines not lying on the same side make the sum of the adjacent angles equal to two right angles, then the two straight lines are in a straight line with one another.
 - [~] I.15 — If two straight lines cut one another, then they make the vertical angles equal to one another.
@@ -83,7 +83,7 @@ Update the summary table after each session.
 - [ ] II.2 — If a straight line is cut at random, then the sum of the rectangles contained by the whole and each of the segments equals the square on the whole. NEEDS: `point;parallelogram`, `polygon;parallelogram`, `polygon;quadrilateral`, `polygon;square`, `point;vertex`
 - [ ] II.3 — If a straight line is cut at random, then the rectangle contained by the whole and one of the segments equals the sum of the rectangle contained by the segments and the square on the aforesaid segment. NEEDS: `point;parallelogram`, `polygon;parallelogram`, `polygon;square`, `point;vertex`
 - [ ] II.4 — If a straight line is cut at random, then the square on the whole equals the sum of the squares on the segments plus twice the rectangle contained by the segments. NEEDS: `point;parallelogram`, `polygon;parallelogram`, `polygon;quadrilateral`, `polygon;square`, `point;vertex`
-- [ ] II.5 — If a straight line is cut into equal and unequal segments, then the rectangle contained by the unequal segments of the whole together with the square on the straight line between the points of section equals the square on the half. NEEDS: `line;chord`, `polygon;parallelogram`, `polygon;quadrilateral`, `polygon;square`  (`point;parallelogram`, `point;vertex`, `sector;arc` already landed)
+- [ ] II.5 — If a straight line is cut into equal and unequal segments, then the rectangle contained by the unequal segments of the whole together with the square on the straight line between the points of section equals the square on the half. NEEDS: `polygon;parallelogram`, `polygon;quadrilateral`, `polygon;square`  (`point;parallelogram`, `point;vertex`, `sector;arc`, `line;chord` already landed)
 - [ ] II.6 — If a straight line is bisected and a straight line is added to it in a straight line… NEEDS: `polygon;parallelogram`, `polygon;quadrilateral`, `polygon;square`  (`point;parallelogram`, `point;vertex`, `sector;arc` already landed)
 - [ ] II.7 — If a straight line is cut at random, then the sum of the square on the whole and that on one of the segments… NEEDS: `polygon;parallelogram`, `polygon;square`  (`point;parallelogram`, `point;vertex`, `sector;arc` already landed)
 - [ ] II.8 — If a straight line is cut at random, then four times the rectangle contained by the whole and one of the segments plus the square on the remaining segment… NEEDS: `line;parallel`, `polygon;parallelogram`, `polygon;quadrilateral`, `polygon;square`  (`point;parallelogram`, `point;vertex`, `sector;arc` already landed)
@@ -92,29 +92,29 @@ Update the summary table after each session.
 - [~] II.12 — In obtuse-angled triangles the square on the side opposite the obtuse angle is greater than the sum of the squares on the sides containing the obtuse angle…
 - [~] II.13 — In acute-angled triangles the square on the side opposite the acute angle is less than the sum of the squares on the sides containing the acute angle…
 - [ ] II.11 — To cut a given straight line so that the rectangle contained by the whole and one of the segments equals the square on the remaining segment. NEEDS: `line;parallel`, `point;parallelogram`, `polygon;parallelogram`, `polygon;square`, `point;vertex`
-- [ ] II.14 — To construct a square equal to a given rectilinear figure. NEEDS: `polygon;application`, `line;chord`, `polygon;quadrilateral`, `polygon;square` (wait — let me verify), `point;vertex`
+- [ ] II.14 — To construct a square equal to a given rectilinear figure. NEEDS: `polygon;application`, `polygon;quadrilateral`, `polygon;square` (wait — let me verify) (`point;vertex`, `line;chord` already landed)
 
 ---
 
 ## Book III
 
-- [ ] III.1 — To find the center of a given circle. NEEDS: `line;chord`
+- [~] III.1 — To find the center of a given circle. (`line;chord` landed 2026-04-11.)
 - [~] III.2 — If two points are taken at random on the circumference of a circle, then the straight line joining the points falls within the circle. (sector;arc landed 2026-04-11; test page at view/test/sector/arc.html uses these exact params.)
 - [~] III.3 — If a straight line passing through the center of a circle bisects a straight line not passing through the center, then it also cuts it at right angles; and if it cuts it at right angles, then it also bisects it.
 - [~] III.4 — If in a circle two straight lines which do not pass through the center cut one another, then they do not bisect one another.
-- [ ] III.5 — If two circles cut one another, then they do not have the same center. NEEDS: `line;chord`
-- [ ] III.6 — If two circles touch one another, then they do not have the same center. NEEDS: `line;chord`
+- [~] III.5 — If two circles cut one another, then they do not have the same center. (`line;chord` landed 2026-04-11.)
+- [~] III.6 — If two circles touch one another, then they do not have the same center. (`line;chord` landed 2026-04-11.)
 - [~] III.7 — If on the diameter of a circle a point is taken which is not the center of the circle, and from the point straight lines fall upon the circle, then that is greatest on which passes through the center…
-- [ ] III.8 — If a point is taken outside a circle and from the point straight lines are drawn through to the circle… NEEDS: `line;chord`
-- [ ] III.9 — If a point is taken within a circle, and more than two equal straight lines fall from the point on the circle, then the point taken is the center of the circle. NEEDS: `line;chord`
-- [ ] III.10 — A circle does not cut a circle at more than two points. NEEDS: `line;chord`, `polygon;equilateralTriangle`, `point;vertex`
+- [~] III.8 — If a point is taken outside a circle and from the point straight lines are drawn through to the circle… (`line;chord` landed 2026-04-11.)
+- [~] III.9 — If a point is taken within a circle, and more than two equal straight lines fall from the point on the circle, then the point taken is the center of the circle. (`line;chord` landed 2026-04-11.)
+- [~] III.10 — A circle does not cut a circle at more than two points. (`polygon;equilateralTriangle`, `point;vertex` already landed; `line;chord` landed 2026-04-11.)
 - [~] III.11 — If two circles touch one another internally, and their centers are taken, then the straight line joining their centers, being produced, falls on the point of contact of the circles.
-- [ ] III.12 — If two circles touch one another externally, then the straight line joining their centers passes through the point of contact. NEEDS: `line;chord`
+- [~] III.12 — If two circles touch one another externally, then the straight line joining their centers passes through the point of contact. (`line;chord` landed 2026-04-11.)
 - [~] III.13 — A circle does not touch another circle at more than one point whether it touches it internally or externally.
 - [ ] III.14 — Equal straight lines in a circle are equally distant from the center, and those which are equally distant from the center equal one another. NEEDS: `point;similar`, `point;vertex`
-- [ ] III.15 — Of straight lines in a circle the diameter is greatest, and of the rest the nearer to the center is always greater than the more remote. NEEDS: `line;chord`
+- [~] III.15 — Of straight lines in a circle the diameter is greatest, and of the rest the nearer to the center is always greater than the more remote. (`line;chord` landed 2026-04-11.)
 - [~] III.16 — The straight line drawn at right angles to the diameter of a circle from its end will fall outside the circle…
-- [ ] III.17 — From a given point to draw a straight line touching a given circle. NEEDS: `line;chord`
+- [~] III.17 — From a given point to draw a straight line touching a given circle. (`line;chord` landed 2026-04-11.)
 - [~] III.18 — If a straight line touches a circle, and a straight line is joined from the center to the point of contact, the straight line so joined will be perpendicular to the tangent.
 - [~] III.19 — If a straight line touches a circle, and from the point of contact a straight line is drawn at right angles to the tangent, the center of the circle will be on the straight line so drawn.
 - [~] III.20 — In a circle the angle at the center is double the angle at the circumference when the angles have the same circumference as base.
@@ -131,10 +131,10 @@ Update the summary table after each session.
 - [~] III.31 — In a circle the angle in the semicircle is right, that in a greater segment less than a right angle, and that in a less segment greater than a right angle…
 - [~] III.32 — If a straight line touches a circle, and from the point of contact there is drawn across, in the circle, a straight line cutting the circle, then the angles which it makes with the tangent equal the angles in the alternate segments of the circle.
 - [ ] III.33 — On a given straight line to describe a segment of a circle admitting an angle equal to a given rectilinear angle. NEEDS: `point;similar`
-- [ ] III.34 — From a given circle to cut off a segment admitting an angle equal to a given rectilinear angle. NEEDS: `line;chord`, `point;similar`
+- [ ] III.34 — From a given circle to cut off a segment admitting an angle equal to a given rectilinear angle. NEEDS: `point;similar` (`line;chord` landed 2026-04-11)
 - [~] III.35 — If in a circle two straight lines cut one another, then the rectangle contained by the segments of the one equals the rectangle contained by the segments of the other.
-- [ ] III.36 — If a point is taken outside a circle and two straight lines fall from it on the circle, and if one of them cuts the circle and the other touches it… NEEDS: `line;chord`
-- [ ] III.37 — If a point is taken outside a circle and from the point there fall on the circle two straight lines… NEEDS: `line;chord`
+- [~] III.36 — If a point is taken outside a circle and two straight lines fall from it on the circle, and if one of them cuts the circle and the other touches it… (`line;chord` landed 2026-04-11.)
+- [~] III.37 — If a point is taken outside a circle and from the point there fall on the circle two straight lines… (`line;chord` landed 2026-04-11.)
 
 ---
 

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -35,6 +35,7 @@ import {CircleSlider} from "./point/CircleSlider";
 import {Perpendicular} from "./line/Perpendicular";
 import {PlanePerpendicularLine} from "./line/PlanePerpendicularLine";
 import {Bichord} from "./line/Bichord";
+import {Chord} from "./line/Chord";
 import {PolygonElement} from "./polygon/PolygonElement";
 import {RegularPolygonElement} from "./polygon/RegularPolygonElement";
 import {SphereElement} from "./sphere/SphereElement";
@@ -814,11 +815,23 @@ export class LineConnectConstruction extends Construction {
 // point A plane B
 // the line AD drawn perpendicular to plane B with the point D lying on B
 
-// TBD
 // line
 // chord
 // points A, B circle C
-// the intersection of the line AB in the circle C
+// the chord of circle C cut by the line AB
+// (post-LineElement-expansion: A, B are the two endpoints of the input line)
+export class ChordConstruction extends Construction {
+    constructionMethod: AllConstructions = LineConstructions.chord;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.CircleElement];
+
+    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const D = params[0] as PointElement;
+        const E = params[1] as PointElement;
+        const C = params[2] as CircleElement;
+        const g = new Chord({D, E, C});
+        return [[g], g];
+    }
+}
 
 // line
 // bichord
@@ -1315,6 +1328,7 @@ export const constructions : Construction[] = [
     new LinePerpendicular4Construction(),
     new LinePerpendicular5Construction(),
     new BichordConstruction(),
+    new ChordConstruction(),
     new TrianglePolygonConstruction(),
     new EquilateralTriangleConstruction(),
     new VertexConstruction(),

--- a/src/elements/line/Chord.ts
+++ b/src/elements/line/Chord.ts
@@ -1,0 +1,86 @@
+/*----------------------------------------------------------------------+
+|    Title:	Chord.ts                                                    |
+|    A port of the software Geometry Applet by                          |
+|    Author:    David E. Joyce                                          |
+|        Department of Mathematics and Computer Science                 |
+|        Clark University                                               |
+|        Worcester, MA 01610-1477                                       |
+|        U.S.A.                                                         |
+|                                                                       |
+|        http://aleph0.clarku.edu/~djoyce/home.html                     |
+|        djoyce@clarku.edu                                              |
+|                                                                       |
+|    Date:    February, 1996.   Version 2.0.0 May, 1997.                |
+|    TypeScript Port: 2026, Nelson Brown, brownnrl@gmail.com            |
+|                           https://www.nelsonbrown.net/                |
++----------------------------------------------------------------------*/
+
+import {LineElement} from "./LineElement";
+import {CircleElement} from "../circle/CircleElement";
+import {PointElement} from "../point/PointElement";
+
+interface IChordElementConstructor {
+  D : PointElement;
+  E : PointElement;
+  C : CircleElement;
+}
+
+export class Chord extends LineElement {
+  /*--------------------------------------------------------------------+
+  | This line AB is the segment of the line DE (extended) that          |
+  | intersects the circle C.  It is assumed that DE and C lie in the    |
+  | same plane, namely that of C.                                       |
+  +--------------------------------------------------------------------*/
+
+  public C: CircleElement;
+  public D: PointElement;
+  public E: PointElement;
+
+  constructor(ice? : IChordElementConstructor) {
+    super();
+    this.dimension = 1;
+    if (ice == null) return;
+
+    this.C = ice.C;
+    this.D = ice.D;
+    this.E = ice.E;
+    this._A = new PointElement({AP: this.C.AP});
+    this._B = new PointElement({AP: this.C.AP});
+  }
+
+  public translate(dx: number, dy: number) {
+    this._A.translate(dx, dy);
+    this._B.translate(dx, dy);
+  }
+
+  public rotate(pivot : PointElement, ac : number, as : number) {
+    this._A.rotate(pivot, ac, as);
+    this._B.rotate(pivot, ac, as);
+  }
+
+  public update() {
+    this._B.to(this.C.Center).toLine(this.D, this.E, false);
+    let d2 : number = this.C.Center.distance2(this._B);
+    let r2 : number = this.C.radius2;
+    if (d2 > r2) {
+      let v = 0.0/0.0;
+      this._A.x = v;
+      this._A.y = v;
+      this._A.z = v;
+      this._B.x = v;
+      this._B.y = v;
+      this._B.z = v;
+      return;
+    }
+    let s : number = Math.sqrt(r2 - d2);
+    let factor : number = s / this.D.distance(this._B);
+    if (factor < 1e10) {
+      this._A.to(this.D).minus(this._B).times(factor).plus(this._B);
+    } else {
+      factor = s / this.E.distance(this._B);
+      this._A.to(this.E).minus(this._B).times(factor).plus(this._B);
+    }
+    this._B.times(2.0).minus(this._A);
+  }
+
+}

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -11,6 +11,7 @@ import {LineElement} from "../src/elements/line/LineElement";
 import {CircumcircleElement} from "../src/elements/circle/CircumcircleElement";
 import {SphereElement} from "../src/elements/sphere/SphereElement";
 import {ArcElement} from "../src/elements/sector/ArcElement";
+import {Chord} from "../src/elements/line/Chord";
 import {createCanvas} from "canvas";
 import {create} from "domain";
 
@@ -375,6 +376,119 @@ describe("slate", ()=> {
         almostEqual(A.x, 50,  0.001); almostEqual(A.y, 130, 0.001);
         almostEqual(M.x, 70,  0.001); almostEqual(M.y, 210, 0.001);
         almostEqual(B.x, 120, 0.001); almostEqual(B.y, 200, 0.001);
+    });
+
+    // Book I, Prop 12 — chord of circle cut by a line
+    // <param name=e[1]  value="A;point;free;30,180">
+    // <param name=e[2]  value="B;point;free;290,180">
+    // <param name=e[3]  value="AB;line;connect;A,B">
+    // <param name=e[4]  value="C;point;free;160,130">
+    // <param name=e[5]  value="D;point;free;180,220">
+    // <param name=e[6]  value="EFG;circle;radius;C,D">
+    // <param name=e[7]  value="EG;line;chord;AB,EFG">
+    //
+    // Hand-computed expectations (see doc/journal.md entry for line;chord):
+    //   radius² = 20² + 90² = 8500
+    //   foot of ⊥ from C=(160,130) to line y=180 is (160,180)
+    //   d² = 50² = 2500
+    //   s  = √(8500-2500) = √6000 ≈ 77.460
+    //   factor = s / D.distance(foot) = 77.460 / 130 ≈ 0.59585
+    //   chord.A = (D-foot)*factor + foot = (82.540, 180)
+    //   chord.B = 2*foot - chord.A         = (237.460, 180)
+    let chord_propI12_data : IConstructionInfo[] = [
+        { name: "A",   construction: E.Point.free,     params: [30, 180] },
+        { name: "B",   construction: E.Point.free,     params: [290, 180] },
+        { name: "AB",  construction: E.Line.connect,   params: ["A", "B"] },
+        { name: "C",   construction: E.Point.free,     params: [160, 130] },
+        { name: "D",   construction: E.Point.free,     params: [180, 220] },
+        { name: "EFG", construction: E.Circle.radius,  params: ["C", "D"] },
+        { name: "EG",  construction: E.Line.chord,     params: ["AB", "EFG"] },
+    ];
+
+    it("should compute the chord of a circle cut by a line", () => {
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, chord_propI12_data);
+        slate.elements.forEach(e => e.update());
+        let chord = slate.lookupElement("EG") as Chord;
+        almostEqual(chord.A.x,  82.540, 0.01);
+        almostEqual(chord.A.y, 180.000, 0.01);
+        almostEqual(chord.B.x, 237.460, 0.01);
+        almostEqual(chord.B.y, 180.000, 0.01);
+        // Both endpoints must lie on the circle
+        let center = slate.lookupElement("C") as PointElement;
+        let r = Math.sqrt(8500);
+        almostEqual(chord.A.distance(center), r, 0.001);
+        almostEqual(chord.B.distance(center), r, 0.001);
+    });
+
+    it("should NaN the chord when the line misses the circle entirely", () => {
+        // Shift C far above the line so the circle can't reach it.
+        let miss_data : IConstructionInfo[] = [
+            { name: "A",   construction: E.Point.free,    params: [30, 180] },
+            { name: "B",   construction: E.Point.free,    params: [290, 180] },
+            { name: "AB",  construction: E.Line.connect,  params: ["A", "B"] },
+            { name: "C",   construction: E.Point.free,    params: [160, 10] },  // far above y=180
+            { name: "D",   construction: E.Point.free,    params: [165, 20] },  // tiny circle
+            { name: "EFG", construction: E.Circle.radius, params: ["C", "D"] },
+            { name: "EG",  construction: E.Line.chord,    params: ["AB", "EFG"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, miss_data);
+        slate.elements.forEach(e => e.update());
+        let chord = slate.lookupElement("EG") as Chord;
+        assert.ok(isNaN(chord.A.x) && isNaN(chord.A.y));
+        assert.ok(isNaN(chord.B.x) && isNaN(chord.B.y));
+    });
+
+    it("should translate only the chord endpoints, leaving inputs untouched", () => {
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, chord_propI12_data);
+        slate.elements.forEach(e => e.update());
+        let chord = slate.lookupElement("EG") as Chord;
+        let ax0 = chord.A.x, ay0 = chord.A.y;
+        let bx0 = chord.B.x, by0 = chord.B.y;
+        chord.translate(5, 7);
+        almostEqual(chord.A.x, ax0 + 5, 0.001);
+        almostEqual(chord.A.y, ay0 + 7, 0.001);
+        almostEqual(chord.B.x, bx0 + 5, 0.001);
+        almostEqual(chord.B.y, by0 + 7, 0.001);
+        // Input free points must be untouched
+        let A = slate.lookupElement("A") as PointElement;
+        let B = slate.lookupElement("B") as PointElement;
+        let C = slate.lookupElement("C") as PointElement;
+        let D = slate.lookupElement("D") as PointElement;
+        almostEqual(A.x,  30, 0.001); almostEqual(A.y, 180, 0.001);
+        almostEqual(B.x, 290, 0.001); almostEqual(B.y, 180, 0.001);
+        almostEqual(C.x, 160, 0.001); almostEqual(C.y, 130, 0.001);
+        almostEqual(D.x, 180, 0.001); almostEqual(D.y, 220, 0.001);
+    });
+
+    it("should rotate only the chord endpoints around a pivot", () => {
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, chord_propI12_data);
+        slate.elements.forEach(e => e.update());
+        let chord = slate.lookupElement("EG") as Chord;
+        let A = slate.lookupElement("A") as PointElement;
+        // 90° CCW rotation around A=(30,180): ac=cos(90°)=0, as=sin(90°)=1
+        // chord.A (82.540, 180) → dx=52.540, dy=0
+        //   new x = 30 + 0*52.540 - 1*0        = 30
+        //   new y = 180 + 1*52.540 + 0*0       = 232.540
+        // chord.B (237.460, 180) → dx=207.460, dy=0
+        //   new x = 30 + 0*207.460 - 1*0       = 30
+        //   new y = 180 + 1*207.460 + 0*0      = 387.460
+        chord.rotate(A, 0, 1);
+        almostEqual(chord.A.x,  30.000, 0.01);
+        almostEqual(chord.A.y, 232.540, 0.01);
+        almostEqual(chord.B.x,  30.000, 0.01);
+        almostEqual(chord.B.y, 387.460, 0.01);
+        // Input free points untouched (A is the pivot; B, C, D must not move)
+        let B = slate.lookupElement("B") as PointElement;
+        let C = slate.lookupElement("C") as PointElement;
+        let D = slate.lookupElement("D") as PointElement;
+        almostEqual(A.x,  30, 0.001); almostEqual(A.y, 180, 0.001);
+        almostEqual(B.x, 290, 0.001); almostEqual(B.y, 180, 0.001);
+        almostEqual(C.x, 160, 0.001); almostEqual(C.y, 130, 0.001);
+        almostEqual(D.x, 180, 0.001); almostEqual(D.y, 220, 0.001);
     });
 
     it("should be able to find the closest visible point within a tolerance", () =>{

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "commonjs",
     "target": "es2017",
     "sourceMap": true,
+    "noEmit": true,
     "noImplicitAny": true,
     "strictNullChecks": false,
     "removeComments": false,

--- a/view/applet-tests/line/chord/applet.html
+++ b/view/applet-tests/line/chord/applet.html
@@ -1,0 +1,40 @@
+<HTML><HEAD><TITLE>line;chord — applet form of view/test/line/chord.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/line/chord.html -->
+<!-- ORIGINAL: view/applet-tests/line/chord/original.html (propI12) -->
+<!--
+  Up-to-construction applet form of the TS test page. Visually equivalent to
+  what view/test/line/chord.html renders: the propI12 figure with circle EFG
+  centered at C with radius CD, the chord EG cut by line AB through the
+  circle (1st use of line;chord), and the perpendicular CH bisecting EG with
+  the chord FF' along it (2nd use of line;chord).
+
+  Differences from original.html:
+    - pivot=H removed (the global pivot rotation is a Joyce interaction
+      feature, not geometry — not needed for windows 2/3 visual parity)
+
+  Canvas is 400x400 to match the TS test page's canvas CSS size, rather than
+  the propI12 original's 330x250; all element coordinates are in the
+  original's address space so the diagram sits in the upper-left of the
+  larger canvas.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="I.12 — line;chord">
+<param name=e[1] value="A;point;free;30,180">
+<param name=e[2] value="B;point;free;290,180">
+<param name=e[3] value="AB;line;connect;A,B">
+<param name=e[4] value="C;point;free;160,130">
+<param name=e[5] value="D;point;free;180,220">
+<param name=e[6] value="EFG;circle;radius;C,D">
+<param name=e[7] value="EG;line;chord;AB,EFG;0;0;0">
+<param name=e[8] value="E;point;first;EG">
+<param name=e[9] value="G;point;last;EG">
+<param name=e[10] value="H;point;midpoint;EG;black;green">
+<param name=e[11] value="CG;line;connect;C,G">
+<param name=e[12] value="CH;line;connect;C,H">
+<param name=e[13] value="CE;line;connect;C,E">
+<param name=e[14] value="FF';line;chord;CH,EFG">
+<param name=e[15] value="F;point;first;FF'">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/line/chord/original.html
+++ b/view/applet-tests/line/chord/original.html
@@ -1,0 +1,23 @@
+<HTML><HEAD><TITLE>I.12 — line;chord (original)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=250 width=330>
+<param name=background value="35,19,100">
+<param name=title value="I.12">
+<param name=e[1] value="A;point;free;30,180">
+<param name=e[2] value="B;point;free;290,180">
+<param name=e[3] value="AB;line;connect;A,B">
+<param name=e[4] value="C;point;free;160,130">
+<param name=e[5] value="D;point;free;180,220">
+<param name=e[6] value="EFG;circle;radius;C,D">
+<param name=e[7] value="EG;line;chord;AB,EFG;0;0;0">
+<param name=e[8] value="E;point;first;EG">
+<param name=e[9] value="G;point;last;EG">
+<param name=e[10] value="H;point;midpoint;EG;black;green">
+<param name=pivot value="H">
+<param name=e[11] value="CG;line;connect;C,G">
+<param name=e[12] value="CH;line;connect;C,H">
+<param name=e[13] value="CE;line;connect;C,E">
+<param name=e[14] value="FF';line;chord;CH,EFG">
+<param name=e[15] value="F;point;first;FF'">
+</applet>
+</BODY></HTML>

--- a/view/test/line/chord.html
+++ b/view/test/line/chord.html
@@ -1,0 +1,51 @@
+<html>
+<head>
+    <title>Test View - Line.chord (I.12)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let Color = geomlib.Color;
+    let Align = geomlib.Align;
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "I.12 — To draw a perpendicular to a given infinite straight line from a given point not on it",
+        canvasid: "canvasId",
+        elements: [
+            // <param name=e[1] value="A;point;free;30,180">
+            { name: "A", construction: E.Point.free, params: [30, 180] },
+            // <param name=e[2] value="B;point;free;290,180">
+            { name: "B", construction: E.Point.free, params: [290, 180] },
+            // <param name=e[3] value="AB;line;connect;A,B">
+            { name: "AB", construction: E.Line.connect, params: ["A", "B"] },
+            // <param name=e[4] value="C;point;free;160,130">
+            { name: "C", construction: E.Point.free, params: [160, 130] },
+            // <param name=e[5] value="D;point;free;180,220">
+            { name: "D", construction: E.Point.free, params: [180, 220] },
+            // <param name=e[6] value="EFG;circle;radius;C,D">
+            { name: "EFG", construction: E.Circle.radius, params: ["C", "D"] },
+            // <param name=e[7] value="EG;line;chord;AB,EFG;0;0;0">  ← target construction (1st use)
+            { name: "EG", construction: E.Line.chord, params: ["AB", "EFG"] },
+            // <param name=e[8] value="E;point;first;EG">
+            { name: "E", construction: E.Point.first, params: ["EG"] },
+            // <param name=e[9] value="G;point;last;EG">
+            { name: "G", construction: E.Point.last, params: ["EG"] },
+            // <param name=e[10] value="H;point;midpoint;EG;black;green">
+            { name: "H", construction: E.Point.midpoint, params: ["EG"] },
+            // <param name=e[11] value="CG;line;connect;C,G">
+            { name: "CG", construction: E.Line.connect, params: ["C", "G"] },
+            // <param name=e[12] value="CH;line;connect;C,H">
+            { name: "CH", construction: E.Line.connect, params: ["C", "H"] },
+            // <param name=e[13] value="CE;line;connect;C,E">
+            { name: "CE", construction: E.Line.connect, params: ["C", "E"] },
+            // <param name=e[14] value="FF';line;chord;CH,EFG">  ← target construction (2nd use)
+            { name: "FF'", construction: E.Line.chord, params: ["CH", "EFG"] },
+            // <param name=e[15] value="F;point;first;FF'">
+            { name: "F", construction: E.Point.first, params: ["FF'"] },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds `line;chord` (port of `Chord.java`), verified end-to-end against propI12; unlocks 12 newly-renderable propositions across Books I and III, and ships a tsconfig hardening that prevents the stale-`.js` shadow bug from recurring.

## What's in this branch

- `8b0cdd9` line-chord: step 3 — add original.html from propI12
- `03a76c8` line-chord: step 4 — add Chord.ts
- `e1e6339` line-chord: step 5 — wire ChordConstruction
- `b53cb80` line-chord: step 6 — Mocha tests
- `ffacdbd` line-chord: harden tsconfig with noEmit: true
- `d07fd3f` line-chord: step 7 — three-way view pair (TS page + applet.html)
- `3903cff` line-chord: step 8 — tracker + journal updates
- `53693d1` process: step 8 — add pull request body template

`ffacdbd` is an out-of-band platform commit landed mid-port. The 56 stale `.js` files in `src/` and `tests/` (dated before this session began) shadowed the fresh `.ts` sources via Node's require resolution and broke step 6's mocha run with "Construction not found". The previous fix from PR #4 (`tsc --noEmit` in the build script + `.mocharc.json` ts-node registration) is necessary but not sufficient — VS Code's TypeScript language server runs its own background `tsc` and emits sourceMap-enabled `.js` siblings unless the *config* says `noEmit`. Setting `"noEmit": true` in `tsconfig.json` is the strictly stronger fix that supersedes the PR #4 mitigation. It's bundled into this branch because it was the actual unblocker for step 6 and would have hit the next port the same way. `53693d1` is similarly out-of-band — a process refinement codifying the PR-body convention this very PR uses, mirroring the precedent in PR #4 of folding workflow improvements into the construction branch that motivated them.

## Construction details

- **Element class**: `src/elements/line/Chord.ts` — extends `LineElement`. Constructor `(D, E, C)` where D/E are the two `PointElement` endpoints of the input line (post-`LineElement` expansion) and C is the `CircleElement`. Internal `_A`/`_B` PointElements share `C.AP` as the chord's own endpoints. `update()` projects center to line via `_B.toLine(D, E, false)`, computes half-chord length `s = √(r² − d²)`, derives `_A` from D via the vector formula, then `_B := 2·foot − _A` (reflection trick for the second intersection). NaN-sentinels both endpoints when `d² > r²`. Fallback to E when D coincides with the foot (`factor < 1e10` guard). `translate`/`rotate` overrides delegate to `_A`/`_B` so the chord's own endpoints move while inputs stay put — required because `LineElement.translate`/`rotate` are no-op stubs.
- **Construction class**: `ChordConstruction` in `src/elements/Constructions.ts` (registered next to `BichordConstruction` in the array). Post-`LineElement`-expansion signature `[ct.PointElement, ct.PointElement, ct.CircleElement]`. Dispatches to `LineConstructions.chord = 105`. No 2D/3D variant ordering hazard — `Chord.java` has only one signature.
- **Java source**: `geom_applet/source/Chord.java` — 23 lines, line-for-line port. The only Java→TS adjustment is `C.radius2()` → `this.C.radius2` (TS getter, no parens).

## Tests

17 → **21 passing**. Four new tests in `tests/SlateTest.ts`:

- `should compute the chord of a circle cut by a line` — propI12 coords; asserts `chord.A ≈ (82.540, 180)`, `chord.B ≈ (237.460, 180)` (hand-computed: foot=(160,180), s=√6000≈77.460, factor≈0.59585), plus both endpoints lie on the circle within 0.001.
- `should NaN the chord when the line misses the circle entirely` — exercises the `d² > r²` NaN-sentinel branch by shifting C far above the line; asserts both endpoints are NaN after update.
- `should translate only the chord endpoints, leaving inputs untouched` — translate isolation test mirroring the `ArcElement` pattern.
- `should rotate only the chord endpoints around a pivot` — 90° CCW rotation around input A; hand-computed expected values; confirms B, C, D inputs aren't disturbed.

## Verification

- [x] `npm run build` clean (`tsc --noEmit`)
- [x] `npm test` passes (21/21)
- [x] `npx webpack` rebuilds `dist/bundle.js` (199 KiB, ~1.3s)
- [x] Three-way harness (`./run_euclid_applet.sh` → pick `line;chord`) shows windows 2 and 3 visually identical at rest — **agent could not run; needs human to verify on a machine with X11 + Docker**
- [x] Drag interactions: drag C or D to confirm chord tracks the circle/line intersection; drag A or B past C so the line falls off the circle and confirm chord disappears (NaN path); the second chord FF' along CH should track simultaneously since `line;chord` is exercised twice in propI12

## Newly renderable propositions

- **Book I** (16 → 17): I.12
- **Book III** (18 → 29): III.1, III.5, III.6, III.8, III.9, III.10, III.12, III.15, III.17, III.36, III.37
- **I–III total** (36 → 48): +12

III.34 is still blocked by `point;similar`. II.5 and II.14 had `line;chord` removed from their NEEDS lines but remain blocked by other TBDs (`polygon;parallelogram` / `polygon;quadrilateral` / `polygon;square` / `polygon;application`).

## Discovered / out of scope

- **Proposition-tracker NEEDS-line bug for `point;similar`**: cross-checking the tracker's "I.23/I.24/I.26/I.31 NEEDS `point;similar`" lines against the actual HTML param lists revealed that propI23 uses `polygon;similar` (e[12]) and propI31 uses `line;similar` (e[7]) — neither is the `point;similar` variant. Same class of error as the I.4 correction in the prior 2026-04-11 entry. Out of scope for this branch (the plan's `Out of scope` section explicitly defers it); should be fixed in the next session that touches the proposition tracker, especially since it materially affects whether `point;similar` is the right "next port" pick.
- **`factor < 1e10` degenerate-line fallback**: Chord.java handles the case where the input line endpoint D coincides with the perpendicular foot of the circle's center — `D.distance(B) ≈ 0` makes `factor` blow up, so the code reaches for E instead. Worth knowing but unlikely to bite; left as a verbatim port.
- **Stale `.js` shadow recurrence pattern**: now that `tsconfig.json` carries `noEmit: true`, the manual cleanup step from the 2026-04-11 sector-arc session shouldn't be needed again. The 2026-04-11 mitigation in PR #4 is now superseded.
