### PR TITLE
Feature/scope extension bookiv

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,28 +74,40 @@ and **do not start implementing** until the user has picked a construction:
 ### Project phase
 
 As of this writing the project is in **Phase 1: porting remaining Java
-constructions to TypeScript.** This phase continues until
-[doc/construction-tracker.md](doc/construction-tracker.md) shows every
-construction as IMPL. ~24 of ~65 Java constructions were ported before this
-protocol was formalized; the remaining ~40 are tracked one-per-session.
-**Until Phase 1 completes, the session startup protocol above is the
-default onboarding for every fresh session.**
+constructions to TypeScript.** This phase covers **all books (I–XIII)**,
+not just Books I–III. Progress is driven book-by-book: each new book's
+propositions are analyzed against the construction and
+[Java port tracker](doc/java-port-tracker.md) to discover which TBD
+constructions it needs, then those constructions are ported one-per-session
+using the 8-step workflow. Phase 1 continues until every proposition in
+every book is renderable. **Until Phase 1 completes, the session startup
+protocol above is the default onboarding for every fresh session.**
+
+Books I–III reached 99/99 renderable on 2026-04-12. Book IV analysis is
+underway. Books V–XIII will be analyzed and expanded into the proposition
+tracker one book at a time as Phase 1 progresses.
 
 After Phase 1 completes the project transitions to:
 
-- **Phase 2 — proposition HTML conversion.** Convert all 566 proposition
+- **Phase 2 — presentation bug fixes.** Fix visual divergences between
+  the Java applet and the TypeScript port: colors (parseColor bug,
+  numeric-0 handling, HSB format, default faceColor), label placement,
+  and any behavioral differences discovered during the book-by-book
+  harness verification in Phase 1. The goal is pixel-level visual parity
+  with Joyce's original applets at rest.
+- **Phase 3 — proposition HTML conversion.** Convert all 566 proposition
   HTMLs in `view/euclid-html/` from Java `<param>` format to TypeScript
   `geomlib.init()` calls in a new `view/books/` folder. The working unit
   becomes "one proposition" instead of "one construction" but the
   per-step-commit + feature-branch + human-review workflow is unchanged.
-- **Phase 3 — retire the Java toolchain.** `run_euclid_applet.sh` and both
+- **Phase 4 — retire the Java toolchain.** `run_euclid_applet.sh` and both
   `Containerfile*` files go away; `view/euclid-html/` and `Geometry.zip`
   can be archived or deleted; the `geom_applet/source/*.java` reference
   tree becomes read-only history.
 
-If the startup protocol finds Phase 1 complete (zero TBDs in the tracker),
-**flag this to the user first** so they can confirm the transition rather
-than quietly changing cadence.
+If the startup protocol finds Phase 1 complete (every proposition in every
+book renderable), **flag this to the user first** so they can confirm the
+transition to Phase 2 rather than quietly changing cadence.
 
 ## Key files
 

--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -182,11 +182,11 @@ These affect the library as a whole, independent of individual constructions.
 
 - [ ] **`angleBisector`** — TBD
   - Java source: `AngleDivider.java`
-  - No Books I–III uses
+  - No Books I–IV uses for the point variant (line variant used in IV.4, IV.13, IV.16)
 
 - [ ] **`angleDivider`** — TBD
   - Java source: `AngleDivider.java`
-  - No Books I–III uses
+  - No Books I–IV uses found
 
 - [ ] **`invert`** — TBD
   - Java source: `InvertPoint.java`
@@ -262,11 +262,11 @@ These affect the library as a whole, independent of individual constructions.
 
 - [ ] **`angleBisector`** — TBD
   - Java source: `AngleDivider.java`
-  - No Books I–III uses
+  - Used in: Book IV (IV.4, IV.13, IV.16 — blocks 3 propositions directly + IV.14 indirectly)
 
 - [ ] **`angleDivider`** — TBD
   - Java source: `AngleDivider.java`
-  - No Books I–III uses
+  - No Books I–IV uses found
 
 - [x] **`foot`** (2D variant) — `src/elements/Constructions.ts` (`LineFootConstruction`)
   - No dedicated element class — reuses existing `Foot` + base `LineElement`.
