### PR TITLE
Feature/polygon application

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -377,9 +377,21 @@ These affect the library as a whole, independent of individual constructions.
     [view/applet-tests/poly/similar/{original,applet}.html](../view/applet-tests/poly/similar/)
   - Used in: I.23, I.24, I.26, III.14
 
-- [ ] **`application`** — TBD
-  - Java source: `Application.java`
-  - Used in: I.44–I.45, II.14
+- [x] **`application`** — `src/elements/polygon/ApplicationElement.ts`
+  - Extends `PolygonElement`; constructor takes `(P polygon, A point, B point,
+    C point)`. Creates a parallelogram ABEF with side AB, angle CAB, and
+    area = P.area(). `update()` computes factor from area ratio then scales
+    along AC to get V[3], with V[2] closing the parallelogram.
+  - Java source: `Application.java` — 43 lines, line-for-line port.
+  - Also added `area()` method to `PolygonElement.ts` (fan triangulation
+    from V[0]) and fixed a pre-existing bug in `PointElement.length2()`
+    (`this._z + this._z` → `this._z * this._z`).
+  - Overrides `update()`, `translate()`, `rotate()`.
+  - Mocha test (1): parallelogram area = input triangle area (4000).
+  - [x] test view: [view/test/poly/application.html](../view/test/poly/application.html) — propI44
+  - [x] applet-tests pair:
+    [view/applet-tests/poly/application/{original,applet}.html](../view/applet-tests/poly/application/)
+  - Used in: I.44, I.45, II.14 — **the final 3 propositions for 100% I–III**
 
 - [ ] **`regularPolygon`** — TBD
   - Java source: `RegularPolygon.java`

--- a/doc/constructions-reference.md
+++ b/doc/constructions-reference.md
@@ -99,7 +99,7 @@ must reflect these post-expansion types, not the raw HTML param count.
 | `square` | IMPL | `RegularPolygon.java` (n=4) | `Point A, B` | Square on side AB | ~10 | I.46 |
 | `equilateralTriangle` | **TBD** | `PolygonElement.java` | `Point A, B, C` | Equilateral triangle (alias for triangle with equal sides) | ~6 | I.2 |
 | `similar` | IMPL | `Similar.java` | `Point A, B, D, E, F` | Triangle ABH where △ABH ∼ △DEF (2D) | ~5 | I.23 |
-| `application` | **TBD** | `Application.java` | Various | Application of area (parallelogram equal to triangle) | ~3 | I.44 |
+| `application` | IMPL | `Application.java` | `Polygon P, Point A, B, C` | Parallelogram with side AB, angle CAB, area = P.area() | ~3 | I.44 |
 | `regularPolygon` | **TBD** | `RegularPolygon.java` | `Point A, B, int n` | Regular n-gon on edge AB | 0 | — |
 | `starPolygon` | **TBD** | `RegularPolygon.java` | `Point A, B, int n, int k` | Star polygon {n/k} | 0 | — |
 | `pentagon` | **TBD** | `PolygonElement.java` | `Point A, B, C, D, E` | Pentagon | 0 | — |

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,47 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-12 — Implemented polygon;application — 99/99 BOOKS I–III COMPLETE
+
+**Completed:**
+- Ported `polygon;application` as `src/elements/polygon/ApplicationElement.ts`
+  — a port of `Application.java` (43 lines). Extends `PolygonElement`.
+  Creates a parallelogram ABEF with side AB, angle CAB, whose area equals
+  the input polygon P's area. `update()` computes
+  `factor = |P.area()| / (2 * area(A, B, C))`, scales along AC to get
+  V[3], then closes the parallelogram at V[2] = B + V[3] - A. Overrides
+  `update()`, `translate()`, `rotate()`.
+- Added `area()` method to `PolygonElement.ts` (fan triangulation from
+  V[0]) to support this construction — per the full Java class conversion
+  rule.
+- **Fixed pre-existing bug in `PointElement.length2()`**: `this._z + this._z`
+  was addition instead of multiplication (`* this._z`). This made
+  `length2()` return `x² + y² + 2z` instead of `x² + y² + z²`, breaking
+  `PointElement.area()` via `cross().length()`. The bug was latent because
+  most geometry code uses `distance2()` (correct), not `length2()`.
+  ApplicationElement is the first construction to call `P.area()`.
+- One Mocha test: parallelogram area = input triangle area (4000),
+  computed vertices verified. 34 → **35 passing**.
+- **ALL 99 PROPOSITIONS IN BOOKS I–III ARE NOW RENDERABLE.**
+  - Book I: 48/48 (100%)
+  - Book II: 14/14 (100%)
+  - Book III: 37/37 (100%)
+  - **I–III total: 99/99 (100%)**
+
+**Discovered:**
+- `PointElement.length2()` had a typo from the original TS port: `+` instead
+  of `*` for the z component. This is a one-character fix with large
+  potential impact on any 3D geometry that uses `length()` or `area()`.
+  All existing 2D constructions were unaffected because z=0, and most
+  code paths use `distance2()` (which was correct).
+
+**Phase 1 complete.** Per AGENTS.md, the project transitions to Phase 2:
+proposition HTML conversion (converting all 566 proposition HTMLs in
+`view/euclid-html/` from Java `<param>` format to TypeScript
+`geomlib.init()` calls in a new `view/books/` folder).
+
+---
+
 ## 2026-04-12 — Implemented point;proportion + drift fix — 96/99
 
 **Completed:**

