### PR TITLE
Feature/point proportion

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -169,9 +169,16 @@ These affect the library as a whole, independent of individual constructions.
   - Used in (actual `point;similar`): I.42, III.33, III.34, plus
     III.26–III.29 (but those are blocked by 3-point `circle;radius` TBD)
 
-- [ ] **`proportion`** — TBD
-  - Java source: `Proportion.java`
-  - Used in: I.16, I.29
+- [x] **`proportion`** — `src/elements/point/ProportionElement.ts`
+  - Extends `PointElement`; constructor takes 8 PointElements (S0,S1,T0,T1,
+    U0,U1,V0,V1) defining four line segments. `update()` computes the point
+    V' on V0V1 such that |S|:|T| = |U|:|V0V'|.
+  - Java source: `Proportion.java` — 26 lines, line-for-line port.
+  - Mocha test (1): fourth-proportional at expected position.
+  - [x] test view: [view/test/point/proportion.html](../view/test/point/proportion.html) — standalone
+  - [x] applet-tests pair:
+    [view/applet-tests/point/proportion/{original,applet}.html](../view/applet-tests/point/proportion/)
+  - Used in: I.16, I.29 (secondary applet variants)
 
 - [ ] **`angleBisector`** — TBD
   - Java source: `AngleDivider.java`

--- a/doc/constructions-reference.md
+++ b/doc/constructions-reference.md
@@ -49,7 +49,7 @@ must reflect these post-expansion types, not the raw HTML param count.
 | `parallelogram` | **TBD** | `Geometry.java` | `Point A, Point B, Point C` | 4th vertex D of parallelogram ABCD (D = A+C−B) | ~48 | I.28 |
 | `vertex` | **TBD** | `PolygonElement.java` | `Polygon P, int i` | i-th vertex of polygon P | ~59 | I.2 |
 | `similar` | IMPL | `Similar.java` | `Point A, B, D, E, F [, Plane]` | Point H so △ABH ~ △DEF (2D) | ~15 | III.33 |
-| `proportion` | **TBD** | `Proportion.java` | `Point A, B, C, D, E, F, G, H` | Point on GH s.t. AB:CD = EF:GI | ~4 | I.16 |
+| `proportion` | IMPL | `Proportion.java` | `Point S0,S1,T0,T1,U0,U1,V0,V1` | Point V' on V0V1 s.t. \|S\|:\|T\| = \|U\|:\|V0V'\| | ~4 | I.16 |
 | `invert` | **TBD** | `InvertPoint.java` | `Point A, Circle B` | Inversion of A in circle B | 0 | — |
 | `meanProportional` | **TBD** | `MeanProportional.java` | `Point A, B, C, D, E, F` | Point G on EF s.t. AB:CD = CD:EG | 0 | — |
 | `planeSlider` | **TBD** | `PlaneSlider.java` | `Plane A, int x, int y, int z` | Point draggable on plane A | solid geometry | — |

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,37 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-12 — Implemented point;proportion + drift fix — 96/99
+
+**Completed:**
+- Ported `point;proportion` as `src/elements/point/ProportionElement.ts` —
+  a port of `Proportion.java` (26 lines). Takes 8 PointElements defining
+  four line segments S, T, U, V and computes the point V' on V0V1 such
+  that |S|:|T| = |U|:|V0V'|. `update()` body is 4 lines: compute factor
+  from distance² ratios, apply to the V direction vector.
+- `ProportionPointConstruction` wired with signature `[PointElement × 8]`.
+  One Mocha test with clean collinear coords (factor=0.2, result at (40,0)).
+  33 → **34 passing**.
+- **Drift fix for 5 more propositions**: I.2, I.4, I.9, I.10, I.11 —
+  all had blockers that were already IMPL from earlier sessions (I.2/I.9/
+  I.10/I.11 needed polygon;equilateralTriangle + point;vertex, both IMPL
+  since 2026-04-10; I.4 needed 3-point circle;radius, IMPL since earlier
+  today). Verified all against actual HTML params.
+- Book I: 39 → **46** (+2 proportion + 5 drift). I–III total: 89 → **96**.
+- **Only 3 propositions remain blocked**: I.44, I.45, II.14 — all need
+  `polygon;application`.
+
+**Discovered:**
+- propI16 and propI29 each have dual applet variants. Their primary
+  variants were already renderable (no point;proportion needed). Only the
+  secondary "elliptic geometry" variants use point;proportion.
+
+**Next session:**
+- `polygon;application` — the FINAL construction. Landing it would make
+  I.44, I.45, II.14 renderable, reaching **99/99 = 100%** for Books I–III.
+
+---
+
 ## 2026-04-12 — Implemented polygon;similar + line;similar — BOOK III COMPLETE
 
 **Completed:**

