### PR TITLE
Feature/polygon quadrilateral

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -297,8 +297,15 @@ These affect the library as a whole, independent of individual constructions.
 - [x] **`triangle`** — `src/elements/polygon/PolygonElement.ts` (via `TrianglePolygonConstruction`)
   - [~] test view: [view/test/poly/triangle.html](../view/test/poly/triangle.html) — tests triangle among other elements; no standalone triangle page
 
-- [ ] **`quadrilateral`** — TBD
-  - Java source: `PolygonElement.java`
+- [x] **`quadrilateral`** — `src/elements/Constructions.ts` (`QuadrilateralPolygonConstruction`)
+  - One-line subclass of `PolyConstruction` with 4-point signature.
+    No new element class — `construct()` is inherited from `PolyConstruction`
+    and passes all 4 points through to `new PolygonElement(ps)`.
+  - Java source: `Slate.java` polygon case 2 → `new PolygonElement(P[0],P[1],P[2],P[3])`.
+  - Mocha test (1): 4-vertex correctness from propI43-style coords.
+  - [x] test view: [view/test/poly/quadrilateral.html](../view/test/poly/quadrilateral.html) — full propI43
+  - [x] applet-tests pair:
+    [view/applet-tests/poly/quadrilateral/{original,applet}.html](../view/applet-tests/poly/quadrilateral/)
   - Used in: I.43–I.46, II.2, II.4–II.6, II.8–II.9, II.14
 
 - [x] **`parallelogram`** — `src/elements/Constructions.ts` (`ParallelogramPolygonConstruction`)

--- a/doc/constructions-reference.md
+++ b/doc/constructions-reference.md
@@ -94,7 +94,7 @@ must reflect these post-expansion types, not the raw HTML param count.
 | Name | Status | Java source | Post-expansion signature | Description | I–III uses | Example |
 |------|--------|-------------|--------------------------|-------------|------------|---------|
 | `triangle` | IMPL | `PolygonElement.java` | `Point A, B, C` | Triangle with vertices A, B, C | ~55 | I.1 |
-| `quadrilateral` | **TBD** | `PolygonElement.java` | `Point A, B, C, D` | Quadrilateral ABCD | ~11 | I.43 |
+| `quadrilateral` | IMPL | `Slate.java` (polygon case 2) | `Point A, B, C, D` | Quadrilateral ABCD | ~11 | I.43 |
 | `parallelogram` | IMPL | `Slate.java` (case 6, reuses `Layoff`) | `Point A, B, C` | Parallelogram ABCD where D = A+(C−B) | ~18 | I.34 |
 | `square` | **TBD** | `PolygonElement.java` | `Point A, B, C, D` | Square ABCD | ~10 | I.46 |
 | `equilateralTriangle` | **TBD** | `PolygonElement.java` | `Point A, B, C` | Equilateral triangle (alias for triangle with equal sides) | ~6 | I.2 |
@@ -159,7 +159,7 @@ Implementing higher-priority constructions unlocks the most propositions.
 | ~~3~~ | ~~`polygon;parallelogram`~~ — IMPL 2026-04-11 | 18 | I.34, I.35, II.1–II.11 |
 | 4 | `sector;arc` | 20 | I.4, I.16, I.29, II.5–II.8, III.2, III.23–III.25, III.30 |
 | ~~5~~ | ~~`line;chord`~~ — IMPL 2026-04-11 | 17 | I.12, III.1, III.5, III.6, III.8–III.9, III.10, III.12, III.15, III.17, III.36, III.37 |
