### PR TITLE
Feature/circle radius 3pt

### DIFF
--- a/doc/constructions-reference.md
+++ b/doc/constructions-reference.md
@@ -83,7 +83,7 @@ must reflect these post-expansion types, not the raw HTML param count.
 
 | Name | Status | Java source | Post-expansion signature | Description | I–III uses | Example |
 |------|--------|-------------|--------------------------|-------------|------------|---------|
-| `radius` | IMPL | — | `Point center, Point edge` | Circle with given center and radius point | ~60 | I.1 |
+| `radius` | IMPL | — | `Point center, Point edge [, Point C]` | Circle with center and radius; 2-point (radius=\|center-edge\|) and 3-point (radius=\|edge-C\|) variants | ~60 | I.1 |
 | `circumcircle` | IMPL | `Circumcircle.java` | `Point A, B, C [, Plane]` | Circle through three points (2D and 3D) | ~6 | III.25 |
 | `invert` | **TBD** | `InvertCircle.java` | `Circle A, Circle B` | Inversion of circle A in circle B | 0 | — |
 

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,45 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-12 — Implemented 3-point circle;radius variant
+
+**Completed:**
+- Added `CircleRadius3PointConstruction` to `src/elements/Constructions.ts`
+  — a new signature variant `[PointElement × 3]` for the existing
+  `circle;radius` construction. The 3-point form creates a circle at
+  center=P[0] with radius=|P[1]−P[2]| (distance between two arbitrary
+  points, not from center to edge). Registered BEFORE the 2-point variant
+  per the signature-ordering rule (longer signature first).
+- Updated `CircleElement.ts` to support an optional `A` parameter in the
+  constructor interface, per the "full Java class conversion" rule: when
+  `A` is provided, `radius = A.distance(B)` (3-point form); when omitted,
+  `A = Center` (2-point form, backward-compatible).
+- One Mocha test: propIII26 coords (center H=(340,115), radius-defining
+  points G=(120,115) and A=(75,30), expected radius ≈ 96.177). 30 → **31
+  passing**.
+- Test page + applet companion using the full propIII26 — two equal circles
+  (left = 2-point, right = 3-point form), inscribed triangles, sectors,
+  and the similar-point construction for vertex F.
+- Book III renderable count: 31 → **36** (+III.24, III.26, III.27, III.28,
+  III.29). I–III total: 72 → **77**.
+
+**Discovered:**
+- propIII24's `circle;radius;C,AB` param has `AB` as a LineElement, which
+  expands to 2 PointElements — making it a 3-point circle;radius call
+  (center C, radius=|A−B|). The LineElement expansion rule from AGENTS.md
+  applies here too.
+- The 3D variants (2-point with explicit PlaneElement, 3-point with
+  explicit PlaneElement) remain TBD — deferred per 2D-first policy.
+
+**Next session:**
+- `polygon;similar` + `line;similar` (unlocks I.23, I.24, I.26, I.31,
+  III.14 = +5). Share `Similar.java` with `point;similar`.
+- Tracker drift fix for I.28, I.30, I.32, I.35, I.36, I.41 (should be
+  renderable since `point;parallelogram` has been IMPL since 2026-04-10).
+- `point;proportion` (4 I–III uses, unlocks I.16, I.29).
+
+---
+
 ## 2026-04-12 — Implemented line;foot (2D) — Pythagoras unlocked
 
 **Completed:**

--- a/doc/proposition-tracker.md
+++ b/doc/proposition-tracker.md
@@ -16,8 +16,8 @@ Tracks the port status of all propositions across Euclid's Elements.
 |-------|-------|--------------------|------------------|
 | Book I | 48 | 28 | 0 |
 | Book II | 14 | 13 | 0 |
-| Book III | 37 | 31 | 0 |
-| **I–III total** | **99** | **72** | **0** |
+| Book III | 37 | 36 | 0 |
+| **I–III total** | **99** | **77** | **0** |
 | Books IV–XIII | ~365 | — | — |
 
 Update the summary table after each session.
