### PR TITLE
Feature/similar polygon line

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -273,9 +273,16 @@ These affect the library as a whole, independent of individual constructions.
     [view/applet-tests/line/foot/{original,applet}.html](../view/applet-tests/line/foot/)
   - Used in: I.47 (Pythagoras' theorem)
 
-- [ ] **`similar`** — TBD
-  - Java source: `Similar.java`
-  - No Books I–III uses
+- [x] **`similar`** — `src/elements/Constructions.ts` (`SimilarLineConstruction`)
+  - No new element class — reuses `SimilarElement` (from `point;similar`) +
+    `LineElement` wrapper. `construct()` creates `SimilarElement(A,B,screen,D,E,F,screen)`
+    then `LineElement(A, sim)`.
+  - Java source: `Slate.java` line case 10.
+  - Mocha test (1): line endpoint at the similar point.
+  - [x] test view: [view/test/line/similar.html](../view/test/line/similar.html) — propI31
+  - [x] applet-tests pair:
+    [view/applet-tests/line/similar/{original,applet}.html](../view/applet-tests/line/similar/)
+  - Used in: I.31
 
 - [ ] **`proportion`** — TBD
   - Java source: `Proportion.java`
@@ -352,9 +359,16 @@ These affect the library as a whole, independent of individual constructions.
   - [x] test view: [view/test/poly/equilateralTriangle.html](../view/test/poly/equilateralTriangle.html) — mirrors propI10 params
   - Used in: I.2, I.9–I.11, III.10, III.24
 
-- [ ] **`similar`** — TBD
-  - Java source: `Similar.java`
-  - Used in: III.23–III.24, III.26–III.29
+- [x] **`similar`** — `src/elements/Constructions.ts` (`SimilarPolygonConstruction`)
+  - No new element class — reuses `SimilarElement` (from `point;similar`) +
+    `PolygonElement` wrapper. `construct()` creates `SimilarElement(A,B,screen,D,E,F,screen)`
+    then `PolygonElement([A, B, sim])`.
+  - Java source: `Slate.java` polygon case 9.
+  - Mocha test (1): triangle vertices at expected similar-point location.
+  - [x] test view: [view/test/poly/similar.html](../view/test/poly/similar.html) — propI23
+  - [x] applet-tests pair:
+    [view/applet-tests/poly/similar/{original,applet}.html](../view/applet-tests/poly/similar/)
+  - Used in: I.23, I.24, I.26, III.14
 
 - [ ] **`application`** — TBD
   - Java source: `Application.java`

--- a/doc/constructions-reference.md
+++ b/doc/constructions-reference.md
@@ -73,7 +73,7 @@ must reflect these post-expansion types, not the raw HTML param count.
 | `angleBisector` | **TBD** | `AngleDivider.java` | `Point A, B, C [, Plane]` | Bisector of angle ∠ABC | 0 | — |
 | `angleDivider` | **TBD** | `AngleDivider.java` | `Point A, B, C [, Plane], int n` | 1/n division of ∠ABC as a line | 0 | — |
 | `foot` | **TBD** | `PlaneFoot.java` | `Point A, Plane B` | Perpendicular from A to plane B | solid only | — |
-| `similar` | **TBD** | `Similar.java` | `Point A, B, D, E, F [, Plane]` | Line corresponding to similar construction | 0 | — |
+| `similar` | IMPL | `Similar.java` | `Point A, B, D, E, F` | Line AH where △ABH ∼ △DEF (2D) | ~1 | I.31 |
 | `proportion` | **TBD** | `Proportion.java` | As point variant | Line form of proportion | 0 | — |
 | `meanProportional` | **TBD** | `MeanProportional.java` | As point variant | Line form | 0 | — |
 
@@ -98,7 +98,7 @@ must reflect these post-expansion types, not the raw HTML param count.
 | `parallelogram` | IMPL | `Slate.java` (case 6, reuses `Layoff`) | `Point A, B, C` | Parallelogram ABCD where D = A+(C−B) | ~18 | I.34 |
 | `square` | IMPL | `RegularPolygon.java` (n=4) | `Point A, B` | Square on side AB | ~10 | I.46 |
 | `equilateralTriangle` | **TBD** | `PolygonElement.java` | `Point A, B, C` | Equilateral triangle (alias for triangle with equal sides) | ~6 | I.2 |
-| `similar` | **TBD** | `Similar.java` | `Point A, B, C, D, E, F` | Similar polygon construction | ~5 | III.24 |
+| `similar` | IMPL | `Similar.java` | `Point A, B, D, E, F` | Triangle ABH where △ABH ∼ △DEF (2D) | ~5 | I.23 |
 | `application` | **TBD** | `Application.java` | Various | Application of area (parallelogram equal to triangle) | ~3 | I.44 |
 | `regularPolygon` | **TBD** | `RegularPolygon.java` | `Point A, B, int n` | Regular n-gon on edge AB | 0 | — |
 | `starPolygon` | **TBD** | `RegularPolygon.java` | `Point A, B, int n, int k` | Star polygon {n/k} | 0 | — |

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,46 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-12 — Implemented polygon;similar + line;similar — BOOK III COMPLETE
+
+**Completed:**
+- Ported `polygon;similar` as `SimilarPolygonConstruction` and
+  `line;similar` as `SimilarLineConstruction` in
+  `src/elements/Constructions.ts`. Both reuse the existing `SimilarElement`
+  (from the `point;similar` session) as an intermediate, wrapping it in a
+  `PolygonElement([A, B, sim])` or `LineElement(A, sim)` respectively. Same
+  dispatch-trick pattern. No new element class for either.
+- Two Mocha tests: polygon;similar creates a 3-vertex triangle,
+  line;similar creates a line from A to the similar point. 31 → **33
+  passing**.
+- Test pages + applet companions for both: propI23 (polygon;similar) and
+  propI31 (line;similar).
+- **Tracker drift fix**: verified HTML param lists for I.28, I.30, I.32,
+  I.33, I.35, I.36, I.41 — all had been renderable since `point;parallelogram`
+  landed on 2026-04-10 but were never flipped. Fixed all 7.
+- **BOOK III IS 100% RENDERABLE**: III.14 was the last remaining `[ ]`
+  entry; it uses `polygon;similar` which just landed. 37/37 propositions
+  now at `[~]`.
+- Book I: 28 → **39** (+4 similar + 7 drift fix + I.31). Book III: 36 →
+  **37** (COMPLETE). I–III total: 77 → **89** (90%).
+
+**Discovered:**
+- I.33 was another drift candidate not in the original list — both its
+  blockers (`point;parallelogram`, `point;vertex`) were IMPL since
+  2026-04-10. Fixed alongside the other 6.
+- The `Similar.java` port is now fully complete across all three type
+  variants: point (session 4), line (this session), polygon (this session).
+  All share the same `SimilarElement` intermediate.
+
+**Next session:**
+- Remaining Book I blockers: `point;proportion` (I.16, I.29),
+  `polygon;application` (I.44, I.45, II.14), `line;foot` 3D variant
+  (no I–III uses).
+- Consider a sweep to audit every remaining `[ ]` entry in Book I against
+  actual HTML params — the drift fix pattern suggests more may be hiding.
+
+---
+
 ## 2026-04-12 — Implemented 3-point circle;radius variant
 
 **Completed:**

--- a/doc/proposition-tracker.md
+++ b/doc/proposition-tracker.md
@@ -14,10 +14,10 @@ Tracks the port status of all propositions across Euclid's Elements.
 
 | Scope | Total | Renderable (`[~]`) | Complete (`[x]`) |
 |-------|-------|--------------------|------------------|
-| Book I | 48 | 28 | 0 |
+| Book I | 48 | 39 | 0 |
 | Book II | 14 | 13 | 0 |
-| Book III | 37 | 36 | 0 |
-| **I–III total** | **99** | **77** | **0** |
+| Book III | 37 | **37** | 0 |
+| **I–III total** | **99** | **89** | **0** |
 | Books IV–XIII | ~365 | — | — |
 
 Update the summary table after each session.
@@ -48,25 +48,25 @@ Update the summary table after each session.
 - [~] I.20 — In any triangle the sum of any two sides is greater than the remaining one.
 - [~] I.21 — If from the ends of one of the sides of a triangle two straight lines are constructed meeting within the triangle…
 - [~] I.22 — To construct a triangle out of three straight lines which equal three given straight lines. (`line;parallel` landed 2026-04-11.)
-- [ ] I.23 — To construct a rectilinear angle equal to a given rectilinear angle on a given straight line and at a point on it. NEEDS: `polygon;similar` (NOT point;similar — corrected 2026-04-12; propI23 e[12] uses polygon;similar)
-- [ ] I.24 — If two triangles have two sides equal to two sides respectively, but have one of the angles contained by the equal straight lines greater than the other… NEEDS: `polygon;similar` (NOT point;similar — corrected 2026-04-12; propI24 e[11] uses polygon;similar)
+- [~] I.23 — To construct a rectilinear angle equal to a given rectilinear angle on a given straight line and at a point on it. (`polygon;similar` landed 2026-04-12.)
+- [~] I.24 — If two triangles have two sides equal to two sides respectively, but have one of the angles contained by the equal straight lines greater than the other… (`polygon;similar` landed 2026-04-12.)
 - [~] I.25 — If two triangles have two sides equal to two sides respectively, but have the base greater than the base…
-- [ ] I.26 — If two triangles have two angles equal to two angles respectively, and one side equal to one side… (AAS/ASA congruence). NEEDS: `polygon;similar` (NOT point;similar — corrected 2026-04-12; propI26 e[8] uses polygon;similar)
+- [~] I.26 — If two triangles have two angles equal to two angles respectively, and one side equal to one side… (AAS/ASA congruence). (`polygon;similar` landed 2026-04-12.)
 - [~] I.27 — If a straight line falling on two straight lines makes the alternate angles equal to one another, then the straight lines are parallel. (`line;parallel` landed 2026-04-11.)
-- [ ] I.28 — If a straight line falling on two straight lines makes the exterior angle equal to the interior and opposite angle on the same side… NEEDS: `point;parallelogram`
+- [~] I.28 — If a straight line falling on two straight lines makes the exterior angle equal to the interior and opposite angle on the same side… (`point;parallelogram` landed 2026-04-10; tracker drift fixed 2026-04-12.)
 - [ ] I.29 — A straight line falling on parallel straight lines makes the alternate angles equal to one another… NEEDS: `point;parallelogram`, `point;proportion`
-- [ ] I.30 — Straight lines parallel to the same straight line are also parallel to one another. NEEDS: `point;parallelogram`
-- [ ] I.31 — To draw a straight line through a given point parallel to a given straight line. NEEDS: `line;similar` (NOT point;similar — corrected 2026-04-12; propI31 e[7] uses line;similar)
-- [ ] I.32 — In any triangle, if one of the sides is produced, then the exterior angle equals the sum of the two interior and opposite angles… NEEDS: `point;parallelogram`
-- [ ] I.33 — Straight lines which join the ends of equal and parallel straight lines in the same directions are themselves equal and parallel. NEEDS: `point;parallelogram`, `point;vertex`
+- [~] I.30 — Straight lines parallel to the same straight line are also parallel to one another. (`point;parallelogram` landed 2026-04-10; tracker drift fixed 2026-04-12.)
+- [~] I.31 — To draw a straight line through a given point parallel to a given straight line. (`line;similar` landed 2026-04-12.)
+- [~] I.32 — In any triangle, if one of the sides is produced, then the exterior angle equals the sum of the two interior and opposite angles… (`point;parallelogram` landed 2026-04-10; tracker drift fixed 2026-04-12.)
+- [~] I.33 — Straight lines which join the ends of equal and parallel straight lines in the same directions are themselves equal and parallel. (`point;parallelogram`, `point;vertex` landed 2026-04-10; tracker drift fixed 2026-04-12.)
 - [~] I.34 — In parallelogrammic areas the opposite sides and angles equal one another, and the diameter bisects the areas. (`point;parallelogram`, `point;vertex`, `polygon;parallelogram` all landed by 2026-04-11.)
-- [ ] I.35 — Parallelograms which are on the same base and in the same parallels equal one another. NEEDS: `point;parallelogram`
-- [ ] I.36 — Parallelograms which are on equal bases and in the same parallels equal one another. NEEDS: `point;parallelogram`, `point;vertex`
+- [~] I.35 — Parallelograms which are on the same base and in the same parallels equal one another. (`point;parallelogram` landed 2026-04-10; tracker drift fixed 2026-04-12.)
+- [~] I.36 — Parallelograms which are on equal bases and in the same parallels equal one another. (`point;parallelogram`, `point;vertex` landed 2026-04-10; tracker drift fixed 2026-04-12.)
 - [~] I.37 — Triangles which are on the same base and in the same parallels equal one another. (`line;parallel`, `point;parallelogram` both landed 2026-04-11.)
 - [~] I.38 — Triangles which are on equal bases and in the same parallels equal one another. (`line;parallel`, `point;parallelogram` both landed 2026-04-11.)
 - [~] I.39 — Equal triangles which are on the same base and on the same side are also in the same parallels. (`line;parallel` landed 2026-04-11.)
 - [~] I.40 — Equal triangles which are on equal bases and on the same side are also in the same parallels. (`line;parallel` landed 2026-04-11.)
-- [ ] I.41 — If a parallelogram has the same base with a triangle and is in the same parallels, then the parallelogram is double the triangle. NEEDS: `point;parallelogram`, `point;vertex`
+- [~] I.41 — If a parallelogram has the same base with a triangle and is in the same parallels, then the parallelogram is double the triangle. (`point;parallelogram`, `point;vertex` landed 2026-04-10; tracker drift fixed 2026-04-12.)
 - [~] I.42 — To construct a parallelogram equal to a given triangle in a given rectilinear angle. (`point;parallelogram`, `point;similar` both landed by 2026-04-12.)
 - [~] I.43 — In any parallelogram the complements of the parallelograms about the diameter equal one another. (`point;parallelogram`, `polygon;quadrilateral`, `point;vertex` all landed by 2026-04-12.)
 - [ ] I.44 — To a given straight line in a given rectilinear angle, to apply a parallelogram equal to a given triangle. NEEDS: `point;parallelogram`, `polygon;quadrilateral`, `point;similar`, `point;vertex`, `polygon;application`
@@ -111,7 +111,7 @@ Update the summary table after each session.
 - [~] III.11 — If two circles touch one another internally, and their centers are taken, then the straight line joining their centers, being produced, falls on the point of contact of the circles.
 - [~] III.12 — If two circles touch one another externally, then the straight line joining their centers passes through the point of contact. (`line;chord` landed 2026-04-11.)
 - [~] III.13 — A circle does not touch another circle at more than one point whether it touches it internally or externally.
-- [ ] III.14 — Equal straight lines in a circle are equally distant from the center, and those which are equally distant from the center equal one another. NEEDS: `polygon;similar` (NOT point;similar — corrected 2026-04-12; propIII14 e[7] uses polygon;similar)
+- [~] III.14 — Equal straight lines in a circle are equally distant from the center, and those which are equally distant from the center equal one another. (`polygon;similar` landed 2026-04-12.)
 - [~] III.15 — Of straight lines in a circle the diameter is greatest, and of the rest the nearer to the center is always greater than the more remote. (`line;chord` landed 2026-04-11.)
 - [~] III.16 — The straight line drawn at right angles to the diameter of a circle from its end will fall outside the circle…
 - [~] III.17 — From a given point to draw a straight line touching a given circle. (`line;chord` landed 2026-04-11.)

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -961,11 +961,22 @@ export class LineParallelConstruction extends Construction {
     }
 }
 