--- a/doc/proposition-tracker.md
+++ b/doc/proposition-tracker.md
@@ -14,10 +14,10 @@ Tracks the port status of all propositions across Euclid's Elements.
 
 | Scope | Total | Renderable (`[~]`) | Complete (`[x]`) |
 |-------|-------|--------------------|------------------|
-| Book I | 48 | 39 | 0 |
+| Book I | 48 | **46** | 0 |
 | Book II | 14 | 13 | 0 |
 | Book III | 37 | **37** | 0 |
-| **I–III total** | **99** | **89** | **0** |
+| **I–III total** | **99** | **96** | **0** |
 | Books IV–XIII | ~365 | — | — |
 
 Update the summary table after each session.
@@ -27,21 +27,21 @@ Update the summary table after each session.
 ## Book I
 
 - [~] I.1 — To construct an equilateral triangle on a given finite straight line.
-- [ ] I.2 — To place a straight line equal to a given straight line with one end at a given point. NEEDS: `polygon;equilateralTriangle`, `point;vertex`
+- [~] I.2 — To place a straight line equal to a given straight line with one end at a given point. (`polygon;equilateralTriangle`, `point;vertex` landed 2026-04-10; tracker drift fixed 2026-04-12.)
 - [~] I.3 — To cut off from the greater of two given unequal straight lines a straight line equal to the less.
-- [ ] I.4 — If two triangles have two sides equal to two sides respectively… (SAS congruence). NEEDS: `circle;radius` 3-point variant (`A,B,C` for "circle at A with radius |BC|" — TBD, distinct from the 2-point IMPL variant). Note: the only remaining arc-only blocker since `sector;arc` landed; this proposition still cannot render until the 3-point circle-radius variant is implemented.
+- [~] I.4 — If two triangles have two sides equal to two sides respectively… (SAS congruence). (3-point `circle;radius` landed 2026-04-12; `sector;arc` landed 2026-04-11; tracker drift fixed 2026-04-12.)
 - [~] I.5 — In isosceles triangles the angles at the base equal one another.
 - [~] I.6 — If in a triangle two angles equal one another, then the sides opposite the equal angles also equal one another.
 - [~] I.7 — Given two straight lines constructed from the ends of a straight line and meeting in a point…
 - [~] I.8 — If two triangles have the two sides equal to two sides respectively, and also have the base equal to the base… (SSS congruence).
-- [ ] I.9 — To bisect a given rectilinear angle. NEEDS: `polygon;equilateralTriangle`, `point;vertex`
-- [ ] I.10 — To bisect a given finite straight line. NEEDS: `polygon;equilateralTriangle`, `point;vertex`
-- [ ] I.11 — To draw a straight line at right angles to a given straight line from a given point on it. NEEDS: `polygon;equilateralTriangle`, `point;vertex`
+- [~] I.9 — To bisect a given rectilinear angle. (`polygon;equilateralTriangle`, `point;vertex` landed 2026-04-10; tracker drift fixed 2026-04-12.)
+- [~] I.10 — To bisect a given finite straight line. (`polygon;equilateralTriangle`, `point;vertex` landed 2026-04-10; tracker drift fixed 2026-04-12.)
+- [~] I.11 — To draw a straight line at right angles to a given straight line from a given point on it. (`polygon;equilateralTriangle`, `point;vertex` landed 2026-04-10; tracker drift fixed 2026-04-12.)
 - [~] I.12 — To draw a straight line perpendicular to a given infinite straight line from a given point not on it. (`line;chord` landed 2026-04-11; test page at view/test/line/chord.html uses these exact params.)
 - [~] I.13 — If a straight line stands on a straight line, then it makes either two right angles or angles whose sum equals two right angles.
 - [~] I.14 — If with any straight line, and at a point on it, two straight lines not lying on the same side make the sum of the adjacent angles equal to two right angles, then the two straight lines are in a straight line with one another.
 - [~] I.15 — If two straight lines cut one another, then they make the vertical angles equal to one another.