@@ -121,12 +121,12 @@ Update the summary table after each session.
 - [~] III.21 — In a circle the angles in the same segment equal one another.
 - [~] III.22 — The sum of the opposite angles of quadrilaterals in circles equals two right angles.
 - [~] III.23 — On the same straight line there cannot be constructed two similar and unequal segments of circles on the same side. (sector;arc landed 2026-04-11.)
-- [ ] III.24 — Similar segments of circles on equal straight lines equal one another. NEEDS: `point;similar`  (`polygon;equilateralTriangle`, `point;vertex`, `sector;arc` already landed)
+- [~] III.24 — Similar segments of circles on equal straight lines equal one another. (3-point `circle;radius`, `point;similar`, `polygon;equilateralTriangle`, `point;vertex`, `sector;arc` all landed by 2026-04-12.)
 - [~] III.25 — Given a segment of a circle, to describe the complete circle of which it is a segment. (sector;arc landed 2026-04-11.)
-- [ ] III.26 — In equal circles equal angles stand on equal circumferences whether they stand at the centers or at the circumferences. NEEDS: `circle;radius` 3-point variant (`point;similar` landed 2026-04-12 but e[7] uses 3-point circle;radius which is TBD)
-- [ ] III.27 — In equal circles angles standing on equal circumferences equal one another whether they stand at the centers or at the circumferences. NEEDS: `circle;radius` 3-point variant (same blocker as III.26)
-- [ ] III.28 — In equal circles equal straight lines cut off equal circumferences, the greater circumference equals the greater and the less equals the less. NEEDS: `circle;radius` 3-point variant (same blocker as III.26)
-- [ ] III.29 — In equal circles straight lines that cut off equal circumferences are equal. NEEDS: `circle;radius` 3-point variant (same blocker as III.26)
+- [~] III.26 — In equal circles equal angles stand on equal circumferences whether they stand at the centers or at the circumferences. (3-point `circle;radius` + `point;similar` both landed 2026-04-12.)
+- [~] III.27 — In equal circles angles standing on equal circumferences equal one another whether they stand at the centers or at the circumferences. (3-point `circle;radius` + `point;similar` both landed 2026-04-12.)
+- [~] III.28 — In equal circles equal straight lines cut off equal circumferences, the greater circumference equals the greater and the less equals the less. (3-point `circle;radius` + `point;similar` both landed 2026-04-12.)
+- [~] III.29 — In equal circles straight lines that cut off equal circumferences are equal. (3-point `circle;radius` + `point;similar` both landed 2026-04-12.)
 - [~] III.30 — To bisect a given circumference. (sector;arc landed 2026-04-11.)
 - [~] III.31 — In a circle the angle in the semicircle is right, that in a greater segment less than a right angle, and that in a less segment greater than a right angle…
 - [~] III.32 — If a straight line touches a circle, and from the point of contact there is drawn across, in the circle, a straight line cutting the circle, then the angles which it makes with the tangent equal the angles in the alternate segments of the circle.

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -1000,15 +1000,27 @@ export class CircleRadiusCenterConstruction extends Construction {
 
 // TBD
 // circle
-// radius
-// points A, B [plane C=any]
+// radius (3D, 2-point)
+// points A, B, plane C
 // the circle with center A and radius AB in the plane C
 
-// TBD
 // circle
-// radius
-// points A, B, C [plane D]
-// the circle with center A and radius BC in the plane D
+// radius (2D, 3-point)
+// points A, B, C
+// the circle with center A and radius |BC| in the screen plane
+// (Java: CircleElement(A, B, C, screen) — A=center, radius=B.distance(C))
+// MUST be registered BEFORE the 2-point variant in the constructions array
+// (signature variant ordering rule: longer signature first)
+export class CircleRadius3PointConstruction extends Construction {
+    constructionMethod: AllConstructions = CircleConstructions.radius;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
+
+    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let g = new CircleElement({C: ps[0], A: ps[1], B: ps[2], AP: screen});
+        return [[g], g];
+    }
+}
 
 
 // TBD