-// TBD
 // line
-// similar
-// points A, B, D, E, F [planes C, G]
-// the line AH so that triangle ABH in plane C is similar to triangle DEF in plane G
+// similar (2D variant)
+// points A, B, D, E, F
+// the line AH so that triangle ABH is similar to triangle DEF (screen plane)
+// (Java: Slate.java line case 10 — Similar(A,B,screen,D,E,F,screen) + LineElement(A,H))
+export class SimilarLineConstruction extends Construction {
+    constructionMethod: AllConstructions = LineConstructions.similar;
+    signature: ConstructionTypes[] = (new Array(5)).fill(ct.PointElement);
+
+    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let sim = new SimilarElement(ps[0], ps[1], screen, ps[2], ps[3], ps[4], screen);
+        let g = new LineElement({A: ps[0], B: sim});
+        return [[sim, g], g];
+    }
+}
 
 // TBD
 // line
@@ -1159,12 +1170,22 @@ export class ParallelogramPolygonConstruction extends Construction {
 // the star polygon on a side AB given the number of vertices n and the density d
 
 
-// TBD
 // polygon
-// similar
-// points A, B, D, E, F [planes C, G]
-// the triangle ABH in plane C is similar to triangle DEF in plane G
+// similar (2D variant)
+// points A, B, D, E, F
+// the triangle ABH where H is the similar point so △ABH ∼ △DEF (screen plane)
+// (Java: Slate.java polygon case 9 — Similar(A,B,screen,D,E,F,screen) + PolygonElement(A,B,H))
+export class SimilarPolygonConstruction extends Construction {
+    constructionMethod: AllConstructions = PolygonConstructions.similar;
+    signature: ConstructionTypes[] = (new Array(5)).fill(ct.PointElement);
 
+    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let sim = new SimilarElement(ps[0], ps[1], screen, ps[2], ps[3], ps[4], screen);
+        let g = new PolygonElement([ps[0], ps[1], sim]);
+        return [[sim, g], g];
+    }
+}
 
 // TBD
 // polygon
