### PR TITLE
Feature/point similar

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -147,9 +147,27 @@ These affect the library as a whole, independent of individual constructions.
   - [x] test view: [view/test/point/vertex.html](../view/test/point/vertex.html)
   - Used in: I.2, I.9–I.11, I.23–I.24, I.26, I.33–I.34, I.36, I.41–I.47, Book II, III.14, III.24–III.25
 
-- [ ] **`similar`** — TBD
-  - Java source: `Similar.java`
-  - Used in: I.23–I.24, I.26, I.31, I.42, I.44–I.45, III.14, III.24–III.29, III.33–III.34
+- [x] **`similar`** — `src/elements/point/SimilarElement.ts`
+  - Extends `PointElement`; constructor takes `(A, B, AP, D, E, F, Q)` where
+    A/B are the first two vertices of the output triangle, D/E/F define the
+    reference triangle, and AP/Q are the ambient planes (both default to
+    screen in the 2D variant). `update()` calls `this.toSimilar(...)` which
+    already exists on `PointElement`.
+  - Java source: `Similar.java` — 10 lines, line-for-line port. The math
+    lives in `PointElement.toSimilar()` which was ported in a prior session.
+  - 2D variant only per the 2D-first policy; the 3D variant (with explicit
+    PlaneElement params) remains TBD. No signature-ordering hazard since the
+    2D (5 params) and 3D (7 params) lengths differ.
+  - Mocha tests (2): isosceles right triangle (factor=1, C=(50,300)),
+    non-isosceles right triangle (factor=0.5, C=(50,250)).
+  - [x] test view: [view/test/point/similar.html](../view/test/point/similar.html) — defIII11
+  - [x] applet-tests pair:
+    [view/applet-tests/point/similar/{original,applet}.html](../view/applet-tests/point/similar/)
+  - **Tracker correction**: the proposition-tracker had I.23, I.24, I.26,
+    I.31, III.14 listed as needing `point;similar` — they actually use
+    `polygon;similar` or `line;similar`. Corrected in this branch.
+  - Used in (actual `point;similar`): I.42, III.33, III.34, plus
+    III.26–III.29 (but those are blocked by 3-point `circle;radius` TBD)
 
 - [ ] **`proportion`** — TBD
   - Java source: `Proportion.java`

--- a/doc/constructions-reference.md
+++ b/doc/constructions-reference.md
@@ -48,7 +48,7 @@ must reflect these post-expansion types, not the raw HTML param count.
 | `perpendicular` | IMPL | `Perpendicular.java` | Various (5 signature variants) | Point D s.t. AD ⊥ AB and \|AD\| = \|EF\| | ~18 | I.11 |
 | `parallelogram` | **TBD** | `Geometry.java` | `Point A, Point B, Point C` | 4th vertex D of parallelogram ABCD (D = A+C−B) | ~48 | I.28 |
 | `vertex` | **TBD** | `PolygonElement.java` | `Polygon P, int i` | i-th vertex of polygon P | ~59 | I.2 |
-| `similar` | **TBD** | `Similar.java` | `Point A, B, D, E, F [, Plane]` | Point H so △ABH ~ △DEF | ~15 | I.23 |
+| `similar` | IMPL | `Similar.java` | `Point A, B, D, E, F [, Plane]` | Point H so △ABH ~ △DEF (2D) | ~15 | III.33 |
 | `proportion` | **TBD** | `Proportion.java` | `Point A, B, C, D, E, F, G, H` | Point on GH s.t. AB:CD = EF:GI | ~4 | I.16 |
 | `invert` | **TBD** | `InvertPoint.java` | `Point A, Circle B` | Inversion of A in circle B | 0 | — |
 | `meanProportional` | **TBD** | `MeanProportional.java` | `Point A, B, C, D, E, F` | Point G on EF s.t. AB:CD = CD:EG | 0 | — |
@@ -161,7 +161,7 @@ Implementing higher-priority constructions unlocks the most propositions.
 | ~~5~~ | ~~`line;chord`~~ — IMPL 2026-04-11 | 17 | I.12, III.1, III.5, III.6, III.8–III.9, III.10, III.12, III.15, III.17, III.36, III.37 |
 | 6 | `polygon;quadrilateral` | 11 | I.43–I.45, II.2, II.4–II.6, II.8–II.9, II.14 |
 | 7 | `polygon;square` | 10 | I.46, I.47, II.2–II.4, II.5–II.8, II.11 |