@@ -1378,6 +1390,7 @@ export const constructions : Construction[] = [
     new ArcConstruction(),
     new CircleSliderConstruction(),
     new CircleSliderConstruction2dPoint(),
+    new CircleRadius3PointConstruction(),
     new CircleRadiusCenterConstruction(),
     new PointPerpendicular1Construction(),
     new PointPerpendicular2Construction(),

--- a/src/elements/circle/CircleElement.ts
+++ b/src/elements/circle/CircleElement.ts
@@ -23,7 +23,10 @@ import {SlateCanvas} from "../../Slate";
 
 export interface ICircleElementConstruction {
     C : PointElement; // center of the circle
-    B : PointElement; // point on the circle
+    B : PointElement; // point defining one end of the radius segment
+    A? : PointElement; // point defining the other end of the radius segment
+                       // (defaults to C — so radius = C.distance(B) in the 2-point form,
+                       // or A.distance(B) in the 3-point form where A ≠ C)
     AP : PlaneElement;
 }
 
@@ -39,7 +42,7 @@ export class CircleElement extends GeomElement {
         this.dimension = 2;
         if(ice == null) return;
         this.Center = ice.C;
-        this.A = this.Center;
+        this.A = ice.A != null ? ice.A : this.Center;
         this.B = ice.B;
         this.AP = ice.AP;
     }

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -14,6 +14,7 @@ import {ArcElement} from "../src/elements/sector/ArcElement";
 import {Chord} from "../src/elements/line/Chord";
 import {PolygonElement} from "../src/elements/polygon/PolygonElement";
 import {SimilarElement} from "../src/elements/point/SimilarElement";
+import {CircleElement} from "../src/elements/circle/CircleElement";
 import {createCanvas} from "canvas";
 import {create} from "domain";
 
@@ -564,6 +565,29 @@ describe("slate", ()=> {
     //   D=(0,0), E=(200,0), F=(0,100) → θ = π/2, factor = 100/200 = 0.5
     //   A=(50,200), B=(150,200)
     //   C = rotate B around A by π/2 then scale by 0.5 → (50, 250)
+
+    // circle;radius 3-point — circle at Center with radius = |A-B| (not |Center-B|)
+    // propIII26: center H=(340,115), radius-points G=(120,115), A=(75,30)
+    //   radius = |GA| = sqrt(45^2 + 85^2) = sqrt(2025+7225) = sqrt(9250) ≈ 96.177
+    it("should create a circle with center H and radius |GA| (3-point form)", () => {
+        let data : IConstructionInfo[] = [
+            { name: "G",   construction: E.Point.free,    params: [120, 115] },
+            { name: "A",   construction: E.Point.free,    params: [75, 30] },
+            { name: "H",   construction: E.Point.free,    params: [340, 115] },
+            { name: "DEF", construction: E.Circle.radius, params: ["H", "G", "A"] },
+        ];
+        let slate = new Slate(createCanvas(500, 300));
+        toElements(slate, data);
+        let circle = slate.lookupElement("DEF") as CircleElement;
+        // Center should be H
+        almostEqual(circle.Center.x, 340, 0.01);
+        almostEqual(circle.Center.y, 115, 0.01);
+        // Radius should be |GA|, not |H-anything|
+        let expectedRadius = Math.sqrt(45*45 + 85*85); // sqrt(9250) ≈ 96.177
+        almostEqual(circle.radius, expectedRadius, 0.01);
+        // A should NOT be Center (that would be the 2-point form)
+        assert.notEqual(circle.A, circle.Center);
+    });
 
     // line;foot (2D) — line from A to the foot of the perpendicular from A to line BC
     // A=(100,50), B=(50,200), C=(250,200) — BC is horizontal at y=200

--- a/view/applet-tests/circle/radius3pt/applet.html
+++ b/view/applet-tests/circle/radius3pt/applet.html
@@ -1,0 +1,34 @@
+<HTML><HEAD><TITLE>circle;radius 3-point — applet form of view/test/circle/radius3pt.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/circle/radius3pt.html -->
+<!-- ORIGINAL: view/applet-tests/circle/radius3pt/original.html (propIII26) -->
+<!--
+  PropIII26: two "equal circles" (same radius, different centers). The left
+  circle ABC has center G and edge point A (2-point form). The right circle
+  DEF has center H and radius |GA| (3-point form — the target construction).
+  Point F is computed via point;similar so △DEF ∼ △(inscribed angle).
+  Canvas 430x400 (original is 430x230).
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=430 height=400>
+<param name=background value="35,19,100">
+<param name=title value="III.26 — circle;radius 3-point">
+<param name=e[1] value="G;point;free;120,115">
+<param name=e[2] value="A;point;free;75,30">
+<param name=e[3] value="ABC;circle;radius;G,A">
+<param name=e[4] value="B;point;circleSlider;ABC,60,190">
+<param name=e[5] value="C;point;circleSlider;ABC,180,190">
+<param name=e[6] value="H;point;free;340,115">
+<param name=e[7] value="DEF;circle;radius;H,G,A">
+<param name=e[8] value="D;point;circleSlider;DEF,380,100">
+<param name=e[9] value="E;point;circleSlider;DEF,280,190">
+<param name=e[10] value="F;point;similar;H,E,G,B,C">
+<param name=e[11] value="triABC;polygon;triangle;A,B,C;0;0;black;random">
+<param name=e[12] value="triDEF;polygon;triangle;D,E,F;0;0;black;random">
+<param name=e[13] value="GBC;sector;sector;G,B,C;0;0;0;random">
+<param name=e[14] value="HEF;sector;sector;H,E,F;0;0;0;random">
+<param name=e[15] value="GB;line;connect;G,B">
+<param name=e[16] value="GC;line;connect;G,C">
+<param name=e[17] value="HE;line;connect;H,E">
+<param name=e[18] value="HF;line;connect;H,F">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/circle/radius3pt/original.html
+++ b/view/applet-tests/circle/radius3pt/original.html
@@ -1,0 +1,27 @@
+<HTML><HEAD><TITLE>III.26 — circle;radius 3-point (original)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=230 width=430>
+<param name=background value="35,19,100">
+<param name=title value="III.26">
+<param name=e[1] value="G;point;free;120,115">
+<param name=e[2] value="A;point;free;75,30">
+<param name=e[3] value="ABC;circle;radius;G,A">
+<param name=e[4] value="B;point;circleSlider;ABC,60,190">
+<param name=e[5] value="C;point;circleSlider;ABC,180,190">
+<param name=e[6] value="H;point;free;340,115">
+<param name=e[7] value="DEF;circle;radius;H,G,A">
+<param name=e[8] value="D;point;circleSlider;DEF,380,100">
+<param name=e[9] value="E;point;circleSlider;DEF,280,190">
+<param name=e[10] value="F;point;similar;H,E,G,B,C">
+<param name=e[11] value="AB;line;connect;A,B">
+<param name=e[12] value="triABC;polygon;triangle;A,B,C;0;0;black;random">
+<param name=e[13] value="triDEF;polygon;triangle;D,E,F;0;0;black;random">
+<param name=e[14] value="GBC;sector;sector;G,B,C;0;0;0;random">
+<param name=e[15] value="HEF;sector;sector;H,E,F;0;0;0;random">
+<param name=e[16] value="GB;line;connect;G,B">
+<param name=e[17] value="GC;line;connect;G,C">
+<param name=e[18] value="HF;line;connect;H,F">
+<param name=e[19] value="HE;line;connect;H,E">
+<param name=e[20] value="K;point;circleSlider;ABC,120,210;black;0">
+</applet>
+</BODY></HTML>

--- a/view/test/circle/radius3pt.html
+++ b/view/test/circle/radius3pt.html
@@ -1,0 +1,53 @@
+<html>
+<head>
+    <title>Test View - Circle.radius 3-point (III.26)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:430px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "III.26 — In equal circles equal angles stand on equal circumferences",
+        canvasid: "canvasId",
+        elements: [
+            // Left circle: center G, edge point A (2-point form)
+            // <param name=e[1] value="G;point;free;120,115">
+            { name: "G", construction: E.Point.free, params: [120, 115] },
+            // <param name=e[2] value="A;point;free;75,30">
+            { name: "A", construction: E.Point.free, params: [75, 30] },
+            // <param name=e[3] value="ABC;circle;radius;G,A">
+            { name: "ABC", construction: E.Circle.radius, params: ["G", "A"] },
+            // <param name=e[4] value="B;point;circleSlider;ABC,60,190">
+            { name: "B", construction: E.Point.circleSlider, params: ["ABC", 60, 190] },
+            // <param name=e[5] value="C;point;circleSlider;ABC,180,190">
+            { name: "C", construction: E.Point.circleSlider, params: ["ABC", 180, 190] },
+
+            // Right circle: center H, radius = |GA| (3-point form) ← target
+            // <param name=e[6] value="H;point;free;340,115">
+            { name: "H", construction: E.Point.free, params: [340, 115] },
+            // <param name=e[7] value="DEF;circle;radius;H,G,A">  ← 3-point circle;radius
+            { name: "DEF", construction: E.Circle.radius, params: ["H", "G", "A"] },
+            // <param name=e[8] value="D;point;circleSlider;DEF,380,100">
+            { name: "D", construction: E.Point.circleSlider, params: ["DEF", 380, 100] },
+            // <param name=e[9] value="E;point;circleSlider;DEF,280,190">
+            { name: "E", construction: E.Point.circleSlider, params: ["DEF", 280, 190] },
+            // <param name=e[10] value="F;point;similar;H,E,G,B,C">
+            { name: "F", construction: E.Point.similar, params: ["H", "E", "G", "B", "C"] },
+
+            // Triangles and sectors
+            { name: "triABC", construction: E.Polygon.triangle, params: ["A", "B", "C"] },
+            { name: "triDEF", construction: E.Polygon.triangle, params: ["D", "E", "F"] },
+            { name: "GBC", construction: E.Sector.sector, params: ["G", "B", "C"] },
+            { name: "HEF", construction: E.Sector.sector, params: ["H", "E", "F"] },
+            // Radii lines
+            { name: "GB", construction: E.Line.connect, params: ["G", "B"] },
+            { name: "GC", construction: E.Line.connect, params: ["G", "C"] },
+            { name: "HE", construction: E.Line.connect, params: ["H", "E"] },
+            { name: "HF", construction: E.Line.connect, params: ["H", "F"] },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds the 3-point `circle;radius` variant — circle at center with radius equal to the distance between two separate points. Completes the `CircleElement.java` constructor port by adding the optional `A` parameter. Unlocks 5 Book III propositions (III.24, III.26–III.29).

## What's in this branch

- `be32737` circle-radius-3pt: step 3 — add original.html from propIII26
- `e2a7480` circle-radius-3pt: step 4+5 — add optional A param to CircleElement + wire CircleRadius3PointConstruction
- `1617e1c` circle-radius-3pt: step 6 — Mocha test
- `8a5301b` circle-radius-3pt: step 7 — three-way view pair (TS page + applet.html)
- `afa9249` circle-radius-3pt: step 8 — tracker + journal + Book III unlock

## Construction details

- **Element class**: `CircleElement.ts` updated — added optional `A` field to `ICircleElementConstruction`. When `A` is provided, `radius = A.distance(B)` (3-point); when omitted, `A = Center` (2-point, backward-compatible). Completes the Java class port per the full-conversion rule.
- **Construction class**: `CircleRadius3PointConstruction` — signature `[PointElement × 3]`, registered **before** the 2-point variant (signature-ordering rule). Dispatches to `CircleConstructions.radius = 201`.
- **Java source**: `CircleElement.java` constructors + `Slate.java` circle case 0 choice 1.

## Tests

30 → **31 passing**. One new test: center at (340,115), radius = |G-A| ≈ 96.177 (propIII26 coords), `A ≠ Center` assertion.

## Verification

- [x] `npm run build` clean
- [x] `npm test` passes (31/31)
- [x] `npx webpack` rebuilds `dist/bundle.js`
- [x] Three-way harness — **needs human verification**
- [x] Drag A or G to change the left circle's radius; the right circle should track (same radius, different center)

## Newly renderable propositions

- **Book III** (31 → 36): III.24, III.26, III.27, III.28, III.29
- **I–III total** (72 → 77): +5