@@ -394,20 +394,25 @@ These affect the library as a whole, independent of individual constructions.
   - Used in: I.44, I.45, II.14 — **the final 3 propositions for 100% I–III**
 
 - [ ] **`regularPolygon`** — TBD
-  - Java source: `RegularPolygon.java`
-  - No Books I–III uses
+  - Java source: `RegularPolygon.java` — **element class already ported** as
+    `RegularPolygonElement.ts` (used by equilateralTriangle n=3 and square n=4).
+    Only the Construction dispatcher with variable-n signature
+    `[PointElement, PointElement, Integer]` is needed.
+  - Used in: Book IV (IV.11, IV.12, IV.13, IV.14, IV.16 — **blocks 5 propositions**)
 
 - [ ] **`starPolygon`** — TBD
-  - Java source: `RegularPolygon.java`
-  - No Books I–III uses
+  - Java source: `RegularPolygon.java` — element class ported with density
+    param `d` (added 2026-04-12). Only the Construction dispatcher with
+    `[PointElement, PointElement, Integer, Integer]` signature is needed.
+  - No Books I–IV uses found
 
 - [ ] **`pentagon`** — TBD
-  - Java source: `PolygonElement.java`
-  - No Books I–III uses
+  - Java source: `PolygonElement.java` (5 free vertices, pass-through)
+  - No Books I–IV uses found (IV.11 uses `regularPolygon;A,B,5` instead)
 
 - [ ] **`hexagon`** — TBD
-  - Java source: `PolygonElement.java`
-  - No Books I–III uses
+  - Java source: `PolygonElement.java` (6 free vertices, pass-through)
+  - Used in: Book IV (IV.15 — blocks 1 proposition)
 
 - [ ] **`octagon`** — TBD
   - Java source: `PolygonElement.java`