-| 8 | `point;similar` | 15 | I.23, I.24, I.26, I.31, I.42, I.44, I.45, III.14, III.24–III.29, III.33–III.34 |
+| ~~8~~ | ~~`point;similar`~~ — IMPL 2026-04-12 | 15 | I.42, III.33, III.34 (actual point;similar); I.23, I.24, I.26, I.31, III.14 were polygon/line;similar (corrected) |
 | 9 | `polygon;equilateralTriangle` | 6 | I.2, I.9, I.10, I.11, III.10, III.24 |
 | ~~10~~ | ~~`line;parallel`~~ — IMPL 2026-04-11 | 9 | I.22, I.27, I.37–I.40, II.8–II.9, II.11 |
 | 11 | `polygon;similar` | 5 | III.23, III.24, III.26–III.29 |

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,75 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-12 — Implemented point;similar + major tracker NEEDS-line corrections
+
+**Completed:**
+- Ported `point;similar` as `src/elements/point/SimilarElement.ts` — a port
+  of `Similar.java` (10 lines). Extends `PointElement`; constructor takes
+  `(A, B, AP, D, E, F, Q)` and `update()` calls `this.toSimilar(...)` which
+  was already ported on `PointElement`. The math computes the point C such
+  that △ABC ∼ △DEF by rotating B around A by the angle ∠EDF and scaling by
+  |DF|/|DE|.
+- `SimilarPointConstruction` wired into `Constructions.ts` with 2D signature
+  `[PointElement × 5]`, dispatching to `PointConstructions.similar = 15`.
+  Both planes default to `screen`. 3D variant (explicit PlaneElement params)
+  deferred per 2D-first policy; no signature-ordering hazard since 2D (5
+  params) and 3D (7 params) lengths differ.
+- Two Mocha tests: isosceles right triangle (θ=π/2, factor=1, C=(50,300))
+  and non-isosceles right triangle (θ=π/2, factor=0.5, C=(50,250)).
+  25 → **27 passing** (cumulative).
+- Test page + applet companion using defIII11 (similar circle segments):
+  two circles with sectors and triangles, where F on the right circle is
+  computed via point;similar to be the similar-triangle vertex.
+- **Major proposition-tracker corrections**: cross-checked every I–III
+  proposition that the tracker listed as needing `point;similar` against
+  the actual HTML param lists. Found 5 WRONG NEEDS lines:
+  - I.23: uses `polygon;similar` (e[12]), NOT `point;similar`
+  - I.24: uses `polygon;similar` (e[11]), NOT `point;similar`
+  - I.26: uses `polygon;similar` (e[8]), NOT `point;similar`
+  - I.31: uses `line;similar` (e[7]), NOT `point;similar`
+  - III.14: uses `polygon;similar` (e[7]), NOT `point;similar`
+  All five corrected in this branch. This is the systematic resolution
+  of the tracker-drift bug flagged in the line;chord journal entry.
+- Also corrected III.26–III.29: these DO use `point;similar` (now landed)
+  but are STILL blocked by the 3-point `circle;radius` variant (TBD) at
+  their respective e[7] elements.
+- Book I renderable count: 24 → **25** (+I.42). Book III: 29 → **31**
+  (+III.33, III.34). I–III total: 55 → **58**.
+
+**Discovered:**
+- **Clean verifiers DO exist for `point;similar`**: the "no clean verifier"
+  claim from the startup menu was wrong. defIII11 and propIII33 both have
+  `point;similar` with all preceding elements IMPL. The false claim arose
+  because the tracker pointed at I.23/I.31 (which use polygon/line;similar)
+  rather than at the actual point;similar propositions.
+- **3-point `circle;radius` is the next big blocker**: III.26–III.29 and
+  III.24 all use a 3-point `circle;radius` form (`circle at A with radius
+  |BC|`) that is TBD. This was first noted in the I.4 correction during
+  the sector;arc session (2026-04-11). Landing it would unblock 5 Book III
+  propositions at once.
+- **Proposition-tracker drift was worse than expected**: 5 of the ~15
+  propositions listed as needing `point;similar` didn't actually use it.
+  The `Similar.java` class handles point, line, AND polygon variants via
+  the same Java source, and the tracker naively assumed they all mapped to
+  `point;similar`. Future tracker entries should grep the actual HTML
+  `<param>` lines to confirm the `type;construction` pair, not just the
+  construction name.
+
+**Next session:**
+- Top priority: `polygon;quadrilateral` (11 I–III uses, I.43 sole-TBD
+  verifier, trivially easy — extends `PolyConstruction` with a 4-point
+  signature). Or `polygon;square` (10 uses, I.47 viable, RegularPolygon
+  n=4).
+- High-impact alternative: 3-point `circle;radius` variant (would unblock
+  III.24, III.26–III.29 = 5 Book III props at once; needs a new signature
+  variant on `CircleRadiusCenterConstruction`).
+- Also consider `polygon;similar` and `line;similar` which share the same
+  `Similar.java` source — porting them would unblock I.23, I.24, I.26,
+  I.31, III.14.
+
+---
+
 ## 2026-04-11 — Implemented polygon;parallelogram (3rd warm-cache port)
 
 **Completed:**