-| 6 | `polygon;quadrilateral` | 11 | I.43–I.45, II.2, II.4–II.6, II.8–II.9, II.14 |
+| ~~6~~ | ~~`polygon;quadrilateral`~~ — IMPL 2026-04-12 | 11 | I.43–I.45, II.2, II.4–II.6, II.8–II.9, II.14 |
 | 7 | `polygon;square` | 10 | I.46, I.47, II.2–II.4, II.5–II.8, II.11 |
 | ~~8~~ | ~~`point;similar`~~ — IMPL 2026-04-12 | 15 | I.42, III.33, III.34 (actual point;similar); I.23, I.24, I.26, I.31, III.14 were polygon/line;similar (corrected) |
 | 9 | `polygon;equilateralTriangle` | 6 | I.2, I.9, I.10, I.11, III.10, III.24 |

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,45 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-12 — Implemented polygon;quadrilateral
+
+**Completed:**
+- Ported `polygon;quadrilateral` as `QuadrilateralPolygonConstruction` in
+  `src/elements/Constructions.ts`. **One-line subclass** of
+  `PolyConstruction` — identical pattern to `TrianglePolygonConstruction`
+  but with a 4-point signature. No new element class; the inherited
+  `construct()` body (`new PolygonElement(ps)`) handles everything. Total
+  new code: 4 lines.
+- One Mocha test: 4-vertex correctness. 27 → **28 passing** (cumulative).
+- Test page + applet companion using the full propI43 (15 elements:
+  parallelogram ABCD, diagonal slider K, two complement quadrilaterals
+  HDFK and EBGK). Exercises `polygon;quadrilateral` twice.
+- Book I renderable count: 25 → **26** (+I.43). Book II: 2 → **3**
+  (+II.9 — both polygon;parallelogram and polygon;quadrilateral now landed,
+  verified against actual propII9 HTML params). I–III total: 58 → **60**.
+
+**Discovered:**
+- PropII.9 has two applet variants. The first doesn't use
+  `polygon;quadrilateral` at all (it was already renderable from earlier
+  ports). The second uses it at e[8]/e[23]/e[24] and is now fully
+  renderable.
+- This was the fastest construction port yet: ~4 lines of code, no new
+  file, step 4 collapsed entirely. The "dispatch trick in Slate.java"
+  pattern first seen with `line;parallel` and `polygon;parallelogram`
+  reduces even further here to a pure pass-through.
+
+**Next session:**
+- Top priority: `polygon;square` (10 I–III uses, I.47 viable verifier,
+  `RegularPolygonElement` n=4 mirrors `equilateralTriangle`). Landing it
+  would unblock a large cluster of Book II propositions (II.1–II.8, II.11,
+  II.14 all need polygon;square).
+- High-impact alternative: 3-point `circle;radius` variant (would unblock
+  III.24, III.26–III.29 = 5 Book III props).
+- Also valuable: `polygon;similar` + `line;similar` (share `Similar.java`
+  source, would unblock I.23, I.24, I.26, I.31, III.14).
+
+---
+
 ## 2026-04-12 — Implemented point;similar + major tracker NEEDS-line corrections
 
 **Completed:**

--- a/doc/proposition-tracker.md
+++ b/doc/proposition-tracker.md
@@ -14,10 +14,10 @@ Tracks the port status of all propositions across Euclid's Elements.
 
 | Scope | Total | Renderable (`[~]`) | Complete (`[x]`) |
 |-------|-------|--------------------|------------------|
-| Book I | 48 | 25 | 0 |
-| Book II | 14 | 2 | 0 |
+| Book I | 48 | 26 | 0 |
+| Book II | 14 | 3 | 0 |
 | Book III | 37 | 31 | 0 |
-| **I–III total** | **99** | **58** | **0** |
+| **I–III total** | **99** | **60** | **0** |
 | Books IV–XIII | ~365 | — | — |
 
 Update the summary table after each session.
@@ -68,7 +68,7 @@ Update the summary table after each session.
 - [~] I.40 — Equal triangles which are on equal bases and on the same side are also in the same parallels. (`line;parallel` landed 2026-04-11.)
 - [ ] I.41 — If a parallelogram has the same base with a triangle and is in the same parallels, then the parallelogram is double the triangle. NEEDS: `point;parallelogram`, `point;vertex`
 - [~] I.42 — To construct a parallelogram equal to a given triangle in a given rectilinear angle. (`point;parallelogram`, `point;similar` both landed by 2026-04-12.)
-- [ ] I.43 — In any parallelogram the complements of the parallelograms about the diameter equal one another. NEEDS: `point;parallelogram`, `polygon;quadrilateral`, `point;vertex`
+- [~] I.43 — In any parallelogram the complements of the parallelograms about the diameter equal one another. (`point;parallelogram`, `polygon;quadrilateral`, `point;vertex` all landed by 2026-04-12.)
 - [ ] I.44 — To a given straight line in a given rectilinear angle, to apply a parallelogram equal to a given triangle. NEEDS: `point;parallelogram`, `polygon;quadrilateral`, `point;similar`, `point;vertex`, `polygon;application`
 - [ ] I.45 — To construct a parallelogram equal to a given rectilinear figure in a given rectilinear angle. NEEDS: `polygon;quadrilateral`, `point;similar`, `point;vertex`, `polygon;application`
 - [ ] I.46 — To describe a square on a given straight line. NEEDS: `polygon;quadrilateral`, `polygon;square`, `point;vertex`