--- a/doc/java-port-tracker.md
+++ b/doc/java-port-tracker.md
@@ -1,0 +1,133 @@
+# Java Port Tracker
+
+Maps every `.java` file in `geom_applet/source/` to its TypeScript
+implementation status. Updated as constructions are ported.
+
+## Status legend
+
+| Status | Meaning |
+|--------|---------|
+| **PORTED** | Fully ported — all constructors and methods converted to TypeScript |
+| **PARTIAL** | Some functionality ported; remaining work noted |
+| **TBD** | Not yet ported; construction stubs may exist in `Constructions.ts` |
+| **N/A** | Java applet infrastructure with no TypeScript equivalent needed |
+
+---
+
+## Element base classes
+
+| Java File | Status | TS Location | Notes |
+|---|---|---|---|
+| `Element.java` | PORTED | `src/elements/GeomElement.ts` | Base class for all geometry elements. TS name differs (GeomElement). |
+| `CircleElement.java` | PORTED | `src/elements/circle/CircleElement.ts` | Both 2-point and 3-point constructors (optional `A` param added 2026-04-12). |
+| `LineElement.java` | PORTED | `src/elements/line/LineElement.ts` | Base line class; `translate`/`rotate` are no-op stubs (overridden in subclasses). |
+| `PlaneElement.java` | PORTED | `src/elements/plane/PlaneElement.ts` | |
+| `PointElement.java` | PORTED | `src/elements/point/PointElement.ts` | All vector ops, `toSimilar`, `toCircumcenter`, `toLine`, `toCircle`, `toIntersection`, `toInvertPoint`, `rotate`, `angle`, etc. Bug fix 2026-04-12: `length2()` had `+` instead of `*` for z component. |
+| `PolygonElement.java` | PORTED | `src/elements/polygon/PolygonElement.ts` | `area()` method added 2026-04-12. |
+| `SectorElement.java` | PORTED | `src/elements/sector/SectorElement.ts` | |
+| `SphereElement.java` | PORTED | `src/elements/sphere/SphereElement.ts` | |
+| `PolyhedronElement.java` | TBD | — | Base class for 3D polyhedra. Needed for Books XI–XIII. |
+
+---
+
+## Point constructions
+
+| Java File | Status | TS Location | Notes |
+|---|---|---|---|
+| `CircleSlider.java` | PORTED | `src/elements/point/CircleSlider.ts` | 2D + 3D variants. |
+| `FixedPoint.java` | PORTED | `src/elements/point/FixedPoint.ts` | 2D + 3D variants. |
+| `Foot.java` | PORTED | `src/elements/point/Foot.ts` | Perpendicular foot from point to line. Also used by `LineFootConstruction` (2D line;foot dispatch). |
+| `Intersection.java` | PORTED | `src/elements/point/Intersection.ts` | Line–line intersection, 2D + 3D. |
+| `IntersectionPL.java` | PARTIAL | `src/elements/point/IntersectionPL.ts` | **File exists but is a copy of Intersection.ts** — documented as a known platform bug in construction-tracker.md. Should implement plane–line intersection via `toIntersectionPL()` (which does exist on PointElement). |
+| `Layoff.java` | PORTED | `src/elements/point/Layoff.ts` | Core utility for `extend`, `cutoff`, `parallelogram`, `line;parallel`, `line;extend`. |
+| `LineSlider.java` | PORTED | `src/elements/point/LineSlider.ts` | 2D, 3D, and segment variants. |
+| `Midpoint.java` | PORTED | `src/elements/point/Midpoint.ts` | |
+| `Perpendicular.java` | PORTED | `src/elements/point/Perpendicular*.ts` + `src/elements/line/Perpendicular.ts` | 5 signature variants across point and line constructions. |
+| `PlaneSlider.java` | PORTED | `src/elements/point/PlaneSlider.ts` | Used for `point;free` (draggable points). |
+| `Proportion.java` | PORTED | `src/elements/point/ProportionElement.ts` | Fourth proportional. Ported 2026-04-12. |
+| `Similar.java` | PORTED | `src/elements/point/SimilarElement.ts` | All three type variants ported: `SimilarPointConstruction`, `SimilarLineConstruction`, `SimilarPolygonConstruction` (all in Constructions.ts). Ported 2026-04-12. |
+| `AngleDivider.java` | TBD | — | Handles both `angleBisector` and `angleDivider` for point and line types. Needed for Book IV (IV.4, IV.13, IV.16). |
+| `Harmonic.java` | TBD | — | Harmonic conjugate. No Books I–IV uses found. |
+| `InvertPoint.java` | TBD | — | Point inversion in circle. No Books I–IV uses found. |
+| `MeanProportional.java` | TBD | — | Mean proportional construction. No Books I–IV uses found. |
+| `SphereSlider.java` | TBD | — | Point slider on sphere surface. Needed for solid geometry (Books XI–XIII). |
+
+---
+
+## Line constructions
+
+| Java File | Status | TS Location | Notes |
+|---|---|---|---|
+| `Bichord.java` | PORTED | `src/elements/line/Bichord.ts` | Common chord of two circles. |
+| `Chord.java` | PORTED | `src/elements/line/Chord.ts` | Chord of circle cut by a line. Ported 2026-04-11. |
+| `PlaneFoot.java` | TBD | — | Foot of perpendicular from point to plane (solid geometry). The 2D `line;foot` variant uses `Foot.ts` + LineElement dispatch instead. |
+| `PerpendicularPL.java` | PARTIAL | `src/elements/line/PlanePerpendicularLine.ts` + `src/elements/plane/PerpendicularPlane.ts` | Java class was split across two TS files for the plane-perpendicular construction. |
+
+---
+
+## Circle constructions
+
+| Java File | Status | TS Location | Notes |
+|---|---|---|---|
+| `Circumcircle.java` | PORTED | `src/elements/circle/CircumcircleElement.ts` | 2D + 3D variants. |
+| `InvertCircle.java` | TBD | — | Circle inversion in another circle. No Books I–IV uses found. |
+| `IntersectionSS.java` | TBD | — | Intersection of two spheres (yields a circle). Solid geometry (Books XI–XIII). |
+
+---
+
+## Polygon constructions
+
+| Java File | Status | TS Location | Notes |
+|---|---|---|---|
+| `Application.java` | PORTED | `src/elements/polygon/ApplicationElement.ts` | Application of area. Ported 2026-04-12. |
+| `RegularPolygon.java` | PORTED | `src/elements/polygon/RegularPolygonElement.ts` | Both regular and star-polygon constructors (density `d` param added 2026-04-12). Used by `equilateralTriangle` (n=3) and `square` (n=4). The `regularPolygon` (variable n) and `starPolygon` (variable n,d) Construction dispatchers are still TBD. |
+
+---
+
+## Sector constructions
+
+| Java File | Status | TS Location | Notes |
+|---|---|---|---|
+| `Arc.java` | PORTED | `src/elements/sector/ArcElement.ts` | 2D variant. Ported 2026-04-11. |
+
+---
+
+## Plane constructions
+
+| Java File | Status | TS Location | Notes |
+|---|---|---|---|
+| `PlanePerpendicular.java` | PORTED | `src/elements/plane/PerpendicularPlane.ts` | |
+| `ParallelP.java` | TBD | — | Parallel plane construction (solid geometry). NOT `line;parallel` — that uses Layoff dispatch. |
+
+---
+
+## 3D / Polyhedra constructions
+
+| Java File | Status | TS Location | Notes |
+|---|---|---|---|
+| `Prism.java` | TBD | — | Prism construction. Needed for Books XI–XIII. |
+| `Pyramid.java` | TBD | — | Pyramid construction. Needed for Books XI–XIII. |
+
+---
+
+## Java applet infrastructure (no TS equivalent needed)
+
+| Java File | Status | Notes |
+|---|---|---|
+| `Geometry.java` | N/A | Java applet main entry point. TS equivalent is `src/index.ts`. |
+| `ClientFrame.java` | N/A | Java Swing/AWT UI component. No TS equivalent. |
+| `Remote.java` | N/A | Applet remote communication. No TS equivalent. |
+| `Slate.java` | PARTIAL | Construction dispatch logic ported to `src/elements/Constructions.ts`. Rendering logic replaced by HTML5 Canvas in `src/Slate.ts`. The Java construction-name-to-index mapping tables at lines 69–122 are the authoritative reference for dispatch. |
+
+---
+
+## Summary
+
+| Status | Count | Files |
+|--------|-------|-------|
+| PORTED | 27 | Core element classes + all ported constructions |
+| PARTIAL | 3 | IntersectionPL, PerpendicularPL, Slate |
+| TBD | 9 | AngleDivider, Harmonic, InvertPoint, InvertCircle, MeanProportional, SphereSlider, PlaneFoot, Prism, Pyramid |
+| TBD (base) | 2 | PolyhedronElement, ParallelP (plane), IntersectionSS |
+| N/A | 3 | Geometry, ClientFrame, Remote |
+| **Total** | **44** | |

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,55 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-12 — Scope extension: all-books coverage + Java port tracker
+
+**Completed:**
+- Corrected project phase descriptions in AGENTS.md and doc/process.md.
+  Phase 1 now explicitly covers **all books (I–XIII)**, not just I–III.
+  Books I–III reaching 99/99 was a milestone, not the end of Phase 1.
+  Inserted a new Phase 2 (presentation bug fixes) between construction
+  porting and HTML conversion. Phase numbering is now:
+  1. Port all Java constructions (book-by-book, I through XIII)
+  2. Fix presentation bugs (colors, labels, behavioral parity)
+  3. HTML conversions (566 files from Java params to TS init calls)
+  4. Retire the Java toolchain
+- Created `doc/java-port-tracker.md` — maps all 44 `.java` files in
+  `geom_applet/source/` to their TypeScript implementation status (PORTED,
+  PARTIAL, TBD, N/A), with TS file locations, deviation notes, and
+  remaining work per file. 27 fully ported, 3 partial, 9 TBD, 3 N/A,
+  2 TBD base classes.
+- Extended `doc/proposition-tracker.md` with Book IV (16 propositions).
+  10 already renderable using existing constructions; 6 blocked by 3 TBD
+  constructions: `polygon;regularPolygon` (5 props), `line;angleBisector`
+  (3 props + 1 indirect), `polygon;hexagon` (1 prop).
+- Updated `doc/construction-tracker.md` with Book IV blocker analysis:
+  noted which TBD constructions each Book IV proposition needs and how
+  many props each would unblock.
+
+**Discovered:**
+- `polygon;regularPolygon` is the highest-priority Book IV blocker (5
+  propositions), and the element class `RegularPolygonElement.ts` is
+  **already fully ported** (including the star-polygon density parameter
+  from the polygon;square session). Only the Construction dispatcher
+  with variable-n signature `[PointElement, PointElement, Integer]` is
+  needed — trivial to wire.
+- `polygon;pentagon` (5 free vertices) is NOT needed for Book IV — propIV11
+  uses `polygon;regularPolygon;A,B,5` (computed regular pentagon), not
+  `polygon;pentagon;A,B,C,D,E` (5 free vertices).
+- `polygon;hexagon` (6 free vertices) IS needed for IV.15 as a pass-through
+  PolyConstruction, same trivial pattern as quadrilateral.
+
+**Next session:**
+- Top priority: `polygon;regularPolygon` — unblocks 5 Book IV props,
+  element class already ported, just needs a Construction dispatcher.
+  Trivially easy.
+- Then: `line;angleBisector` (`AngleDivider.java`) — unblocks 4 Book IV
+  props. Real porting work.
+- Then: `polygon;hexagon` — trivial pass-through, unblocks IV.15.
+- After Book IV is fully covered: analyze Book V and continue the cycle.
+
+---
+
 ## 2026-04-12 — Implemented polygon;application — 99/99 BOOKS I–III COMPLETE
 
 **Completed:**