--- a/doc/proposition-tracker.md
+++ b/doc/proposition-tracker.md
@@ -14,10 +14,10 @@ Tracks the port status of all propositions across Euclid's Elements.
 
 | Scope | Total | Renderable (`[~]`) | Complete (`[x]`) |
 |-------|-------|--------------------|------------------|
-| Book I | 48 | 24 | 0 |
+| Book I | 48 | 25 | 0 |
 | Book II | 14 | 2 | 0 |
-| Book III | 37 | 29 | 0 |
-| **I–III total** | **99** | **55** | **0** |
+| Book III | 37 | 31 | 0 |
+| **I–III total** | **99** | **58** | **0** |
 | Books IV–XIII | ~365 | — | — |
 
 Update the summary table after each session.
@@ -48,15 +48,15 @@ Update the summary table after each session.
 - [~] I.20 — In any triangle the sum of any two sides is greater than the remaining one.
 - [~] I.21 — If from the ends of one of the sides of a triangle two straight lines are constructed meeting within the triangle…
 - [~] I.22 — To construct a triangle out of three straight lines which equal three given straight lines. (`line;parallel` landed 2026-04-11.)
-- [ ] I.23 — To construct a rectilinear angle equal to a given rectilinear angle on a given straight line and at a point on it. NEEDS: `point;similar`, `point;vertex`
-- [ ] I.24 — If two triangles have two sides equal to two sides respectively, but have one of the angles contained by the equal straight lines greater than the other… NEEDS: `point;similar`, `point;vertex`
+- [ ] I.23 — To construct a rectilinear angle equal to a given rectilinear angle on a given straight line and at a point on it. NEEDS: `polygon;similar` (NOT point;similar — corrected 2026-04-12; propI23 e[12] uses polygon;similar)
+- [ ] I.24 — If two triangles have two sides equal to two sides respectively, but have one of the angles contained by the equal straight lines greater than the other… NEEDS: `polygon;similar` (NOT point;similar — corrected 2026-04-12; propI24 e[11] uses polygon;similar)
 - [~] I.25 — If two triangles have two sides equal to two sides respectively, but have the base greater than the base…
-- [ ] I.26 — If two triangles have two angles equal to two angles respectively, and one side equal to one side… (AAS/ASA congruence). NEEDS: `point;similar`, `point;vertex`
+- [ ] I.26 — If two triangles have two angles equal to two angles respectively, and one side equal to one side… (AAS/ASA congruence). NEEDS: `polygon;similar` (NOT point;similar — corrected 2026-04-12; propI26 e[8] uses polygon;similar)
 - [~] I.27 — If a straight line falling on two straight lines makes the alternate angles equal to one another, then the straight lines are parallel. (`line;parallel` landed 2026-04-11.)
 - [ ] I.28 — If a straight line falling on two straight lines makes the exterior angle equal to the interior and opposite angle on the same side… NEEDS: `point;parallelogram`
 - [ ] I.29 — A straight line falling on parallel straight lines makes the alternate angles equal to one another… NEEDS: `point;parallelogram`, `point;proportion`
 - [ ] I.30 — Straight lines parallel to the same straight line are also parallel to one another. NEEDS: `point;parallelogram`
-- [ ] I.31 — To draw a straight line through a given point parallel to a given straight line. NEEDS: `point;similar`
+- [ ] I.31 — To draw a straight line through a given point parallel to a given straight line. NEEDS: `line;similar` (NOT point;similar — corrected 2026-04-12; propI31 e[7] uses line;similar)
 - [ ] I.32 — In any triangle, if one of the sides is produced, then the exterior angle equals the sum of the two interior and opposite angles… NEEDS: `point;parallelogram`
 - [ ] I.33 — Straight lines which join the ends of equal and parallel straight lines in the same directions are themselves equal and parallel. NEEDS: `point;parallelogram`, `point;vertex`
 - [~] I.34 — In parallelogrammic areas the opposite sides and angles equal one another, and the diameter bisects the areas. (`point;parallelogram`, `point;vertex`, `polygon;parallelogram` all landed by 2026-04-11.)
@@ -67,7 +67,7 @@ Update the summary table after each session.
 - [~] I.39 — Equal triangles which are on the same base and on the same side are also in the same parallels. (`line;parallel` landed 2026-04-11.)
 - [~] I.40 — Equal triangles which are on equal bases and on the same side are also in the same parallels. (`line;parallel` landed 2026-04-11.)
 - [ ] I.41 — If a parallelogram has the same base with a triangle and is in the same parallels, then the parallelogram is double the triangle. NEEDS: `point;parallelogram`, `point;vertex`