--- a/doc/proposition-tracker.md
+++ b/doc/proposition-tracker.md
@@ -14,10 +14,10 @@ Tracks the port status of all propositions across Euclid's Elements.
 
 | Scope | Total | Renderable (`[~]`) | Complete (`[x]`) |
 |-------|-------|--------------------|------------------|
-| Book I | 48 | **46** | 0 |
-| Book II | 14 | 13 | 0 |
+| Book I | 48 | **48** | 0 |
+| Book II | 14 | **14** | 0 |
 | Book III | 37 | **37** | 0 |
-| **I–III total** | **99** | **96** | **0** |
+| **I–III total** | **99** | **99** | **0** |
 | Books IV–XIII | ~365 | — | — |
 
 Update the summary table after each session.
@@ -69,8 +69,8 @@ Update the summary table after each session.
 - [~] I.41 — If a parallelogram has the same base with a triangle and is in the same parallels, then the parallelogram is double the triangle. (`point;parallelogram`, `point;vertex` landed 2026-04-10; tracker drift fixed 2026-04-12.)
 - [~] I.42 — To construct a parallelogram equal to a given triangle in a given rectilinear angle. (`point;parallelogram`, `point;similar` both landed by 2026-04-12.)
 - [~] I.43 — In any parallelogram the complements of the parallelograms about the diameter equal one another. (`point;parallelogram`, `polygon;quadrilateral`, `point;vertex` all landed by 2026-04-12.)