-- [ ] I.16 — In any triangle, if one of the sides is produced, then the exterior angle is greater than either of the interior and opposite angles. NEEDS: `point;proportion`  (`sector;arc` landed 2026-04-11)
+- [~] I.16 — In any triangle, if one of the sides is produced, then the exterior angle is greater than either of the interior and opposite angles. (`point;proportion` landed 2026-04-12; `sector;arc` landed 2026-04-11. Note: the primary applet variant doesn't use point;proportion; only the secondary elliptic-geometry variant does.)
 - [~] I.17 — In any triangle the sum of any two angles is less than two right angles.
 - [~] I.18 — In any triangle the angle opposite the greater side is greater.
 - [~] I.19 — In any triangle the side opposite the greater angle is greater.
@@ -54,7 +54,7 @@ Update the summary table after each session.
 - [~] I.26 — If two triangles have two angles equal to two angles respectively, and one side equal to one side… (AAS/ASA congruence). (`polygon;similar` landed 2026-04-12.)
 - [~] I.27 — If a straight line falling on two straight lines makes the alternate angles equal to one another, then the straight lines are parallel. (`line;parallel` landed 2026-04-11.)
 - [~] I.28 — If a straight line falling on two straight lines makes the exterior angle equal to the interior and opposite angle on the same side… (`point;parallelogram` landed 2026-04-10; tracker drift fixed 2026-04-12.)
-- [ ] I.29 — A straight line falling on parallel straight lines makes the alternate angles equal to one another… NEEDS: `point;parallelogram`, `point;proportion`
+- [~] I.29 — A straight line falling on parallel straight lines makes the alternate angles equal to one another… (`point;parallelogram` landed 2026-04-10; `point;proportion` landed 2026-04-12. Primary applet variant doesn't use point;proportion.)
 - [~] I.30 — Straight lines parallel to the same straight line are also parallel to one another. (`point;parallelogram` landed 2026-04-10; tracker drift fixed 2026-04-12.)
 - [~] I.31 — To draw a straight line through a given point parallel to a given straight line. (`line;similar` landed 2026-04-12.)
 - [~] I.32 — In any triangle, if one of the sides is produced, then the exterior angle equals the sum of the two interior and opposite angles… (`point;parallelogram` landed 2026-04-10; tracker drift fixed 2026-04-12.)

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -37,6 +37,7 @@ import {PlanePerpendicularLine} from "./line/PlanePerpendicularLine";
 import {Bichord} from "./line/Bichord";
 import {Chord} from "./line/Chord";
 import {SimilarElement} from "./point/SimilarElement";
+import {ProportionElement} from "./point/ProportionElement";
 import {PolygonElement} from "./polygon/PolygonElement";
 import {RegularPolygonElement} from "./polygon/RegularPolygonElement";
 import {SphereElement} from "./sphere/SphereElement";
@@ -684,11 +685,21 @@ export class PointPerpendicular5Construction extends PointPerpendicularConstruct
 }
 
 
-// TBD
 // point
 // proportion
-// 8 points A, B, C, D, E, F, G, H
-// the point I on GH so that AB:CD = EF:GI
+// 8 points S0, S1, T0, T1, U0, U1, V0, V1
+// the point V' on V0V1 so that |S0S1|:|T0T1| = |U0U1|:|V0V'|
+// (Java: Proportion.java — 26 lines, line-for-line port)
+export class ProportionPointConstruction extends Construction {
+    constructionMethod: AllConstructions = PointConstructions.proportion;
+    signature: ConstructionTypes[] = (new Array(8)).fill(ct.PointElement);
+
+    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let g = new ProportionElement(ps[0], ps[1], ps[2], ps[3], ps[4], ps[5], ps[6], ps[7]);
+        return [[g], g];
+    }
+}
 
 // TBD
 // point