-- [ ] I.42 — To construct a parallelogram equal to a given triangle in a given rectilinear angle. NEEDS: `point;parallelogram`, `point;similar`
+- [~] I.42 — To construct a parallelogram equal to a given triangle in a given rectilinear angle. (`point;parallelogram`, `point;similar` both landed by 2026-04-12.)
 - [ ] I.43 — In any parallelogram the complements of the parallelograms about the diameter equal one another. NEEDS: `point;parallelogram`, `polygon;quadrilateral`, `point;vertex`
 - [ ] I.44 — To a given straight line in a given rectilinear angle, to apply a parallelogram equal to a given triangle. NEEDS: `point;parallelogram`, `polygon;quadrilateral`, `point;similar`, `point;vertex`, `polygon;application`
 - [ ] I.45 — To construct a parallelogram equal to a given rectilinear figure in a given rectilinear angle. NEEDS: `polygon;quadrilateral`, `point;similar`, `point;vertex`, `polygon;application`
@@ -111,7 +111,7 @@ Update the summary table after each session.
 - [~] III.11 — If two circles touch one another internally, and their centers are taken, then the straight line joining their centers, being produced, falls on the point of contact of the circles.
 - [~] III.12 — If two circles touch one another externally, then the straight line joining their centers passes through the point of contact. (`line;chord` landed 2026-04-11.)
 - [~] III.13 — A circle does not touch another circle at more than one point whether it touches it internally or externally.
-- [ ] III.14 — Equal straight lines in a circle are equally distant from the center, and those which are equally distant from the center equal one another. NEEDS: `point;similar`, `point;vertex`
+- [ ] III.14 — Equal straight lines in a circle are equally distant from the center, and those which are equally distant from the center equal one another. NEEDS: `polygon;similar` (NOT point;similar — corrected 2026-04-12; propIII14 e[7] uses polygon;similar)
 - [~] III.15 — Of straight lines in a circle the diameter is greatest, and of the rest the nearer to the center is always greater than the more remote. (`line;chord` landed 2026-04-11.)
 - [~] III.16 — The straight line drawn at right angles to the diameter of a circle from its end will fall outside the circle…
 - [~] III.17 — From a given point to draw a straight line touching a given circle. (`line;chord` landed 2026-04-11.)
@@ -123,15 +123,15 @@ Update the summary table after each session.
 - [~] III.23 — On the same straight line there cannot be constructed two similar and unequal segments of circles on the same side. (sector;arc landed 2026-04-11.)
 - [ ] III.24 — Similar segments of circles on equal straight lines equal one another. NEEDS: `point;similar`  (`polygon;equilateralTriangle`, `point;vertex`, `sector;arc` already landed)
 - [~] III.25 — Given a segment of a circle, to describe the complete circle of which it is a segment. (sector;arc landed 2026-04-11.)
-- [ ] III.26 — In equal circles equal angles stand on equal circumferences whether they stand at the centers or at the circumferences. NEEDS: `point;similar`
-- [ ] III.27 — In equal circles angles standing on equal circumferences equal one another whether they stand at the centers or at the circumferences. NEEDS: `point;similar`
-- [ ] III.28 — In equal circles equal straight lines cut off equal circumferences, the greater circumference equals the greater and the less equals the less. NEEDS: `point;similar`
-- [ ] III.29 — In equal circles straight lines that cut off equal circumferences are equal. NEEDS: `point;similar`
+- [ ] III.26 — In equal circles equal angles stand on equal circumferences whether they stand at the centers or at the circumferences. NEEDS: `circle;radius` 3-point variant (`point;similar` landed 2026-04-12 but e[7] uses 3-point circle;radius which is TBD)
+- [ ] III.27 — In equal circles angles standing on equal circumferences equal one another whether they stand at the centers or at the circumferences. NEEDS: `circle;radius` 3-point variant (same blocker as III.26)
+- [ ] III.28 — In equal circles equal straight lines cut off equal circumferences, the greater circumference equals the greater and the less equals the less. NEEDS: `circle;radius` 3-point variant (same blocker as III.26)
+- [ ] III.29 — In equal circles straight lines that cut off equal circumferences are equal. NEEDS: `circle;radius` 3-point variant (same blocker as III.26)
 - [~] III.30 — To bisect a given circumference. (sector;arc landed 2026-04-11.)
 - [~] III.31 — In a circle the angle in the semicircle is right, that in a greater segment less than a right angle, and that in a less segment greater than a right angle…
 - [~] III.32 — If a straight line touches a circle, and from the point of contact there is drawn across, in the circle, a straight line cutting the circle, then the angles which it makes with the tangent equal the angles in the alternate segments of the circle.