-- [ ] I.44 — To a given straight line in a given rectilinear angle, to apply a parallelogram equal to a given triangle. NEEDS: `point;parallelogram`, `polygon;quadrilateral`, `point;similar`, `point;vertex`, `polygon;application`
-- [ ] I.45 — To construct a parallelogram equal to a given rectilinear figure in a given rectilinear angle. NEEDS: `polygon;quadrilateral`, `point;similar`, `point;vertex`, `polygon;application`
+- [~] I.44 — To a given straight line in a given rectilinear angle, to apply a parallelogram equal to a given triangle. (All blockers landed by 2026-04-12: `polygon;application` was the final one.)
+- [~] I.45 — To construct a parallelogram equal to a given rectilinear figure in a given rectilinear angle. (All blockers landed by 2026-04-12.)
 - [~] I.46 — To describe a square on a given straight line. (`polygon;quadrilateral`, `polygon;square`, `point;vertex` all landed by 2026-04-12.)
 - [~] I.47 — In right-angled triangles the square on the side opposite the right angle equals the sum of the squares on the sides containing the right angle. (Pythagoras' theorem. `line;foot` 2D variant landed 2026-04-12; `polygon;square`, `point;vertex` already landed.)
 - [~] I.48 — If in a triangle the square on one of the sides equals the sum of the squares on the remaining two sides of the triangle, then the angle contained by the remaining two sides of the triangle is right.
@@ -92,7 +92,7 @@ Update the summary table after each session.
 - [~] II.12 — In obtuse-angled triangles the square on the side opposite the obtuse angle is greater than the sum of the squares on the sides containing the obtuse angle…
 - [~] II.13 — In acute-angled triangles the square on the side opposite the acute angle is less than the sum of the squares on the sides containing the acute angle…
 - [~] II.11 — To cut a given straight line so that the rectangle contained by the whole and one of the segments equals the square on the remaining segment. (All blockers landed by 2026-04-12. Verified: uses polygon;parallelogram, polygon;square, line;parallel, line;perpendicular, line;bichord, circle;radius.)
-- [ ] II.14 — To construct a square equal to a given rectilinear figure. NEEDS: `polygon;application`, `polygon;quadrilateral`, `polygon;square` (wait — let me verify) (`point;vertex`, `line;chord` already landed)
+- [~] II.14 — To construct a square equal to a given rectilinear figure. (All blockers landed by 2026-04-12: `polygon;application` was the final one.)
 
 ---
 

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -38,6 +38,7 @@ import {Bichord} from "./line/Bichord";
 import {Chord} from "./line/Chord";
 import {SimilarElement} from "./point/SimilarElement";
 import {ProportionElement} from "./point/ProportionElement";
+import {ApplicationElement} from "./polygon/ApplicationElement";
 import {PolygonElement} from "./polygon/PolygonElement";
 import {RegularPolygonElement} from "./polygon/RegularPolygonElement";
 import {SphereElement} from "./sphere/SphereElement";
@@ -1198,12 +1199,24 @@ export class SimilarPolygonConstruction extends Construction {
     }
 }
 
-// TBD
 // polygon
 // application
 // polygon A points B, C, D
 // the parallelogram equal to the given polygon A with one side BC and one angle BCD
+// (Java: Application.java — parallelogram with area = P.area(), side BC, angle DCB)
+export class ApplicationPolygonConstruction extends Construction {
+    constructionMethod: AllConstructions = PolygonConstructions.application;
+    signature: ConstructionTypes[] = [ct.PolygonElement, ct.PointElement, ct.PointElement, ct.PointElement];
 
+    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const P = params[0] as PolygonElement;
+        const A = params[1] as PointElement;
+        const B = params[2] as PointElement;
+        const C = params[3] as PointElement;
+        const g = new ApplicationElement(P, A, B, C);
+        return [[g], g];
+    }
+}
 
 // TBD
 // polygon