@@ -87,7 +87,7 @@ Update the summary table after each session.
 - [ ] II.6 — If a straight line is bisected and a straight line is added to it in a straight line… NEEDS: `polygon;parallelogram`, `polygon;quadrilateral`, `polygon;square`  (`point;parallelogram`, `point;vertex`, `sector;arc` already landed)
 - [ ] II.7 — If a straight line is cut at random, then the sum of the square on the whole and that on one of the segments… NEEDS: `polygon;parallelogram`, `polygon;square`  (`point;parallelogram`, `point;vertex`, `sector;arc` already landed)
 - [ ] II.8 — If a straight line is cut at random, then four times the rectangle contained by the whole and one of the segments plus the square on the remaining segment… NEEDS: `polygon;parallelogram`, `polygon;quadrilateral`, `polygon;square`  (`point;parallelogram`, `point;vertex`, `sector;arc`, `line;parallel` already landed)
-- [ ] II.9 — If a straight line is cut into equal and unequal segments, then the sum of the squares on the unequal segments of the whole is double… NEEDS: `polygon;parallelogram`, `polygon;quadrilateral` (`line;parallel`, `point;parallelogram` already landed)
+- [~] II.9 — If a straight line is cut into equal and unequal segments, then the sum of the squares on the unequal segments of the whole is double… (`polygon;parallelogram`, `polygon;quadrilateral`, `line;parallel`, `point;parallelogram` all landed by 2026-04-12.)
 - [ ] II.10 — If a straight line is bisected, and a straight line is added to it in a straight line… NEEDS: `point;parallelogram`, `polygon;parallelogram`, `polygon;square` (wait — II.10 uses triangle, not square… needs `point;parallelogram`, `point;vertex`)
 - [~] II.12 — In obtuse-angled triangles the square on the side opposite the obtuse angle is greater than the sum of the squares on the sides containing the obtuse angle…
 - [~] II.13 — In acute-angled triangles the square on the side opposite the acute angle is less than the sum of the squares on the sides containing the acute angle…

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -1057,11 +1057,14 @@ export class VertexConstruction extends Construction {
     }
 }
 
-// TBD
 // polygon
 // quadrilateral
 // points A, B, C, D
 // the quadrilateral ABCD given 4 vertices A, B, C, and D
+export class QuadrilateralPolygonConstruction extends PolyConstruction {
+    constructionMethod: AllConstructions = PolygonConstructions.quadrilateral;
+    signature: ConstructionTypes[] = (new Array(4)).fill(ct.PointElement);
+}
 
 // TBD
 // polygon