--- a/doc/process.md
+++ b/doc/process.md
@@ -471,10 +471,35 @@ themselves on GitHub, pasting the body block into the description.
 
 ---
 
-## Long-term goal
+## Project phases
 
-Once all construction types are implemented:
-- Convert all 566 HTML files in `view/euclid-html/` (Books I–XIII) from Java `<param>` format
-  to TypeScript `geomlib.init()` calls in a new `view/books/` folder
-- Each book becomes a browsable set of interactive TypeScript diagrams
-- The Java applet and Docker environment can then be retired
+### Phase 1 — Port all Java constructions (current)
+
+Port every construction type used across **all thirteen books**, driven
+book-by-book. Extend the proposition tracker one book at a time; compare
+against the construction and [Java port tracker](java-port-tracker.md) to
+identify which TBD constructions each book needs; port them using the
+8-step workflow above. Phase 1 continues until every proposition in every
+book is renderable.
+
+### Phase 2 — Presentation bug fixes
+
+Fix visual divergences between the Java applet and the TypeScript port:
+- Colors: parseColor bug, numeric-0 handling, HSB format, default faceColor
+- Label placement: per-element align, heuristic `drawName` positioning
+- Any behavioral differences discovered during book-by-book harness
+  verification in Phase 1
+
+The goal is visual parity with Joyce's original applets at rest.
+
+### Phase 3 — Proposition HTML conversion
+
+Convert all 566 HTML files in `view/euclid-html/` (Books I–XIII) from Java
+`<param>` format to TypeScript `geomlib.init()` calls in a new `view/books/`
+folder. Each book becomes a browsable set of interactive TypeScript diagrams.
+
+### Phase 4 — Retire the Java toolchain
+
+`run_euclid_applet.sh` and both `Containerfile*` files go away;
+`view/euclid-html/` and `Geometry.zip` can be archived or deleted; the
+`geom_applet/source/*.java` reference tree becomes read-only history.