@@ -1399,6 +1410,7 @@ export const constructions : Construction[] = [
     new CutoffConstruction(),
     new ParallelogramConstruction(),
     new SimilarPointConstruction(),
+    new ProportionPointConstruction(),
     new CircumcircleConstruction(),
     new CircumcircleConstruction2d(),
     new LineSliderConstruction(),

--- a/src/elements/point/ProportionElement.ts
+++ b/src/elements/point/ProportionElement.ts
@@ -1,0 +1,56 @@
+/*----------------------------------------------------------------------+
+|    Title:	ProportionElement.ts                                        |
+|    A port of the software Geometry Applet by                          |
+|    Author:    David E. Joyce                                          |
+|        Department of Mathematics and Computer Science                 |
+|        Clark University                                               |
+|        Worcester, MA 01610-1477                                       |
+|        U.S.A.                                                         |
+|                                                                       |
+|        http://aleph0.clarku.edu/~djoyce/home.html                     |
+|        djoyce@clarku.edu                                              |
+|                                                                       |
+|    Date:    February, 1996.   Version 2.0.0 May, 1997.                |
+|    TypeScript Port: 2026, Nelson Brown, brownnrl@gmail.com            |
+|                           https://www.nelsonbrown.net/                |
++----------------------------------------------------------------------*/
+
+import {PointElement} from "./PointElement";
+
+export class ProportionElement extends PointElement {
+  /*--------------------------------------------------------------------+
+  | Given lines S(S0,S1), T(T0,T1), U(U0,U1), V(V0,V1), cut off from  |
+  | V a fourth proportional V' so that S:T = U:V'.                     |
+  +--------------------------------------------------------------------*/
+
+  private _S0: PointElement;
+  private _S1: PointElement;
+  private _T0: PointElement;
+  private _T1: PointElement;
+  private _U0: PointElement;
+  private _U1: PointElement;
+  private _V0: PointElement;
+  private _V1: PointElement;
+
+  constructor(S0: PointElement, S1: PointElement, T0: PointElement,
+              T1: PointElement, U0: PointElement, U1: PointElement,
+              V0: PointElement, V1: PointElement) {
+    super();
+    this.dimension = 0;
+    this._S0 = S0; this._S1 = S1;
+    this._T0 = T0; this._T1 = T1;
+    this._U0 = U0; this._U1 = U1;
+    this._V0 = V0; this._V1 = V1;
+    if (V0._AP === V1._AP) {
+      this._AP = V0._AP;
+    }
+  }
+
+  public update() {
+    let factor : number = this._T0.distance2(this._T1) * this._U0.distance2(this._U1)
+                        / (this._S0.distance2(this._S1) * this._V0.distance2(this._V1));
+    factor = Math.sqrt(factor);
+    this.to(this._V1).minus(this._V0);
+    this.times(factor).plus(this._V0);
+  }
+}

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -566,6 +566,32 @@ describe("slate", ()=> {
     //   A=(50,200), B=(150,200)
     //   C = rotate B around A by π/2 then scale by 0.5 → (50, 250)
 
+    // point;proportion — point V' on V0V1 so that |S|:|T| = |U|:|V'|
+    // S=(0,0)→(100,0) len=100; T=(0,0)→(50,0) len=50;
+    // U=(0,0)→(80,0) len=80;  V=(0,0)→(200,0) len=200
+    // factor = sqrt(50²*80² / (100²*200²)) = 4000/20000 = 0.2
+    // result = (0,0) + 0.2 * (200,0) = (40, 0)
+    // Check: S:T = 100:50 = 2:1; U:V' = 80:40 = 2:1 ✓
+    it("should compute a fourth proportional point", () => {
+        let data : IConstructionInfo[] = [
+            { name: "S0", construction: E.Point.free, params: [0, 0] },
+            { name: "S1", construction: E.Point.free, params: [100, 0] },
+            { name: "T0", construction: E.Point.free, params: [0, 0] },
+            { name: "T1", construction: E.Point.free, params: [50, 0] },
+            { name: "U0", construction: E.Point.free, params: [0, 0] },
+            { name: "U1", construction: E.Point.free, params: [80, 0] },
+            { name: "V0", construction: E.Point.free, params: [0, 0] },
+            { name: "V1", construction: E.Point.free, params: [200, 0] },
+            { name: "P",  construction: E.Point.proportion, params: ["S0","S1","T0","T1","U0","U1","V0","V1"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let P = slate.lookupElement("P") as PointElement;
+        almostEqual(P.x, 40, 0.01);
+        almostEqual(P.y,  0, 0.01);
+    });
+
     // polygon;similar — triangle ABH where H is the similar point so △ABH ∼ △DEF
     // propI23: A=(40,180), G=(cutoff result), C=(190,80), E=(270,180), D=(260,40)
     // Simpler standalone: A=(50,200), B=(150,200), D=(0,0), E=(100,0), F=(0,100)

--- a/view/applet-tests/point/proportion/applet.html
+++ b/view/applet-tests/point/proportion/applet.html
@@ -1,0 +1,28 @@
+<HTML><HEAD><TITLE>point;proportion — applet form of view/test/point/proportion.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/point/proportion.html -->
+<!-- ORIGINAL: view/applet-tests/point/proportion/original.html (propI16 elliptic variant) -->
+<!--
+  Standalone proportion test: four segments S, T, U, V drawn as horizontal
+  lines. P is the fourth proportional on V so that S:T = U:V0P. Drag any
+  segment endpoint to see P recompute.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="Point.proportion">
+<param name=e[1] value="S0;point;free;30,50">
+<param name=e[2] value="S1;point;free;130,50">
+<param name=e[3] value="S;line;connect;S0,S1">
+<param name=e[4] value="T0;point;free;30,100">
+<param name=e[5] value="T1;point;free;80,100">
+<param name=e[6] value="T;line;connect;T0,T1">
+<param name=e[7] value="U0;point;free;30,150">
+<param name=e[8] value="U1;point;free;110,150">
+<param name=e[9] value="U;line;connect;U0,U1">
+<param name=e[10] value="V0;point;free;30,250">
+<param name=e[11] value="V1;point;free;230,250">
+<param name=e[12] value="V;line;connect;V0,V1">
+<param name=e[13] value="P;point;proportion;S0,S1,T0,T1,U0,U1,V0,V1">
+<param name=e[14] value="VP;line;connect;V0,P">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point/proportion/original.html
+++ b/view/applet-tests/point/proportion/original.html
@@ -1,0 +1,17 @@
+<HTML><HEAD><TITLE>I.16 — point;proportion (original, elliptic variant)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=300 width=300>
+<param name=background value="35,19,100">
+<param name=title value="I.16 elliptic">
+<param name=e[1] value="O;point;free;150,150;0;0">
+<param name=e[2] value="P;point;free;260,150;0;0">
+<param name=e[3] value="disk;circle;radius;O,P;0;0;blue;random">
+<param name=e[4] value="A;point;free;70,140">
+<param name=e[5] value="B;point;free;150,170">
+<param name=e[6] value="C;point;free;125,90">
+<param name=e[7] value="A#;point;proportion;O,A,O,P,O,P,O,A;0;0">
+<param name=e[8] value="A*;point;extend;A,O,O,A#;0;0">
+<param name=e[9] value="C#;point;proportion;O,C,O,P,O,P,O,C;0;0">
+<param name=e[10] value="C*;point;extend;C,O,O,C#;0;0">
+</applet>
+</BODY></HTML>

--- a/view/test/point/proportion.html
+++ b/view/test/point/proportion.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+    <title>Test View - Point.proportion (standalone)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "Point.proportion — fourth proportional",
+        canvasid: "canvasId",
+        elements: [
+            // Segment S: length 100
+            { name: "S0", construction: E.Point.free, params: [30, 50] },
+            { name: "S1", construction: E.Point.free, params: [130, 50] },
+            { name: "S",  construction: E.Line.connect, params: ["S0", "S1"] },
+            // Segment T: length 50
+            { name: "T0", construction: E.Point.free, params: [30, 100] },
+            { name: "T1", construction: E.Point.free, params: [80, 100] },
+            { name: "T",  construction: E.Line.connect, params: ["T0", "T1"] },
+            // Segment U: length 80
+            { name: "U0", construction: E.Point.free, params: [30, 150] },
+            { name: "U1", construction: E.Point.free, params: [110, 150] },
+            { name: "U",  construction: E.Line.connect, params: ["U0", "U1"] },
+            // Segment V: length 200
+            { name: "V0", construction: E.Point.free, params: [30, 250] },
+            { name: "V1", construction: E.Point.free, params: [230, 250] },
+            { name: "V",  construction: E.Line.connect, params: ["V0", "V1"] },
+            // Fourth proportional P on V so that S:T = U:V0P
+            // factor = (T*U)/(S*V) = (50*80)/(100*200) = 0.2
+            // P = V0 + 0.2*(V1-V0) = (30,250) + 0.2*(200,0) = (70,250)
+            { name: "P",  construction: E.Point.proportion, params: ["S0","S1","T0","T1","U0","U1","V0","V1"] },
+            { name: "VP", construction: E.Line.connect, params: ["V0", "P"] },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds `point;proportion` (port of `Proportion.java`) — the fourth-proportional construction. Also fixes 5 tracker-drift entries (I.2, I.4, I.9, I.10, I.11). **96/99 renderable — only `polygon;application` remains as the final construction needed for 100%.**

## What's in this branch

- `254d8c8` point-proportion: step 3 — add original.html from propI16 (elliptic variant)
- `68b9a45` point-proportion: step 4 — add ProportionElement.ts
- `5d3471b` point-proportion: step 5 — wire ProportionPointConstruction
- `fe984a8` point-proportion: step 6 — Mocha test
- `9706eb8` point-proportion: step 7 — three-way view pair (TS page + applet.html)
- `c8f05e4` point-proportion: step 8 — tracker + journal + drift fix (96/99)

## Construction details

- **Element class**: `src/elements/point/ProportionElement.ts` — extends `PointElement`. Constructor `(S0,S1,T0,T1,U0,U1,V0,V1)`. `update()`: `factor = sqrt(|T|²·|U|² / (|S|²·|V|²))`, then `this.to(V1).minus(V0).times(factor).plus(V0)`.
- **Construction class**: `ProportionPointConstruction` — signature `[PointElement × 8]`. Dispatches to `PointConstructions.proportion = 17`.
- **Java source**: `Proportion.java` — 26 lines, line-for-line port.

## Tests

33 → **34 passing**. One new test: factor=0.2 with collinear coords, result at (40,0), proportion S:T=U:V'=2:1.

## Verification

- [x] `npm run build` clean
- [x] `npm test` passes (34/34)
- [x] `npx webpack` rebuilds `dist/bundle.js`
- [x] Three-way harness — **needs human verification**

## Newly renderable propositions

- **Book I** (39 → 46): I.2, I.4, I.9, I.10, I.11 (drift fix), I.16, I.29 (proportion)
- **I–III total** (89 → 96): +7

Only **3 propositions remain**: I.44, I.45, II.14 — all blocked by `polygon;application`.

## Discovered / out of scope

- propI16 and propI29 have dual applet variants; the primary variants were already renderable without `point;proportion`. Only the secondary elliptic-geometry variants use it.
- `polygon;application` is the **final construction** needed for 100% Books I–III renderability.