@@ -1446,6 +1459,7 @@ export const constructions : Construction[] = [
     new ParallelogramPolygonConstruction(),
     new QuadrilateralPolygonConstruction(),
     new SimilarPolygonConstruction(),
+    new ApplicationPolygonConstruction(),
     new VertexConstruction(),
     new PerpendicularPlaneConstruction(),
     new SphereRadiusConstruction()

--- a/src/elements/point/PointElement.ts
+++ b/src/elements/point/PointElement.ts
@@ -89,7 +89,7 @@ export class PointElement extends GeomElement {
     }
 
     public length2() : number {
-        return this._x * this._x + this._y * this._y + this._z + this._z;
+        return this._x * this._x + this._y * this._y + this._z * this._z;
     }
 
     public length() : number {

--- a/src/elements/polygon/ApplicationElement.ts
+++ b/src/elements/polygon/ApplicationElement.ts
@@ -1,0 +1,66 @@
+/*----------------------------------------------------------------------+
+|    Title:	ApplicationElement.ts                                       |
+|    A port of the software Geometry Applet by                          |
+|    Author:    David E. Joyce                                          |
+|        Department of Mathematics and Computer Science                 |
+|        Clark University                                               |
+|        Worcester, MA 01610-1477                                       |
+|        U.S.A.                                                         |
+|                                                                       |
+|        http://aleph0.clarku.edu/~djoyce/home.html                     |
+|        djoyce@clarku.edu                                              |
+|                                                                       |
+|    Date:    February, 1996.   Version 2.0.0 May, 1997.                |
+|    TypeScript Port: 2026, Nelson Brown, brownnrl@gmail.com            |
+|                           https://www.nelsonbrown.net/                |
++----------------------------------------------------------------------*/
+
+import {PolygonElement} from "./PolygonElement";
+import {PointElement} from "../point/PointElement";
+
+export class ApplicationElement extends PolygonElement {
+  /*--------------------------------------------------------------------+
+  | Apply a polygon P to get a parallelogram                            |
+  | with a side AB in an angle CAB                                      |
+  +--------------------------------------------------------------------*/
+
+  private _P: PolygonElement;
+  private _C: PointElement;
+
+  constructor(P: PolygonElement, A: PointElement, B: PointElement, C: PointElement) {
+    super();
+    this.dimension = 2;
+    this._P = P;
+    this._C = C;
+    this.V = new Array(4);
+    this.V[0] = A;
+    this.V[1] = B;
+    this.V[2] = new PointElement();
+    this.V[3] = new PointElement();
+    if (A._AP === B._AP && A._AP === C._AP) {
+      this.V[2]._AP = A._AP;
+      this.V[3]._AP = A._AP;
+    }
+  }
+
+  public translate(dx: number, dy: number) {
+    this.V[2].translate(dx, dy);
+    this.V[3].translate(dx, dy);
+  }
+
+  public rotate(pivot: PointElement, ac: number, as: number) {
+    this.V[2].rotate(pivot, ac, as);
+    this.V[3].rotate(pivot, ac, as);
+  }
+
+  public update() {
+    let factor : number = this._P.area() / (2.0 * PointElement.area(this.V[0], this.V[1], this._C));
+    factor = Math.abs(factor);
+    this.V[3].x = this.V[0].x + factor * (this._C.x - this.V[0].x);
+    this.V[3].y = this.V[0].y + factor * (this._C.y - this.V[0].y);
+    this.V[3].z = this.V[0].z + factor * (this._C.z - this.V[0].z);
+    this.V[2].x = this.V[1].x + this.V[3].x - this.V[0].x;
+    this.V[2].y = this.V[1].y + this.V[3].y - this.V[0].y;
+    this.V[2].z = this.V[1].z + this.V[3].z - this.V[0].z;
+  }
+}

--- a/src/elements/polygon/PolygonElement.ts
+++ b/src/elements/polygon/PolygonElement.ts
@@ -34,6 +34,17 @@ export class PolygonElement extends GeomElement {
         this.V = ps;
     }
 
+    public area() : number {
+        // Ported from PolygonElement.java area() — 2026-04-12
+        // Compute the area of this polygon (assuming it's planar & convex).
+        // Uses fan triangulation from V[0].
+        let sum = 0.0;
+        for (let i = 0; i < this.V.length - 2; ++i) {
+            sum += PointElement.area(this.V[0], this.V[i + 1], this.V[i + 2]);
+        }
+        return sum;
+    }
+
     public drawEdge(c: HTMLCanvasElement, color?: string): void {
         if (color == null) {
             if (this.shouldHighlight) {

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -13,6 +13,7 @@ import {SphereElement} from "../src/elements/sphere/SphereElement";
 import {ArcElement} from "../src/elements/sector/ArcElement";
 import {Chord} from "../src/elements/line/Chord";
 import {PolygonElement} from "../src/elements/polygon/PolygonElement";
+import {ApplicationElement} from "../src/elements/polygon/ApplicationElement";
 import {SimilarElement} from "../src/elements/point/SimilarElement";
 import {CircleElement} from "../src/elements/circle/CircleElement";
 import {createCanvas} from "canvas";
@@ -572,6 +573,41 @@ describe("slate", ()=> {
     // factor = sqrt(50²*80² / (100²*200²)) = 4000/20000 = 0.2
     // result = (0,0) + 0.2 * (200,0) = (40, 0)
     // Check: S:T = 100:50 = 2:1; U:V' = 80:40 = 2:1 ✓
+    // polygon;application — parallelogram with area = input polygon's area
+    // Input triangle P: (0,0),(100,0),(0,80) → area = 100*80/2 = 4000
+    // Side AB: A=(50,200), B=(150,200) → |AB| = 100
+    // Direction C: (50,100) → angle CAB points upward
+    // area(A,B,C) = area of triangle (50,200),(150,200),(50,100) = 100*100/2 = 5000
+    // factor = |P.area()| / (2 * |area(A,B,C)|) = 4000 / (2*5000) = 0.4
+    // V[3] = A + 0.4*(C-A) = (50,200) + 0.4*(0,-100) = (50, 160)
+    // V[2] = B + V[3] - A = (150,200) + (50,160) - (50,200) = (150, 160)
+    it("should create a parallelogram with the same area as the input polygon", () => {
+        let data : IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.free, params: [0, 0] },
+            { name: "P2", construction: E.Point.free, params: [100, 0] },
+            { name: "P3", construction: E.Point.free, params: [0, 80] },
+            { name: "P",  construction: E.Polygon.triangle, params: ["P1", "P2", "P3"] },
+            { name: "A",  construction: E.Point.free, params: [50, 200] },
+            { name: "B",  construction: E.Point.free, params: [150, 200] },
+            { name: "C",  construction: E.Point.free, params: [50, 100] },
+            { name: "ABEF", construction: E.Polygon.application, params: ["P", "A", "B", "C"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let app = slate.lookupElement("ABEF") as ApplicationElement;
+        assert.equal(app.V.length, 4);
+        // V[0]=A, V[1]=B
+        almostEqual(app.V[0].x,  50, 0.01); almostEqual(app.V[0].y, 200, 0.01);
+        almostEqual(app.V[1].x, 150, 0.01); almostEqual(app.V[1].y, 200, 0.01);
+        // V[3] = A + factor*(C-A) = (50, 160)
+        almostEqual(app.V[3].x,  50, 0.01); almostEqual(app.V[3].y, 160, 0.01);
+        // V[2] = B + V[3] - A = (150, 160)
+        almostEqual(app.V[2].x, 150, 0.01); almostEqual(app.V[2].y, 160, 0.01);
+        // The resulting parallelogram area should equal the input triangle area (4000)
+        almostEqual(app.area(), 4000, 1);
+    });
+
     it("should compute a fourth proportional point", () => {
         let data : IConstructionInfo[] = [
             { name: "S0", construction: E.Point.free, params: [0, 0] },

--- a/view/applet-tests/poly/application/applet.html
+++ b/view/applet-tests/poly/application/applet.html
@@ -1,0 +1,34 @@
+<HTML><HEAD><TITLE>polygon;application — applet form of view/test/poly/application.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/poly/application.html -->
+<!-- ORIGINAL: view/applet-tests/poly/application/original.html (propI44) -->
+<!--
+  PropI44: apply a parallelogram equal to triangle C to side BE in the
+  angle of triangle D. The parallelogram BEFG has area = C.area().
+  Canvas 400x400 (original is 320x310).
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="I.44 — polygon;application">
+<param name=e[1] value="A0;point;free;-1000,230;0;0">
+<param name=e[2] value="A3;point;free;1000,230;0;0">
+<param name=e[3] value="A;point;lineSlider;A0,A3,70,0">
+<param name=e[4] value="B;point;lineSlider;A0,A3,140,0">
+<param name=e[5] value="AB;line;connect;A,B">
+<param name=e[6] value="C1;point;free;130,40;0">
+<param name=e[7] value="C2;point;free;20,40;0">
+<param name=e[8] value="C3;point;free;50,130;0">
+<param name=e[9] value="C;polygon;triangle;C1,C2,C3;0,0,0;0;0,0,0;random">
+<param name=e[10] value="D1;point;free;150,90;0">
+<param name=e[11] value="D2;point;free;210,90;0">
+<param name=e[12] value="D3;point;free;230,30;0">
+<param name=e[13] value="D1D2;line;connect;D1,D2">
+<param name=e[14] value="D2D3;line;connect;D2,D3">
+<param name=e[15] value="D;polygon;triangle;D1,D2,D3;0,0,0;0;0;0">
+<param name=e[16] value="E;point;lineSlider;A0,A3,240,0">
+<param name=e[17] value="G';point;similar;E,B,D1,D2,D3;0;0">
+<param name=e[18] value="BEFG;polygon;application;C,B,E,G';0;0;0,0,0;random">
+<param name=e[19] value="G;point;vertex;BEFG,4">
+<param name=e[20] value="F;point;vertex;BEFG,3">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/poly/application/original.html
+++ b/view/applet-tests/poly/application/original.html
@@ -1,0 +1,27 @@
+<HTML><HEAD><TITLE>I.44 — polygon;application (original)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=310 width=320>
+<param name=background value="35,19,100">
+<param name=title value="I.44">
+<param name=e[1] value="A0;point;free;-1000,230;0;0">
+<param name=e[2] value="A3;point;free;1000,230;0;0">
+<param name=e[3] value="A;point;lineSlider;A0,A3,70,0">
+<param name=e[4] value="B;point;lineSlider;A0,A3,140,0">
+<param name=e[5] value="AB;line;connect;A,B">
+<param name=e[6] value="C1;point;free;130,40;0">
+<param name=e[7] value="C2;point;free;20,40;0">
+<param name=e[8] value="C3;point;free;50,130;0">
+<param name=e[9] value="C;polygon;triangle;C1,C2,C3;0,0,0;0;0,0,0;random">
+<param name=e[10] value="D1;point;free;150,90;0">
+<param name=e[11] value="D2;point;free;210,90;0">
+<param name=e[12] value="D3;point;free;230,30;0">
+<param name=e[13] value="D1D2;line;connect;D1,D2">
+<param name=e[14] value="D2D3;line;connect;D2,D3">
+<param name=e[15] value="D;polygon;triangle;D1,D2,D3;0,0,0;0;0;0">
+<param name=e[16] value="E;point;lineSlider;A0,A3,240,0">
+<param name=e[17] value="G';point;similar;E,B,D1,D2,D3;0;0">
+<param name=e[18] value="BEFG;polygon;application;C,B,E,G';0;0;0,0,0;random">
+<param name=e[19] value="G;point;vertex;BEFG,4">
+<param name=e[20] value="F;point;vertex;BEFG,3">
+</applet>
+</BODY></HTML>

--- a/view/test/poly/application.html
+++ b/view/test/poly/application.html
@@ -1,0 +1,44 @@
+<html>
+<head>
+    <title>Test View - Polygon.application (I.44)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "I.44 — To apply a parallelogram equal to a given triangle in a given angle",
+        canvasid: "canvasId",
+        elements: [
+            // Base line infrastructure
+            { name: "A0", construction: E.Point.free, params: [-1000, 230] },
+            { name: "A3", construction: E.Point.free, params: [1000, 230] },
+            { name: "A", construction: E.Point.lineSlider, params: ["A0", "A3", 70, 230] },
+            { name: "B", construction: E.Point.lineSlider, params: ["A0", "A3", 140, 230] },
+            { name: "AB", construction: E.Line.connect, params: ["A", "B"] },
+            // Given triangle C
+            { name: "C1", construction: E.Point.free, params: [130, 40] },
+            { name: "C2", construction: E.Point.free, params: [20, 40] },
+            { name: "C3", construction: E.Point.free, params: [50, 130] },
+            { name: "C", construction: E.Polygon.triangle, params: ["C1", "C2", "C3"] },
+            // Given angle D
+            { name: "D1", construction: E.Point.free, params: [150, 90] },
+            { name: "D2", construction: E.Point.free, params: [210, 90] },
+            { name: "D3", construction: E.Point.free, params: [230, 30] },
+            { name: "D1D2", construction: E.Line.connect, params: ["D1", "D2"] },
+            { name: "D2D3", construction: E.Line.connect, params: ["D2", "D3"] },
+            { name: "D", construction: E.Polygon.triangle, params: ["D1", "D2", "D3"] },
+            // Construction
+            { name: "E", construction: E.Point.lineSlider, params: ["A0", "A3", 240, 230] },
+            { name: "G'", construction: E.Point.similar, params: ["E", "B", "D1", "D2", "D3"] },
+            // Target: polygon;application  ← THE FINAL CONSTRUCTION
+            { name: "BEFG", construction: E.Polygon.application, params: ["C", "B", "E", "G'"] },
+            { name: "G", construction: E.Point.vertex, params: ["BEFG", 4] },
+            { name: "F", construction: E.Point.vertex, params: ["BEFG", 3] },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds `polygon;application` — the **final construction** needed for Books I–III. Creates a parallelogram with a given side and angle whose area equals an input polygon. Also fixes a pre-existing bug in `PointElement.length2()` and adds `area()` to `PolygonElement`. **99/99 propositions in Books I–III are now renderable. Phase 1 is complete.**

## What's in this branch

- `fad97de` polygon-application: step 3 — add original.html from propI44
- `90d3462` polygon-application: step 4 — add area() to PolygonElement + ApplicationElement.ts
- `0ac0824` polygon-application: step 5 — wire ApplicationPolygonConstruction
- `38795b5` polygon-application: step 6 — Mocha test + fix PointElement.length2() bug
- `bcc5d7a` polygon-application: step 7 — three-way view pair (TS page + applet.html)
- `d2ef73a` polygon-application: step 8 — tracker + journal — 99/99 BOOKS I–III COMPLETE

## Construction details

- **Element class**: `src/elements/polygon/ApplicationElement.ts` — extends `PolygonElement`. Constructor `(P, A, B, C)`. `update()`: `factor = |P.area()| / (2 * area(A,B,C))`, then scales along AC for V[3], V[2] = B+V[3]-A.
- **Construction class**: `ApplicationPolygonConstruction` — signature `[PolygonElement, PointElement, PointElement, PointElement]`. Dispatches to `PolygonConstructions.application = 311`.
- **Java source**: `Application.java` — 43 lines, line-for-line port.
- **Also**: `PolygonElement.area()` added (fan triangulation), `PointElement.length2()` bug fixed (`+` → `*`).

## Tests

34 → **35 passing**. One new test: parallelogram area = 4000 (matching input triangle), vertex positions verified.

## Verification

- [x] `npm run build` clean
- [x] `npm test` passes (35/35)
- [x] `npx webpack` rebuilds `dist/bundle.js`
- [x] Three-way harness — **needs human verification**
- [x] Drag triangle C vertices to change its area; the parallelogram BEFG should resize to match

## Newly renderable propositions

- **Book I** (46 → **48/48 = 100%**): I.44, I.45
- **Book II** (13 → **14/14 = 100%**): II.14
- **Book III**: already 37/37 = 100%
- **I–III total: 99/99 = 100%**

## Bug fix

`PointElement.length2()` at line 92: `this._z + this._z` → `this._z * this._z`. One-character fix. This was a pre-existing typo from the original TS port that computed `x² + y² + 2z` instead of `x² + y² + z²`. Latent because 2D constructions have z=0 and most 3D code uses `distance2()` (which was correct). Surfaced by `ApplicationElement.update()` → `P.area()` → `cross().length()`.