--- a/doc/proposition-tracker.md
+++ b/doc/proposition-tracker.md
@@ -17,8 +17,9 @@ Tracks the port status of all propositions across Euclid's Elements.
 | Book I | 48 | **48** | 0 |
 | Book II | 14 | **14** | 0 |
 | Book III | 37 | **37** | 0 |
-| **I–III total** | **99** | **99** | **0** |
-| Books IV–XIII | ~365 | — | — |
+| Book IV | 16 | 10 | 0 |
+| **I–IV total** | **115** | **109** | **0** |
+| Books V–XIII | ~349 | — | — |
 
 Update the summary table after each session.
 
@@ -138,13 +139,35 @@ Update the summary table after each session.
 
 ---
 
-## Books IV–XIII (future scope)
+## Book IV
 
-These books will be converted once all construction types are fully implemented.
+- [~] IV.1 — To inscribe in a given circle a triangle equiangular with a given triangle.
+- [~] IV.2 — To inscribe in a given circle a triangle equiangular with a given triangle (circumcircle variant).
+- [~] IV.3 — To circumscribe about a given circle a triangle equiangular with a given triangle.
+- [ ] IV.4 — To inscribe a circle in a given triangle. NEEDS: `line;angleBisector`
+- [~] IV.5 — To circumscribe a circle about a given triangle.
+- [~] IV.6 — To inscribe a square in a given circle.
+- [~] IV.7 — To circumscribe a square about a given circle.
+- [~] IV.8 — To inscribe a circle in a given square.
+- [~] IV.9 — To circumscribe a circle about a given square.
+- [~] IV.10 — To construct an isosceles triangle having each of the base angles double the remaining one.
+- [ ] IV.11 — To inscribe an equilateral and equiangular pentagon in a given circle. NEEDS: `polygon;regularPolygon`
+- [ ] IV.12 — To circumscribe an equilateral and equiangular pentagon about a given circle. NEEDS: `polygon;regularPolygon`
+- [ ] IV.13 — To inscribe a circle in a given equilateral and equiangular pentagon. NEEDS: `line;angleBisector`, `polygon;regularPolygon`
+- [ ] IV.14 — To circumscribe a circle about a given equilateral and equiangular pentagon. NEEDS: `polygon;regularPolygon`
+- [ ] IV.15 — To inscribe an equilateral and equiangular hexagon in a given circle. NEEDS: `polygon;hexagon`
+- [ ] IV.16 — To inscribe a fifteen-angled equilateral and equiangular figure in a given circle. NEEDS: `line;angleBisector`, `polygon;regularPolygon`
+
+---
+
+## Books V–XIII (future scope)
+
+Coverage will be extended one book at a time. Each book's propositions are
+analyzed against the construction and Java file trackers to determine which
+constructions must be ported before the book is renderable.
 
 | Book | Propositions | Topic |
 |------|-------------|-------|