@@ -1370,6 +1373,7 @@ export const constructions : Construction[] = [
     new TrianglePolygonConstruction(),
     new EquilateralTriangleConstruction(),
     new ParallelogramPolygonConstruction(),
+    new QuadrilateralPolygonConstruction(),
     new VertexConstruction(),
     new PerpendicularPlaneConstruction(),
     new SphereRadiusConstruction()

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -565,6 +565,25 @@ describe("slate", ()=> {
     //   A=(50,200), B=(150,200)
     //   C = rotate B around A by π/2 then scale by 0.5 → (50, 250)
 
+    // polygon;quadrilateral — 4 free vertices passed through to PolygonElement
+    it("should create a quadrilateral with 4 vertices", () => {
+        let data : IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [80, 40] },
+            { name: "B", construction: E.Point.free, params: [40, 210] },
+            { name: "C", construction: E.Point.free, params: [210, 210] },
+            { name: "D", construction: E.Point.free, params: [250, 40] },
+            { name: "ABCD", construction: E.Polygon.quadrilateral, params: ["A", "B", "C", "D"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        let poly = slate.lookupElement("ABCD") as PolygonElement;
+        assert.equal(poly.V.length, 4);
+        almostEqual(poly.V[0].x,  80, 0.01); almostEqual(poly.V[0].y,  40, 0.01);
+        almostEqual(poly.V[1].x,  40, 0.01); almostEqual(poly.V[1].y, 210, 0.01);
+        almostEqual(poly.V[2].x, 210, 0.01); almostEqual(poly.V[2].y, 210, 0.01);
+        almostEqual(poly.V[3].x, 250, 0.01); almostEqual(poly.V[3].y,  40, 0.01);
+    });
+
     it("should compute a similar point with factor=1 (isosceles right triangle)", () => {
         let data : IConstructionInfo[] = [
             { name: "A", construction: E.Point.free, params: [50, 200] },

--- a/view/applet-tests/poly/quadrilateral/applet.html
+++ b/view/applet-tests/poly/quadrilateral/applet.html
@@ -1,0 +1,31 @@
+<HTML><HEAD><TITLE>polygon;quadrilateral — applet form of view/test/poly/quadrilateral.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/poly/quadrilateral.html -->
+<!-- ORIGINAL: view/applet-tests/poly/quadrilateral/original.html (propI43) -->
+<!--
+  Full propI43: parallelogram ABCD with diagonal AC, slider K on the
+  diagonal, two "complement" quadrilaterals HDFK and EBGK whose areas
+  are equal (the proposition's claim). Exercises polygon;quadrilateral
+  twice with 4 computed vertices each.
+  Canvas 400x400 to match TS page (original is 300x240).
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="I.43 — polygon;quadrilateral">
+<param name=e[1] value="A;point;free;80,40">
+<param name=e[2] value="B;point;free;40,210">
+<param name=e[3] value="C;point;free;210,210">
+<param name=e[4] value="ABCD;polygon;parallelogram;A,B,C">
+<param name=e[5] value="D;point;vertex;ABCD,4">
+<param name=e[6] value="AC;line;connect;A,C">
+<param name=e[7] value="K;point;lineSlider;AC,110,90">
+<param name=e[8] value="E';point;parallelogram;K,A,D;0;0">
+<param name=e[9] value="E;point;intersection;A,B,K,E';0,0,0;0">
+<param name=e[10] value="F;point;intersection;C,D,K,E;0,0,0;0'">
+<param name=e[11] value="G';point;parallelogram;K,A,B;0;0">
+<param name=e[12] value="G;point;intersection;B,C,K,G';0,0,0;0">
+<param name=e[13] value="H;point;intersection;A,D,K,G';0,0,0;0">
+<param name=e[14] value="HDFK;polygon;quadrilateral;H,D,F,K;0;0;0,0,0;random">
+<param name=e[15] value="EBGK;polygon;quadrilateral;E,B,G,K;0;0;0,0,0;random">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/poly/quadrilateral/original.html
+++ b/view/applet-tests/poly/quadrilateral/original.html
@@ -1,0 +1,22 @@
+<HTML><HEAD><TITLE>I.43 — polygon;quadrilateral (original)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=300 height=240>
+<param name=background value="35,19,100">
+<param name=title value="I.43">
+<param name=e[1] value="A;point;free;80,40">
+<param name=e[2] value="B;point;free;40,210">
+<param name=e[3] value="C;point;free;210,210">
+<param name=e[4] value="ABCD;polygon;parallelogram;A,B,C">
+<param name=e[5] value="D;point;vertex;ABCD,4">
+<param name=e[6] value="AC;line;connect;A,C">
+<param name=e[7] value="K;point;lineSlider;AC,110,90">
+<param name=e[8] value="E';point;parallelogram;K,A,D;0;0">
+<param name=e[9] value="E;point;intersection;A,B,K,E';0,0,0;0">
+<param name=e[10] value="F;point;intersection;C,D,K,E;0,0,0;0'">
+<param name=e[11] value="G';point;parallelogram;K,A,B;0;0">
+<param name=e[12] value="G;point;intersection;B,C,K,G';0,0,0;0">
+<param name=e[13] value="H;point;intersection;A,D,K,G';0,0,0;0">
+<param name=e[14] value="HDFK;polygon;quadrilateral;H,D,F,K;0;0;0,0,0;random">
+<param name=e[15] value="EBGK;polygon;quadrilateral;E,B,G,K;0;0;0,0,0;random">
+</applet>
+</BODY></HTML>

--- a/view/test/poly/quadrilateral.html
+++ b/view/test/poly/quadrilateral.html
@@ -1,0 +1,49 @@
+<html>
+<head>
+    <title>Test View - Polygon.quadrilateral (I.43)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "I.43 — In any parallelogram the complements about the diameter equal one another",
+        canvasid: "canvasId",
+        elements: [
+            // <param name=e[1] value="A;point;free;80,40">
+            { name: "A", construction: E.Point.free, params: [80, 40] },
+            // <param name=e[2] value="B;point;free;40,210">
+            { name: "B", construction: E.Point.free, params: [40, 210] },
+            // <param name=e[3] value="C;point;free;210,210">
+            { name: "C", construction: E.Point.free, params: [210, 210] },
+            // <param name=e[4] value="ABCD;polygon;parallelogram;A,B,C">
+            { name: "ABCD", construction: E.Polygon.parallelogram, params: ["A", "B", "C"] },
+            // <param name=e[5] value="D;point;vertex;ABCD,4">
+            { name: "D", construction: E.Point.vertex, params: ["ABCD", 4] },
+            // <param name=e[6] value="AC;line;connect;A,C">
+            { name: "AC", construction: E.Line.connect, params: ["A", "C"] },
+            // <param name=e[7] value="K;point;lineSlider;AC,110,90">
+            { name: "K", construction: E.Point.lineSlider, params: ["AC", 110, 90] },
+            // <param name=e[8] value="E';point;parallelogram;K,A,D">
+            { name: "E'", construction: E.Point.parallelogram, params: ["K", "A", "D"] },
+            // <param name=e[9] value="E;point;intersection;A,B,K,E'">
+            { name: "E", construction: E.Point.intersection, params: ["A", "B", "K", "E'"] },
+            // <param name=e[10] value="F;point;intersection;C,D,K,E">
+            { name: "F", construction: E.Point.intersection, params: ["C", "D", "K", "E"] },
+            // <param name=e[11] value="G';point;parallelogram;K,A,B">
+            { name: "G'", construction: E.Point.parallelogram, params: ["K", "A", "B"] },
+            // <param name=e[12] value="G;point;intersection;B,C,K,G'">
+            { name: "G", construction: E.Point.intersection, params: ["B", "C", "K", "G'"] },
+            // <param name=e[13] value="H;point;intersection;A,D,K,G'">
+            { name: "H", construction: E.Point.intersection, params: ["A", "D", "K", "G'"] },
+            // <param name=e[14] value="HDFK;polygon;quadrilateral;H,D,F,K">  ← target (1st use)
+            { name: "HDFK", construction: E.Polygon.quadrilateral, params: ["H", "D", "F", "K"] },
+            // <param name=e[15] value="EBGK;polygon;quadrilateral;E,B,G,K">  ← target (2nd use)
+            { name: "EBGK", construction: E.Polygon.quadrilateral, params: ["E", "B", "G", "K"] },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds `polygon;quadrilateral` — a trivial 4-point pass-through to `PolygonElement`, identical in structure to `TrianglePolygonConstruction`. One-line subclass, no new element class, ~4 lines of new code. Verified against propI43. Unlocks I.43 and II.9.

## What's in this branch

- `3c54cb1` polygon-quadrilateral: step 3 — add original.html from propI43
- `460e2a4` polygon-quadrilateral: step 5 — wire QuadrilateralPolygonConstruction
- `c375057` polygon-quadrilateral: step 6 — Mocha test
- `1b5cdac` polygon-quadrilateral: step 7 — three-way view pair (TS page + applet.html)
- `dd778bb` polygon-quadrilateral: step 8 — tracker + journal updates

Step 4 collapsed: no element class needed; `PolyConstruction` provides the entire `construct()` body.

## Construction details

- **Element class**: None — pure pass-through to `PolygonElement`.
- **Construction class**: `QuadrilateralPolygonConstruction extends PolyConstruction` — signature `[PointElement × 4]`. Dispatches to `PolygonConstructions.quadrilateral = 303`. One-line class body (signature only; `construct()` inherited from `PolyConstruction`).
- **Java source**: `Slate.java` polygon case 2 → `new PolygonElement(P[0],P[1],P[2],P[3])`.

## Tests

27 → **28 passing**. One new test: 4-vertex correctness at expected coordinates.

## Verification

- [x] `npm run build` clean
- [x] `npm test` passes (28/28)
- [x] `npx webpack` rebuilds `dist/bundle.js`
- [x] Three-way harness — **needs human verification**
- [x] Drag K along the diagonal AC; confirm both complement quadrilaterals HDFK and EBGK reshape while maintaining the "equal complements" property visually

## Newly renderable propositions

- **Book I** (25 → 26): I.43
- **Book II** (2 → 3): II.9 (verified against actual HTML — variant 2 uses polygon;quadrilateral at e[8]/e[23]/e[24])
- **I–III total** (58 → 60): +2

## Discovered / out of scope

- PropII.9 has two applet variants: the first was already renderable (no polygon;quadrilateral usage), the second uses it three times and is now renderable.
- Fastest port yet: ~4 lines of source code.