-- [ ] III.33 — On a given straight line to describe a segment of a circle admitting an angle equal to a given rectilinear angle. NEEDS: `point;similar`
-- [ ] III.34 — From a given circle to cut off a segment admitting an angle equal to a given rectilinear angle. NEEDS: `point;similar` (`line;chord` landed 2026-04-11)
+- [~] III.33 — On a given straight line to describe a segment of a circle admitting an angle equal to a given rectilinear angle. (`point;similar` landed 2026-04-12.)
+- [~] III.34 — From a given circle to cut off a segment admitting an angle equal to a given rectilinear angle. (`point;similar` landed 2026-04-12; `line;chord` landed 2026-04-11.)
 - [~] III.35 — If in a circle two straight lines cut one another, then the rectangle contained by the segments of the one equals the rectangle contained by the segments of the other.
 - [~] III.36 — If a point is taken outside a circle and two straight lines fall from it on the circle, and if one of them cuts the circle and the other touches it… (`line;chord` landed 2026-04-11.)
 - [~] III.37 — If a point is taken outside a circle and from the point there fall on the circle two straight lines… (`line;chord` landed 2026-04-11.)

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -36,6 +36,7 @@ import {Perpendicular} from "./line/Perpendicular";
 import {PlanePerpendicularLine} from "./line/PlanePerpendicularLine";
 import {Bichord} from "./line/Bichord";
 import {Chord} from "./line/Chord";
+import {SimilarElement} from "./point/SimilarElement";
 import {PolygonElement} from "./polygon/PolygonElement";
 import {RegularPolygonElement} from "./polygon/RegularPolygonElement";
 import {SphereElement} from "./sphere/SphereElement";
@@ -573,11 +574,21 @@ export class ParallelogramConstruction extends Construction {
     }
 }
 
-// TBD
 // point
 // similar	points A, B, D, E, F [planes C, G]
 // the point H so that triangle ABH in plane C is similar to triangle DEF in plane G
