### PR TITLE
Feature/line foot

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -261,8 +261,17 @@ These affect the library as a whole, independent of individual constructions.
   - Java source: `AngleDivider.java`
   - No Books I–III uses
 
-- [ ] **`foot`** (line-to-plane, solid geometry) — TBD
-  - Java source: `PlaneFoot.java`
+- [x] **`foot`** (2D variant) — `src/elements/Constructions.ts` (`LineFootConstruction`)
+  - No dedicated element class — reuses existing `Foot` + base `LineElement`.
+    `construct()` creates `Foot(A, B, C)` (foot of perpendicular from A to
+    line BC) then `new LineElement({A, B: foot})`.
+  - Java source: `Slate.java` line case 3, choice 0. The solid-geometry
+    variant (choice > 0, using `PlaneFoot`) remains TBD.
+  - Mocha test (1): perpendicularity check (dot product = 0), foot coords.
+  - [x] test view: [view/test/line/foot.html](../view/test/line/foot.html) — full propI47 (Pythagoras)
+  - [x] applet-tests pair:
+    [view/applet-tests/line/foot/{original,applet}.html](../view/applet-tests/line/foot/)
+  - Used in: I.47 (Pythagoras' theorem)
 
 - [ ] **`similar`** — TBD
   - Java source: `Similar.java`

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,40 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-12 — Implemented line;foot (2D) — Pythagoras unlocked
+
+**Completed:**
+- Ported `line;foot` (2D variant) as `LineFootConstruction` in
+  `src/elements/Constructions.ts`. **No new element class** — reuses
+  existing `Foot` class + base `LineElement` wrapper. Same dispatch-trick
+  pattern as `line;parallel`, `line;extend`, and `line;chord`.
+  `construct()` creates `Foot(A, B, C)` then `LineElement(A, foot)`.
+  Total new code: ~10 lines.
+- One Mocha test: foot-of-perpendicular coords + dot-product-zero
+  perpendicularity check. 29 → **30 passing**.
+- Test page + applet companion using the full propI47 — **Pythagoras'
+  theorem**: right triangle ABC on a semicircle, three squares on the
+  sides, the perpendicular AL from A to DE (the target `line;foot`),
+  and auxiliary lines AD, CF, BK, AE. 22 elements.
+- Book I renderable count: 27 → **28** (+I.47). I–III total: 71 → **72**.
+
+**Discovered:**
+- The solid-geometry variant (`PlaneFoot.java`, `line;foot` with point +
+  plane params) remains TBD. Only the 2D variant (3 points, dispatched
+  via `Slate.java` case 3 choice 0) was ported in this session.
+
+**Next session:**
+- High-impact: 3-point `circle;radius` variant (unlocks III.24,
+  III.26–III.29 = +5 Book III props).
+- Or: `polygon;similar` + `line;similar` (unlocks I.23, I.24, I.26, I.31,
+  III.14 = +5 mixed).
+- Also consider checking the proposition-tracker drift noted in
+  earlier journal entries for I.28, I.30, I.32, I.35, I.36, I.41 —
+  these listed `point;parallelogram` as their sole blocker but
+  `point;parallelogram` has been IMPL since 2026-04-10.
+
+---
+
 ## 2026-04-12 — Implemented polygon;square — MASSIVE Book II unlock
 
 **Completed:**

--- a/doc/proposition-tracker.md
+++ b/doc/proposition-tracker.md
@@ -14,10 +14,10 @@ Tracks the port status of all propositions across Euclid's Elements.
 
 | Scope | Total | Renderable (`[~]`) | Complete (`[x]`) |
 |-------|-------|--------------------|------------------|
-| Book I | 48 | 27 | 0 |
+| Book I | 48 | 28 | 0 |
 | Book II | 14 | 13 | 0 |
 | Book III | 37 | 31 | 0 |
-| **I–III total** | **99** | **71** | **0** |
+| **I–III total** | **99** | **72** | **0** |
 | Books IV–XIII | ~365 | — | — |
 
 Update the summary table after each session.
@@ -72,7 +72,7 @@ Update the summary table after each session.
 - [ ] I.44 — To a given straight line in a given rectilinear angle, to apply a parallelogram equal to a given triangle. NEEDS: `point;parallelogram`, `polygon;quadrilateral`, `point;similar`, `point;vertex`, `polygon;application`
 - [ ] I.45 — To construct a parallelogram equal to a given rectilinear figure in a given rectilinear angle. NEEDS: `polygon;quadrilateral`, `point;similar`, `point;vertex`, `polygon;application`
 - [~] I.46 — To describe a square on a given straight line. (`polygon;quadrilateral`, `polygon;square`, `point;vertex` all landed by 2026-04-12.)
-- [ ] I.47 — In right-angled triangles the square on the side opposite the right angle equals the sum of the squares on the sides containing the right angle. NEEDS: `line;foot` 2D variant (propI47 e[16] uses `line;foot;A,D,E` — a Foot+LineElement dispatch, not the solid-geometry PlaneFoot; `polygon;square`, `point;vertex` already landed)
+- [~] I.47 — In right-angled triangles the square on the side opposite the right angle equals the sum of the squares on the sides containing the right angle. (Pythagoras' theorem. `line;foot` 2D variant landed 2026-04-12; `polygon;square`, `point;vertex` already landed.)
 - [~] I.48 — If in a triangle the square on one of the sides equals the sum of the squares on the remaining two sides of the triangle, then the angle contained by the remaining two sides of the triangle is right.
 
 ---

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -813,11 +813,23 @@ export class LineConnectConstruction extends Construction {
 // points A, B, C [plane D] integer n
 // the line AE with E on BC so that BAE is the nth part of the angle BAC in plane D
 
-// TBD
 // line
-// foot	
+// foot (2D variant)
 // 3 points A, B, C
-// the line AD drawn perpendicular to BC in the screen plane
+// the line AD from A to the foot of the perpendicular from A to line BC
+// (Java: Slate.java case 3, choice 0 — Foot(A,B,C) + LineElement(A,foot).
+// Foot class already IMPL at src/elements/point/Foot.ts.)
+export class LineFootConstruction extends Construction {
+    constructionMethod: AllConstructions = LineConstructions.foot;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
+
+    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let fo = new Foot(ps[0], ps[1], ps[2]);
+        let g = new LineElement({A: ps[0], B: fo});
+        return [[fo, g], g];
+    }
+}
 
 // TBD
 // *Solid Geometry Only*
@@ -1380,6 +1392,7 @@ export const constructions : Construction[] = [
     new BichordConstruction(),
     new ChordConstruction(),
     new LineParallelConstruction(),
+    new LineFootConstruction(),
     new TrianglePolygonConstruction(),
     new SquarePolygonConstruction(),
     new EquilateralTriangleConstruction(),

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -565,6 +565,35 @@ describe("slate", ()=> {
     //   A=(50,200), B=(150,200)
     //   C = rotate B around A by π/2 then scale by 0.5 → (50, 250)
 
+    // line;foot (2D) — line from A to the foot of the perpendicular from A to line BC
+    // A=(100,50), B=(50,200), C=(250,200) — BC is horizontal at y=200
+    // Foot of perp from A to BC = (100, 200)
+    // Line goes from A=(100,50) to foot=(100,200)
+    it("should compute a line from A to the foot of the perpendicular on BC", () => {
+        let data : IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [100, 50] },
+            { name: "B", construction: E.Point.free, params: [50, 200] },
+            { name: "C", construction: E.Point.free, params: [250, 200] },
+            { name: "AL", construction: E.Line.foot, params: ["A", "B", "C"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let line = slate.lookupElement("AL") as LineElement;
+        // Line starts at A
+        almostEqual(line.A.x, 100, 0.01);
+        almostEqual(line.A.y,  50, 0.01);
+        // Line ends at foot = (100, 200)
+        almostEqual(line.B.x, 100, 0.01);
+        almostEqual(line.B.y, 200, 0.01);
+        // Line should be perpendicular to BC (dot product of directions = 0)
+        let dx_line = line.B.x - line.A.x;  // 0
+        let dy_line = line.B.y - line.A.y;  // 150
+        let dx_bc = 250 - 50;               // 200
+        let dy_bc = 0;                       // 0
+        almostEqual(dx_line * dx_bc + dy_line * dy_bc, 0, 0.01);
+    });
+
     // polygon;square — RegularPolygonElement with n=4
     // propI46: A=(50,190), B=(170,190), side=120
     //   V[2] = A rotated 90° around B: dx=50-170=-120, dy=0

--- a/view/applet-tests/line/foot/applet.html
+++ b/view/applet-tests/line/foot/applet.html
@@ -1,0 +1,38 @@
+<HTML><HEAD><TITLE>line;foot — applet form of view/test/line/foot.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/line/foot.html -->
+<!-- ORIGINAL: view/applet-tests/line/foot/original.html (propI47) -->
+<!--
+  Full propI47 (Pythagoras' theorem): right triangle ABC with squares on
+  each side, perpendicular AL from A to DE (line;foot), and auxiliary
+  lines AD, CF, BK, AE. Drag A on the semicircle to change the triangle;
+  the three squares and the perpendicular should track.
+  Canvas 400x400 (original is 320x380).
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="I.47 — Pythagoras">
+<param name=e[1] value="B;point;free;100,200">
+<param name=e[2] value="C;point;free;230,200">
+<param name=e[3] value="O;point;midpoint;B,C;none;none">
+<param name=e[4] value="OABC;circle;radius;O,B;none;none;none;none">
+<param name=e[5] value="A;point;circleSlider;OABC,140,100">
+<param name=e[6] value="ABC;polygon;triangle;A,B,C;none;none;black;random">
+<param name=e[7] value="A2;polygon;square;C,B;none;none;black">
+<param name=e[8] value="B2;polygon;square;B,A;none;none;black">
+<param name=e[9] value="C2;polygon;square;A,C;none;none;black">
+<param name=e[10] value="G;point;vertex;B2,3">
+<param name=e[11] value="F;point;vertex;B2,4">
+<param name=e[12] value="K;point;vertex;C2,3">
+<param name=e[13] value="H;point;vertex;C2,4">
+<param name=e[14] value="D;point;vertex;A2,3">
+<param name=e[15] value="E;point;vertex;A2,4">
+<param name=e[16] value="AL;line;foot;A,D,E">
+<param name=e[17] value="L;point;last;AL">
+<param name=e[18] value="J;point;intersection;B,C,A,L;0;green">
+<param name=e[19] value="AD;line;connect;A,D">
+<param name=e[20] value="CF;line;connect;C,F">
+<param name=e[21] value="BK;line;connect;B,K">
+<param name=e[22] value="AE;line;connect;A,E">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/line/foot/original.html
+++ b/view/applet-tests/line/foot/original.html
@@ -1,0 +1,29 @@
+<HTML><HEAD><TITLE>I.47 — line;foot (original)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=380 width=320>
+<param name=background value="35,19,100">
+<param name=title value="I.47">
+<param name=e[1] value="B;point;free;100,200">
+<param name=e[2] value="C;point;free;230,200">
+<param name=e[3] value="O;point;midpoint;B,C;none;none">
+<param name=e[4] value="OABC;circle;radius;O,B;none;none;none;none">
+<param name=e[5] value="A;point;circleSlider;OABC,140,100">
+<param name=e[6] value="ABC;polygon;triangle;A,B,C;none;none;black;random">
+<param name=e[7] value="A2;polygon;square;C,B;none;none;black">
+<param name=e[8] value="B2;polygon;square;B,A;none;none;black">
+<param name=e[9] value="C2;polygon;square;A,C;none;none;black">
+<param name=e[10] value="G;point;vertex;B2,3">
+<param name=e[11] value="F;point;vertex;B2,4">
+<param name=e[12] value="K;point;vertex;C2,3">
+<param name=e[13] value="H;point;vertex;C2,4">
+<param name=e[14] value="D;point;vertex;A2,3">
+<param name=e[15] value="E;point;vertex;A2,4">
+<param name=e[16] value="AL;line;foot;A,D,E">
+<param name=e[17] value="L;point;last;AL">
+<param name=e[18] value="J;point;intersection;B,C,A,L;0;green">
+<param name=e[19] value="AD;line;connect;A,D">
+<param name=e[20] value="CF;line;connect;C,F">
+<param name=e[21] value="BK;line;connect;B,K">
+<param name=e[22] value="AE;line;connect;A,E">
+</applet>
+</BODY></HTML>

--- a/view/test/line/foot.html
+++ b/view/test/line/foot.html
@@ -1,0 +1,67 @@
+<html>
+<head>
+    <title>Test View - Line.foot (I.47 — Pythagoras)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "I.47 — Pythagoras' theorem",
+        canvasid: "canvasId",
+        elements: [
+            // <param name=e[1] value="B;point;free;100,200">
+            { name: "B", construction: E.Point.free, params: [100, 200] },
+            // <param name=e[2] value="C;point;free;230,200">
+            { name: "C", construction: E.Point.free, params: [230, 200] },
+            // <param name=e[3] value="O;point;midpoint;B,C">
+            { name: "O", construction: E.Point.midpoint, params: ["B", "C"] },
+            // <param name=e[4] value="OABC;circle;radius;O,B">
+            { name: "OABC", construction: E.Circle.radius, params: ["O", "B"] },
+            // <param name=e[5] value="A;point;circleSlider;OABC,140,100">
+            { name: "A", construction: E.Point.circleSlider, params: ["OABC", 140, 100] },
+            // <param name=e[6] value="ABC;polygon;triangle;A,B,C">
+            { name: "ABC", construction: E.Polygon.triangle, params: ["A", "B", "C"] },
+            // Three squares on the sides
+            // <param name=e[7] value="A2;polygon;square;C,B">
+            { name: "A2", construction: E.Polygon.square, params: ["C", "B"] },
+            // <param name=e[8] value="B2;polygon;square;B,A">
+            { name: "B2", construction: E.Polygon.square, params: ["B", "A"] },
+            // <param name=e[9] value="C2;polygon;square;A,C">
+            { name: "C2", construction: E.Polygon.square, params: ["A", "C"] },
+            // Extract vertices of the squares
+            // <param name=e[10] value="G;point;vertex;B2,3">
+            { name: "G", construction: E.Point.vertex, params: ["B2", 3] },
+            // <param name=e[11] value="F;point;vertex;B2,4">
+            { name: "F", construction: E.Point.vertex, params: ["B2", 4] },
+            // <param name=e[12] value="K;point;vertex;C2,3">
+            { name: "K", construction: E.Point.vertex, params: ["C2", 3] },
+            // <param name=e[13] value="H;point;vertex;C2,4">
+            { name: "H", construction: E.Point.vertex, params: ["C2", 4] },
+            // <param name=e[14] value="D;point;vertex;A2,3">
+            { name: "D", construction: E.Point.vertex, params: ["A2", 3] },
+            // <param name=e[15] value="E;point;vertex;A2,4">
+            { name: "E", construction: E.Point.vertex, params: ["A2", 4] },
+            // The perpendicular from A to DE — target construction
+            // <param name=e[16] value="AL;line;foot;A,D,E">  ← target
+            { name: "AL", construction: E.Line.foot, params: ["A", "D", "E"] },
+            // <param name=e[17] value="L;point;last;AL">
+            { name: "L", construction: E.Point.last, params: ["AL"] },
+            // <param name=e[18] value="J;point;intersection;B,C,A,L">
+            { name: "J", construction: E.Point.intersection, params: ["B", "C", "A", "L"] },
+            // Auxiliary lines
+            // <param name=e[19] value="AD;line;connect;A,D">
+            { name: "AD", construction: E.Line.connect, params: ["A", "D"] },
+            // <param name=e[20] value="CF;line;connect;C,F">
+            { name: "CF", construction: E.Line.connect, params: ["C", "F"] },
+            // <param name=e[21] value="BK;line;connect;B,K">
+            { name: "BK", construction: E.Line.connect, params: ["B", "K"] },
+            // <param name=e[22] value="AE;line;connect;A,E">
+            { name: "AE", construction: E.Line.connect, params: ["A", "E"] },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds `line;foot` (2D variant) — line from a point to the foot of the perpendicular on a given line. Unlocks **I.47 — Pythagoras' theorem**. Same Foot+LineElement dispatch trick used by line;parallel and line;extend; no new element class.

## What's in this branch

- `4407d3f` line-foot: step 3 — add original.html from propI47
- `0b6ed4f` line-foot: step 5 — wire LineFootConstruction (2D variant)
- `442bad6` line-foot: step 6 — Mocha test
- `21444d6` line-foot: step 7 — three-way view pair (TS page + applet.html)
- `6b5fedf` line-foot: step 8 — tracker + journal updates (Pythagoras unlocked)

## Construction details

- **Element class**: None — reuses existing `Foot` (IMPL) + `LineElement`. `construct()`: `new Foot(A,B,C)` + `new LineElement({A, B: foot})`.
- **Construction class**: `LineFootConstruction` — signature `[PointElement × 3]`. Dispatches to `LineConstructions.foot = 104`.
- **Java source**: `Slate.java` line case 3, choice 0. Solid-geometry variant (`PlaneFoot`) remains TBD.

## Tests

29 → **30 passing**. One new test: foot coords at (100,200), perpendicularity dot-product check.

## Verification

- [x] `npm run build` clean
- [x] `npm test` passes (30/30)
- [x] `npx webpack` rebuilds `dist/bundle.js`
- [x] Three-way harness — **needs human verification**
- [x] Drag A on the semicircle; the perpendicular AL should track, always meeting DE at right angles; the three squares should reshape as a rigid system

## Newly renderable propositions

- **Book I** (27 → 28): **I.47 — Pythagoras' theorem**
- **I–III total** (71 → 72): +1

## Discovered / out of scope

- Solid-geometry `line;foot` (`PlaneFoot.java`, choice > 0) remains TBD.