@@ -1406,11 +1427,13 @@ export const constructions : Construction[] = [
     new ChordConstruction(),
     new LineParallelConstruction(),
     new LineFootConstruction(),
+    new SimilarLineConstruction(),
     new TrianglePolygonConstruction(),
     new SquarePolygonConstruction(),
     new EquilateralTriangleConstruction(),
     new ParallelogramPolygonConstruction(),
     new QuadrilateralPolygonConstruction(),
+    new SimilarPolygonConstruction(),
     new VertexConstruction(),
     new PerpendicularPlaneConstruction(),
     new SphereRadiusConstruction()

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -566,6 +566,50 @@ describe("slate", ()=> {
     //   A=(50,200), B=(150,200)
     //   C = rotate B around A by π/2 then scale by 0.5 → (50, 250)
 
+    // polygon;similar — triangle ABH where H is the similar point so △ABH ∼ △DEF
+    // propI23: A=(40,180), G=(cutoff result), C=(190,80), E=(270,180), D=(260,40)
+    // Simpler standalone: A=(50,200), B=(150,200), D=(0,0), E=(100,0), F=(0,100)
+    //   → H = (50,300) (same as point;similar test with factor=1)
+    //   → polygon vertices = [A, B, H] = [(50,200), (150,200), (50,300)]
+    it("should create a similar triangle polygon", () => {
+        let data : IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [50, 200] },
+            { name: "B", construction: E.Point.free, params: [150, 200] },
+            { name: "D", construction: E.Point.free, params: [0, 0] },
+            { name: "E", construction: E.Point.free, params: [100, 0] },
+            { name: "F", construction: E.Point.free, params: [0, 100] },
+            { name: "ABH", construction: E.Polygon.similar, params: ["A", "B", "D", "E", "F"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let poly = slate.lookupElement("ABH") as PolygonElement;
+        assert.equal(poly.V.length, 3);
+        almostEqual(poly.V[0].x,  50, 0.01); almostEqual(poly.V[0].y, 200, 0.01);
+        almostEqual(poly.V[1].x, 150, 0.01); almostEqual(poly.V[1].y, 200, 0.01);
+        almostEqual(poly.V[2].x,  50, 0.01); almostEqual(poly.V[2].y, 300, 0.01);
+    });
+
+    // line;similar — line AH where H is the similar point
+    it("should create a similar line", () => {
+        let data : IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [50, 200] },
+            { name: "B", construction: E.Point.free, params: [150, 200] },
+            { name: "D", construction: E.Point.free, params: [0, 0] },
+            { name: "E", construction: E.Point.free, params: [100, 0] },
+            { name: "F", construction: E.Point.free, params: [0, 100] },
+            { name: "AH", construction: E.Line.similar, params: ["A", "B", "D", "E", "F"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let line = slate.lookupElement("AH") as LineElement;
+        // Line starts at A
+        almostEqual(line.A.x,  50, 0.01); almostEqual(line.A.y, 200, 0.01);
+        // Line ends at H = similar point = (50, 300)
+        almostEqual(line.B.x,  50, 0.01); almostEqual(line.B.y, 300, 0.01);
+    });
+
     // circle;radius 3-point — circle at Center with radius = |A-B| (not |Center-B|)
     // propIII26: center H=(340,115), radius-points G=(120,115), A=(75,30)
     //   radius = |GA| = sqrt(45^2 + 85^2) = sqrt(2025+7225) = sqrt(9250) ≈ 96.177

--- a/view/applet-tests/line/similar/applet.html
+++ b/view/applet-tests/line/similar/applet.html
@@ -1,0 +1,19 @@
+<HTML><HEAD><TITLE>line;similar — applet form of view/test/line/similar.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/line/similar.html -->
+<!-- ORIGINAL: view/applet-tests/line/similar/original.html (propI31) -->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="I.31 — line;similar">
+<param name=e[1] value="A;point;free;130,40">
+<param name=e[2] value="B;point;free;40,120">
+<param name=e[3] value="C;point;free;180,120">
+<param name=e[4] value="D;point;lineSlider;B,C,100,120">
+<param name=e[5] value="BC;line;connect;B,C">
+<param name=e[6] value="AD;line;connect;A,D">
+<param name=e[7] value="AE;line;similar;A,D,D,A,C">
+<param name=e[8] value="E;point;last;AE">
+<param name=e[9] value="AF;line;extend;E,A,B,D">
+<param name=e[10] value="F;point;last;AF">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/line/similar/original.html
+++ b/view/applet-tests/line/similar/original.html
@@ -1,0 +1,17 @@
+<HTML><HEAD><TITLE>I.31 — line;similar (original)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=170 width=260>
+<param name=background value="35,19,100">
+<param name=title value="I.31">
+<param name=e[1] value="A;point;free;130,40">
+<param name=e[2] value="B;point;free;40,120">
+<param name=e[3] value="C;point;free;180,120">
+<param name=e[4] value="D;point;lineSlider;B,C,100,120">
+<param name=e[5] value="BC;line;connect;B,C">
+<param name=e[6] value="AD;line;connect;A,D">
+<param name=e[7] value="AE;line;similar;A,D,D,A,C">
+<param name=e[8] value="E;point;last;AE">
+<param name=e[9] value="AF;line;extend;E,A,B,D">
+<param name=e[10] value="F;point;last;AF">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/poly/similar/applet.html
+++ b/view/applet-tests/poly/similar/applet.html
@@ -1,0 +1,19 @@
+<HTML><HEAD><TITLE>polygon;similar — applet form of view/test/poly/similar.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/poly/similar.html -->
+<!-- ORIGINAL: view/applet-tests/poly/similar/original.html (propI23) -->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="I.23 — polygon;similar">
+<param name=e[1] value="D;point;free;260,40">
+<param name=e[2] value="C;point;free;190,80">
+<param name=e[3] value="E;point;free;270,180">
+<param name=e[4] value="CDE;polygon;triangle;C,D,E;0;0;0,0,0;random">
+<param name=e[5] value="A;point;free;40,180">
+<param name=e[6] value="B;point;free;200,180">
+<param name=e[7] value="AB;line;connect;A,B">
+<param name=e[8] value="G;point;cutoff;A,B,C,E">
+<param name=e[9] value="AGF;polygon;similar;A,G,C,E,D;0;0;0,0,0;random">
+<param name=e[10] value="F;point;vertex;AGF,3">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/poly/similar/original.html
+++ b/view/applet-tests/poly/similar/original.html
@@ -1,0 +1,20 @@
+<HTML><HEAD><TITLE>I.23 — polygon;similar (original)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=220 width=340>
+<param name=background value="35,19,100">
+<param name=title value="I.23">
+<param name=e[1] value="D;point;free;260,40">
+<param name=e[2] value="C;point;free;190,80">
+<param name=e[3] value="E;point;free;270,180">
+<param name=e[4] value="D1;line;extend;C,D,C,D;0;0">
+<param name=e[5] value="E1;line;extend;C,E,C,E;0;0">
+<param name=e[6] value="CDE;polygon;triangle;C,D,E;0;0;0,0,0;random">
+<param name=e[7] value="A;point;free;40,180">
+<param name=e[8] value="B;point;free;200,180">
+<param name=e[9] value="AB;line;connect;A,B">
+<param name=e[10] value="DE;line;connect;D,E">
+<param name=e[11] value="G;point;cutoff;A,B,C,E">
+<param name=e[12] value="AGF;polygon;similar;A,G,C,E,D;0;0;0,0,0;random">
+<param name=e[13] value="F;point;vertex;AGF,3">
+</applet>
+</BODY></HTML>

--- a/view/test/line/similar.html
+++ b/view/test/line/similar.html
@@ -1,0 +1,39 @@
+<html>
+<head>
+    <title>Test View - Line.similar (I.31)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "I.31 — To draw a straight line through a given point parallel to a given straight line",
+        canvasid: "canvasId",
+        elements: [
+            // <param name=e[1] value="A;point;free;130,40">
+            { name: "A", construction: E.Point.free, params: [130, 40] },
+            // <param name=e[2] value="B;point;free;40,120">
+            { name: "B", construction: E.Point.free, params: [40, 120] },
+            // <param name=e[3] value="C;point;free;180,120">
+            { name: "C", construction: E.Point.free, params: [180, 120] },
+            // <param name=e[4] value="D;point;lineSlider;B,C,100,120">
+            { name: "D", construction: E.Point.lineSlider, params: ["B", "C", 100, 120] },
+            // <param name=e[5] value="BC;line;connect;B,C">
+            { name: "BC", construction: E.Line.connect, params: ["B", "C"] },
+            // <param name=e[6] value="AD;line;connect;A,D">
+            { name: "AD", construction: E.Line.connect, params: ["A", "D"] },
+            // <param name=e[7] value="AE;line;similar;A,D,D,A,C">  ← target
+            { name: "AE", construction: E.Line.similar, params: ["A", "D", "D", "A", "C"] },
+            // <param name=e[8] value="E;point;last;AE">
+            { name: "Ep", construction: E.Point.last, params: ["AE"] },
+            // <param name=e[9] value="AF;line;extend;E,A,B,D">
+            { name: "AF", construction: E.Line.extend, params: ["Ep", "A", "B", "D"] },
+            // <param name=e[10] value="F;point;last;AF">
+            { name: "F", construction: E.Point.last, params: ["AF"] },
+        ]
+    });
+</script>
+</body>
+</html>

--- a/view/test/poly/similar.html
+++ b/view/test/poly/similar.html
@@ -1,0 +1,34 @@
+<html>
+<head>
+    <title>Test View - Polygon.similar (I.23)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "I.23 — To construct a rectilinear angle equal to a given rectilinear angle",
+        canvasid: "canvasId",
+        elements: [
+            // Reference angle CDE
+            { name: "D", construction: E.Point.free, params: [260, 40] },
+            { name: "C", construction: E.Point.free, params: [190, 80] },
+            { name: "Ep", construction: E.Point.free, params: [270, 180] },
+            { name: "CDE", construction: E.Polygon.triangle, params: ["C", "D", "Ep"] },
+            // Base line AB
+            { name: "A", construction: E.Point.free, params: [40, 180] },
+            { name: "B", construction: E.Point.free, params: [200, 180] },
+            { name: "AB", construction: E.Line.connect, params: ["A", "B"] },
+            // Cutoff G on AB equal to CE
+            { name: "G", construction: E.Point.cutoff, params: ["A", "B", "C", "Ep"] },
+            // Similar triangle AGF where △AGF ∼ △CED  ← target
+            // <param name=e[12] value="AGF;polygon;similar;A,G,C,E,D">
+            { name: "AGF", construction: E.Polygon.similar, params: ["A", "G", "C", "Ep", "D"] },
+            { name: "F", construction: E.Point.vertex, params: ["AGF", 3] },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds `polygon;similar` and `line;similar` — the final two `Similar.java` variants, completing the full port of that Java class across all three type categories (point, line, polygon). Also fixes 7 tracker-drift entries for Book I propositions that were renderable since 2026-04-10 but never flipped. **Book III reaches 100% renderable (37/37).**

## What's in this branch

- `932fa09` similar-polygon-line: step 3 — add original.html from propI23 + propI31
- `407543c` similar-polygon-line: step 5 — wire SimilarPolygonConstruction + SimilarLineConstruction
- `7d4c3c1` similar-polygon-line: step 6 — Mocha tests
- `f343451` similar-polygon-line: step 7 — three-way view pairs for both constructions
- `53c09f3` similar-polygon-line: step 8 — tracker + journal + drift fix — BOOK III COMPLETE

## Construction details

- **polygon;similar**: `SimilarPolygonConstruction` — reuses `SimilarElement` + `PolygonElement([A, B, sim])`. Signature `[PointElement × 5]`. Java: `Slate.java` polygon case 9.
- **line;similar**: `SimilarLineConstruction` — reuses `SimilarElement` + `LineElement(A, sim)`. Signature `[PointElement × 5]`. Java: `Slate.java` line case 10.
- No new element classes — both build on `SimilarElement.ts` from the `point;similar` session.

## Tests

31 → **33 passing**. Two new tests: polygon;similar (3-vertex triangle verification), line;similar (line endpoint verification).

## Verification

- [x] `npm run build` clean
- [x] `npm test` passes (33/33)
- [x] `npx webpack` rebuilds `dist/bundle.js`
- [x] Three-way harness for `poly;similar` — **needs human verification**
- [x] Three-way harness for `line;similar` — **needs human verification**

## Newly renderable propositions

- **Book I** (28 → 39): I.23, I.24, I.26, I.31 (from similar), I.28, I.30, I.32, I.33, I.35, I.36, I.41 (tracker drift fix — all verified against HTML params)
- **Book III** (36 → **37/37 = 100%**): III.14 (last remaining — uses polygon;similar)
- **I–III total** (77 → **89**): +12

## Discovered / out of scope

- I.33 was an additional drift candidate not in the original list of 6 — both its blockers were IMPL since 2026-04-10.
- The `Similar.java` port is now fully complete: `point;similar` (SimilarElement.ts), `line;similar` (SimilarLineConstruction), `polygon;similar` (SimilarPolygonConstruction).
- Remaining Book I blockers: `point;proportion` (I.16, I.29), `polygon;application` (I.44, I.45, II.14), and potentially more drift candidates hiding in the 9 remaining `[ ]` entries.