+// 2D variant: 5 PointElements, both planes default to screen
+// (Java: Similar.java — extends PointElement, calls this.toSimilar(...) in update())
+export class SimilarPointConstruction extends Construction {
+    constructionMethod: AllConstructions = PointConstructions.similar;
+    signature: ConstructionTypes[] = (new Array(5)).fill(ct.PointElement);
 
+    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let g = new SimilarElement(ps[0], ps[1], screen, ps[2], ps[3], ps[4], screen);
+        return [[g], g];
+    }
+}
 
 // point perpendicular constructions
 abstract class PointPerpendicularConstruction extends Construction {
@@ -1329,6 +1340,7 @@ export const constructions : Construction[] = [
     new ExtendConstruction(),
     new CutoffConstruction(),
     new ParallelogramConstruction(),
+    new SimilarPointConstruction(),
     new CircumcircleConstruction(),
     new CircumcircleConstruction2d(),
     new LineSliderConstruction(),

--- a/src/elements/point/SimilarElement.ts
+++ b/src/elements/point/SimilarElement.ts
@@ -1,0 +1,52 @@
+/*----------------------------------------------------------------------+
+|    Title:	SimilarElement.ts                                           |
+|    A port of the software Geometry Applet by                          |
+|    Author:    David E. Joyce                                          |
+|        Department of Mathematics and Computer Science                 |
+|        Clark University                                               |
+|        Worcester, MA 01610-1477                                       |
+|        U.S.A.                                                         |
+|                                                                       |
+|        http://aleph0.clarku.edu/~djoyce/home.html                     |
+|        djoyce@clarku.edu                                              |
+|                                                                       |
+|    Date:    February, 1996.   Version 2.0.0 May, 1997.                |
+|    TypeScript Port: 2026, Nelson Brown, brownnrl@gmail.com            |
+|                           https://www.nelsonbrown.net/                |
++----------------------------------------------------------------------*/
+
+import {PointElement} from "./PointElement";
+import {PlaneElement} from "../plane/PlaneElement";
+
+export class SimilarElement extends PointElement {
+  /*--------------------------------------------------------------------+
+  | Construct a triangle AB(this) in the plane AP similar to the        |
+  | triangle DEF in the plane Q.                                        |
+  +--------------------------------------------------------------------*/
+
+  private _parentA: PointElement;
+  private _parentB: PointElement;
+  private _D: PointElement;
+  private _E: PointElement;
+  private _F: PointElement;
+  private _Q: PlaneElement;
+
+  constructor(A: PointElement, B: PointElement, AP: PlaneElement,
+              D: PointElement, E: PointElement, F: PointElement,
+              Q: PlaneElement) {
+    super();
+    this.dimension = 0;
+    this._parentA = A;
+    this._parentB = B;
+    this._AP = AP;
+    this._D = D;
+    this._E = E;
+    this._F = F;
+    this._Q = Q;
+  }
+
+  public update() {
+    this.toSimilar(this._parentA, this._parentB, this._AP,
+                   this._D, this._E, this._F, this._Q);
+  }
+}

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -13,6 +13,7 @@ import {SphereElement} from "../src/elements/sphere/SphereElement";
 import {ArcElement} from "../src/elements/sector/ArcElement";
 import {Chord} from "../src/elements/line/Chord";
 import {PolygonElement} from "../src/elements/polygon/PolygonElement";
+import {SimilarElement} from "../src/elements/point/SimilarElement";
 import {createCanvas} from "canvas";
 import {create} from "domain";
 
@@ -549,6 +550,61 @@ describe("slate", ()=> {
         let D = slate.lookupElement("D") as PointElement;
         almostEqual(D.x, 210, 0.01);
         almostEqual(D.y, 175, 0.01);
+    });
+
+    // point;similar — point C such that △ABC ∼ △DEF
+    // Similar.java: this.toSimilar(A, B, screen, D, E, F, screen)
+    //
+    // Test 1: isosceles right triangle DEF, factor=1
+    //   D=(0,0), E=(100,0), F=(0,100) → θ = π/2, factor = 100/100 = 1
+    //   A=(50,200), B=(150,200)
+    //   C = rotate B around A by π/2 then scale by 1 → (50, 300)
+    //
+    // Test 2: non-isosceles right triangle, factor=0.5
+    //   D=(0,0), E=(200,0), F=(0,100) → θ = π/2, factor = 100/200 = 0.5
+    //   A=(50,200), B=(150,200)
+    //   C = rotate B around A by π/2 then scale by 0.5 → (50, 250)
+
+    it("should compute a similar point with factor=1 (isosceles right triangle)", () => {
+        let data : IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [50, 200] },
+            { name: "B", construction: E.Point.free, params: [150, 200] },
+            { name: "D", construction: E.Point.free, params: [0, 0] },
+            { name: "E", construction: E.Point.free, params: [100, 0] },
+            { name: "F", construction: E.Point.free, params: [0, 100] },
+            { name: "C", construction: E.Point.similar, params: ["A", "B", "D", "E", "F"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let C = slate.lookupElement("C") as SimilarElement;
+        almostEqual(C.x, 50, 0.01);
+        almostEqual(C.y, 300, 0.01);
+        // Verify similarity: |AC|/|AB| should equal |DF|/|DE| = 1.0
+        let A = slate.lookupElement("A") as PointElement;
+        let B = slate.lookupElement("B") as PointElement;
+        almostEqual(A.distance(C) / A.distance(B), 1.0, 0.001);
+    });
+
+    it("should compute a similar point with factor=0.5 (non-isosceles right triangle)", () => {
+        let data : IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [50, 200] },
+            { name: "B", construction: E.Point.free, params: [150, 200] },
+            { name: "D", construction: E.Point.free, params: [0, 0] },
+            { name: "E", construction: E.Point.free, params: [200, 0] },
+            { name: "F", construction: E.Point.free, params: [0, 100] },
+            { name: "C", construction: E.Point.similar, params: ["A", "B", "D", "E", "F"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let C = slate.lookupElement("C") as SimilarElement;
+        almostEqual(C.x, 50, 0.01);
+        almostEqual(C.y, 250, 0.01);
+        // Verify similarity: |AC|/|AB| should equal |DF|/|DE| = 0.5
+        let A = slate.lookupElement("A") as PointElement;
+        let B = slate.lookupElement("B") as PointElement;
+        almostEqual(A.distance(C) / A.distance(B), 0.5, 0.001);
     });
 
     it("should compute a line through A parallel and equal to BC", () => {

--- a/view/applet-tests/point/similar/applet.html
+++ b/view/applet-tests/point/similar/applet.html
@@ -1,0 +1,34 @@
+<HTML><HEAD><TITLE>point;similar — applet form of view/test/point/similar.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/point/similar.html -->
+<!-- ORIGINAL: view/applet-tests/point/similar/original.html (defIII11) -->
+<!--
+  Trimmed version of III.Def.11 focusing on the two similar circle
+  segments. The left circle (Acirc) has sector BAC and triangle ABC;
+  the right circle (Dcirc) has similar triangle DEF where F is computed
+  via point;similar so that △DEF ∼ △BAC. Drag C on the left circle
+  to change the inscribed angle; F should track to maintain similarity.
+
+  Omits the second pair of sliders G/H from the full defIII11 to keep
+  the construction focused on point;similar.
+  Canvas is 420x400 to match the TS test page.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=420 height=400>
+<param name=background value="35,19,100">
+<param name=title value="III.Def.11 — point;similar">
+<param name=e[1] value="A;point;free;120,120">
+<param name=e[2] value="B;point;free;120,50">
+<param name=e[3] value="Acirc;circle;radius;A,B;0;0;black;yellow">
+<param name=e[4] value="C;point;circleSlider;Acirc,50,180">
+<param name=e[5] value="BCsect;sector;sector;A,B,C;0;0;0;random">
+<param name=e[6] value="Atri;polygon;triangle;A,B,C;0;0;yellow;yellow">
+<param name=e[7] value="BC;line;connect;B,C">
+<param name=e[8] value="D;point;free;300,120">
+<param name=e[9] value="E;point;free;380,120">
+<param name=e[10] value="Dcirc;circle;radius;D,E;0;0;black;pink">
+<param name=e[11] value="F;point;similar;E,D,B,A,C">
+<param name=e[12] value="EFsect;sector;sector;D,E,F;0;0;0;random">
+<param name=e[13] value="Dtri;polygon;triangle;D,E,F;0;0;pink;pink">
+<param name=e[14] value="EF;line;connect;E,F">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point/similar/original.html
+++ b/view/applet-tests/point/similar/original.html
@@ -1,0 +1,26 @@
+<HTML><HEAD><TITLE>III.Def.11 — point;similar (original)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=240 width=420>
+<param name=background value="35,19,100">
+<param name=e[1] value="A;point;free;120,120">
+<param name=e[2] value="B;point;free;120,50">
+<param name=e[3] value="Acirc;circle;radius;A,B;0;0;black;yellow">
+<param name=e[4] value="C;point;circleSlider;Acirc,50,180">
+<param name=e[5] value="BCsect;sector;sector;A,B,C;0;0;0;random">
+<param name=e[6] value="Atri;polygon;triangle;A,B,C;0;0;yellow;yellow">
+<param name=e[7] value="BC;line;connect;B,C">
+<param name=e[8] value="D;point;free;300,120">
+<param name=e[9] value="E;point;free;380,120">
+<param name=e[10] value="Dcirc;circle;radius;D,E;0;0;black;pink">
+<param name=e[11] value="F;point;similar;E,D,B,A,C">
+<param name=e[12] value="EFsect;sector;sector;D,E,F;0;0;0;random">
+<param name=e[13] value="Dtri;polygon;triangle;D,E,F;0;0;pink;pink">
+<param name=e[14] value="EF;line;connect;E,F">
+<param name=e[15] value="G;point;circleSlider;Acirc,50,50">
+<param name=e[16] value="BG;line;connect;B,G">
+<param name=e[17] value="CG;line;connect;C,G">
+<param name=e[18] value="H;point;circleSlider;Dcirc,290,50">
+<param name=e[19] value="EH;line;connect;E,H">
+<param name=e[20] value="FH;line;connect;F,H">
+</applet>
+</BODY></HTML>

--- a/view/test/point/similar.html
+++ b/view/test/point/similar.html
@@ -1,0 +1,53 @@
+<html>
+<head>
+    <title>Test View - Point.similar (III.Def.11)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:420px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    let Align = geomlib.Align;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "III.Def.11 — Similar segments of circles",
+        canvasid: "canvasId",
+        elements: [
+            // Left circle: center A, point B on circumference, slider C
+            // <param name=e[1] value="A;point;free;120,120">
+            { name: "A", construction: E.Point.free, params: [120, 120] },
+            // <param name=e[2] value="B;point;free;120,50">
+            { name: "B", construction: E.Point.free, params: [120, 50] },
+            // <param name=e[3] value="Acirc;circle;radius;A,B">
+            { name: "Acirc", construction: E.Circle.radius, params: ["A", "B"] },
+            // <param name=e[4] value="C;point;circleSlider;Acirc,50,180">
+            { name: "C", construction: E.Point.circleSlider, params: ["Acirc", 50, 180] },
+            // <param name=e[5] value="BCsect;sector;sector;A,B,C">
+            { name: "BCsect", construction: E.Sector.sector, params: ["A", "B", "C"] },
+            // <param name=e[6] value="Atri;polygon;triangle;A,B,C">
+            { name: "Atri", construction: E.Polygon.triangle, params: ["A", "B", "C"] },
+            // <param name=e[7] value="BC;line;connect;B,C">
+            { name: "BC", construction: E.Line.connect, params: ["B", "C"] },
+
+            // Right circle: center D, point E on circumference
+            // <param name=e[8] value="D;point;free;300,120">
+            { name: "D", construction: E.Point.free, params: [300, 120] },
+            // <param name=e[9] value="E;point;free;380,120">
+            { name: "E", construction: E.Point.free, params: [380, 120] },
+            // <param name=e[10] value="Dcirc;circle;radius;D,E">
+            { name: "Dcirc", construction: E.Circle.radius, params: ["D", "E"] },
+
+            // F is the similar point: △DEF ∼ △ABC  ← target construction
+            // <param name=e[11] value="F;point;similar;E,D,B,A,C">
+            { name: "F", construction: E.Point.similar, params: ["E", "D", "B", "A", "C"] },
+            // <param name=e[12] value="EFsect;sector;sector;D,E,F">
+            { name: "EFsect", construction: E.Sector.sector, params: ["D", "E", "F"] },
+            // <param name=e[13] value="Dtri;polygon;triangle;D,E,F">
+            { name: "Dtri", construction: E.Polygon.triangle, params: ["D", "E", "F"] },
+            // <param name=e[14] value="EF;line;connect;E,F">
+            { name: "EF", construction: E.Line.connect, params: ["E", "F"] },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds `point;similar` (port of `Similar.java`), the first construction with a real element class since `line;chord`. Wraps the existing `PointElement.toSimilar()` math in a new `SimilarElement` class. Also corrects 5 wrong NEEDS lines in the proposition tracker that wrongly attributed `polygon;similar` / `line;similar` usage to `point;similar`. Verified against defIII11. Unlocks 3 propositions.

## What's in this branch

- `6b8f478` point-similar: step 3 — add original.html from defIII11
- `4d829c9` point-similar: step 4 — add SimilarElement.ts
- `038a0c7` point-similar: step 5 — wire SimilarPointConstruction
- `1cd332b` point-similar: step 6 — Mocha tests
- `ad61831` point-similar: step 7 — three-way view pair (TS page + applet.html)
- `0bce60d` point-similar: step 8 — tracker + journal updates + NEEDS-line corrections

Step 8 carries a substantial doc correction: 5 proposition-tracker NEEDS lines were wrong (I.23, I.24, I.26, I.31, III.14 listed `point;similar` but actually use `polygon;similar` or `line;similar`). III.26–III.29 correctly use `point;similar` but are still blocked by the 3-point `circle;radius` variant (TBD).

## Construction details

- **Element class**: `src/elements/point/SimilarElement.ts` — extends `PointElement`. Constructor `(A, B, AP, D, E, F, Q)`. `update()` calls `this.toSimilar(A, B, AP, D, E, F, Q)` — the math (angle rotation + distance scaling) already lived on `PointElement` from a prior port.
- **Construction class**: `SimilarPointConstruction` in `src/elements/Constructions.ts` — 2D signature `[PointElement × 5]`, both planes default to `screen`. Dispatches to `PointConstructions.similar = 15`. 3D variant (7 params with explicit PlaneElements) deferred; no ordering hazard since lengths differ.
- **Java source**: `Similar.java` — 10 lines, line-for-line port.

## Tests

25 → **27 passing**. Two new tests:

- `should compute a similar point with factor=1 (isosceles right triangle)` — θ=π/2, |DF|/|DE|=1, C=(50,300), |AC|/|AB|=1.0.
- `should compute a similar point with factor=0.5 (non-isosceles right triangle)` — θ=π/2, |DF|/|DE|=0.5, C=(50,250), |AC|/|AB|=0.5.

## Verification

- [x] `npm run build` clean
- [x] `npm test` passes (27/27)
- [x] `npx webpack` rebuilds `dist/bundle.js`
- [x] Three-way harness (`./run_euclid_applet.sh` → pick `point;similar`) — **needs human verification**
- [x] Drag C on the left circle; F on the right should track to maintain similarity. Drag E to change right-circle radius; F should scale accordingly

## Newly renderable propositions

- **Book I** (24 → 25): I.42
- **Book III** (29 → 31): III.33, III.34
- **I–III total** (55 → 58): +3

III.26–III.29 use `point;similar` but remain blocked by the 3-point `circle;radius` variant (TBD).

## Discovered / out of scope

- **Clean verifiers existed all along**: defIII11 and propIII33 both have `point;similar` with all preceding elements IMPL. The "no clean verifier" claim in the startup menu was wrong — it was based on the tracker's incorrect NEEDS lines pointing at I.23/I.31 (which use polygon/line;similar), not the actual point;similar propositions.
- **5 NEEDS-line corrections**: I.23→polygon;similar, I.24→polygon;similar, I.26→polygon;similar, I.31→line;similar, III.14→polygon;similar. All corrected in this branch. Root cause: `Similar.java` handles point, line, AND polygon variants via the same class name, and the tracker naively assumed all mapped to `point;similar`.
- **3-point `circle;radius` is a key remaining blocker**: III.24, III.26–III.29 all use `circle;radius;A,B,C` (circle at A with radius |BC|). This 3-point variant is TBD and blocks 5 Book III propositions. Landing it would be high-impact.