-| IV | 16 | Inscribed and circumscribed figures |
 | V | 25 | Theory of proportion (Eudoxus) |
 | VI | 33 | Similar figures |
 | VII | 39 | Number theory — divisibility |


### PR DESCRIPTION
## Summary

Corrects the project's phase structure and adds tracking infrastructure for the all-books construction porting effort. Books I–III reaching 99/99 renderable was a milestone, not the end of Phase 1. This PR establishes the book-by-book expansion workflow and begins Book IV analysis.

## Change in direction

The previous AGENTS.md described Phase 1 as "port remaining Java constructions" (implicitly I–III only), with Phase 2 as HTML conversions and Phase 3 as retiring the Java toolchain. The corrected phases are:

1. **Phase 1 (extended)**: Port ALL remaining Java constructions across ALL books (I–XIII), driven book-by-book
2. **Phase 2 (new)**: Fix presentation bugs — colors, labels, behavioral parity with the Java applet
3. **Phase 3**: HTML conversions (566 files)
4. **Phase 4**: Retire the Java toolchain

## What's in this branch

- `c33675b` doc: add java-port-tracker.md — maps all 44 .java files to TS status
- `d5a3817` doc: extend proposition-tracker with Book IV — 10/16 renderable, 6 blocked
- `60a590f` doc: correct project phases — all-books coverage before HTML conversion
- `5395c35` doc: update construction-tracker with Book IV blocker analysis
- `d5128ef` doc: journal entry for scope extension and Book IV analysis

## New tracker: java-port-tracker.md

Maps every `.java` file in `geom_applet/source/` to its TypeScript port status:
- **27 PORTED** (all element classes + construction implementations)
- **3 PARTIAL** (IntersectionPL, PerpendicularPL, Slate dispatch logic)
- **9 TBD** (AngleDivider, Harmonic, InvertPoint, InvertCircle, MeanProportional, SphereSlider, PlaneFoot, Prism, Pyramid)
- **2 TBD base classes** (PolyhedronElement, ParallelP-as-plane, IntersectionSS)
- **3 N/A** (Java applet infrastructure)

## Book IV analysis

16 propositions analyzed against actual HTML param lists:
- **10 already renderable** (IV.1–IV.3, IV.5–IV.10)
- **6 blocked** by 3 TBD constructions:
  - `polygon;regularPolygon` → blocks IV.11, IV.12, IV.13, IV.14, IV.16 (element class already ported!)
  - `line;angleBisector` → blocks IV.4, IV.13, IV.16
  - `polygon;hexagon` → blocks IV.15 (trivial pass-through)

## No code changes

This is a documentation-only PR. `npm run build` and `npm test` are unaffected.
