### PR TITLE
Feature/polygon regular polygon

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -393,12 +393,18 @@ These affect the library as a whole, independent of individual constructions.
     [view/applet-tests/poly/application/{original,applet}.html](../view/applet-tests/poly/application/)
   - Used in: I.44, I.45, II.14 — **the final 3 propositions for 100% I–III**
 
-- [ ] **`regularPolygon`** — TBD
-  - Java source: `RegularPolygon.java` — **element class already ported** as
-    `RegularPolygonElement.ts` (used by equilateralTriangle n=3 and square n=4).
-    Only the Construction dispatcher with variable-n signature
-    `[PointElement, PointElement, Integer]` is needed.
-  - Used in: Book IV (IV.11, IV.12, IV.13, IV.14, IV.16 — **blocks 5 propositions**)
+- [x] **`regularPolygon`** — `src/elements/Constructions.ts` (`RegularPolygonConstruction`)
+  - Reuses `RegularPolygonElement.ts` with variable n. 2D variant (screen plane).
+    Signature `[PointElement, PointElement, Integer]`.
+  - Registered BEFORE `SquarePolygonConstruction` and
+    `EquilateralTriangleConstruction` in the constructions array (3-param
+    signature is longer than 2-param, per signature-ordering rule).
+  - Java source: `Slate.java` polygon case 7 → `new RegularPolygon(A, B, screen, n)`.
+  - Mocha test (1): regular pentagon (n=5), all-sides-equal check.
+  - [x] test view: [view/test/poly/regularPolygon.html](../view/test/poly/regularPolygon.html) — propIV11
+  - [x] applet-tests pair:
+    [view/applet-tests/poly/regularPolygon/{original,applet}.html](../view/applet-tests/poly/regularPolygon/)
+  - Used in: Book IV (IV.11, IV.12, IV.13, IV.14, IV.16)
 
 - [ ] **`starPolygon`** — TBD
   - Java source: `RegularPolygon.java` — element class ported with density

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,40 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-12 — Implemented polygon;regularPolygon — first Book IV construction
+
+**Completed:**
+- Wired `RegularPolygonConstruction` in `src/elements/Constructions.ts` —
+  a 2D dispatcher with signature `[PointElement, PointElement, Integer]`
+  that creates `RegularPolygonElement(a, b, screen, n)` for variable n.
+  No new element class needed — `RegularPolygonElement.ts` was already
+  fully ported (including density parameter) during the polygon;square
+  session. Total new code: ~10 lines.
+- Registered BEFORE `SquarePolygonConstruction` and
+  `EquilateralTriangleConstruction` in the constructions array (3-param
+  signature first, per signature-ordering rule).
+- One Mocha test: regular pentagon (n=5), all-5-sides-equal check.
+  35 → **36 passing**.
+- Test page + applet companion using propIV11 variant 1 (inscribed
+  pentagon with circumcircle and diagonals).
+- Book IV renderable count: 10 → **13** (+IV.11, IV.12, IV.14).
+  I–IV total: 109 → **112**.
+
+**Discovered:**
+- IV.13 and IV.16 still need `line;angleBisector` in addition to
+  `polygon;regularPolygon` (which just landed).
+- propIV11 has 3 applet variants: variant 2 uses `point;angleBisector`
+  (TBD) and variant 3 uses `polygon;pentagon` (TBD) — but variant 1
+  renders fully with just `polygon;regularPolygon`.
+
+**Next session:**
+- `line;angleBisector` (`AngleDivider.java`) — unblocks IV.4, IV.13, IV.16
+  (3 remaining Book IV blockers). Real porting work.
+- Then `polygon;hexagon` — trivial pass-through, unblocks IV.15.
+- After those 2: Book IV complete (16/16). Analyze Book V next.
+
+---
+
 ## 2026-04-12 — Scope extension: all-books coverage + Java port tracker
 
 **Completed:**

--- a/doc/proposition-tracker.md
+++ b/doc/proposition-tracker.md
@@ -17,8 +17,8 @@ Tracks the port status of all propositions across Euclid's Elements.
 | Book I | 48 | **48** | 0 |
 | Book II | 14 | **14** | 0 |
 | Book III | 37 | **37** | 0 |
-| Book IV | 16 | 10 | 0 |
-| **I–IV total** | **115** | **109** | **0** |
+| Book IV | 16 | 13 | 0 |
+| **I–IV total** | **115** | **112** | **0** |
 | Books V–XIII | ~349 | — | — |
 
 Update the summary table after each session.
@@ -151,12 +151,12 @@ Update the summary table after each session.
 - [~] IV.8 — To inscribe a circle in a given square.
 - [~] IV.9 — To circumscribe a circle about a given square.
 - [~] IV.10 — To construct an isosceles triangle having each of the base angles double the remaining one.
-- [ ] IV.11 — To inscribe an equilateral and equiangular pentagon in a given circle. NEEDS: `polygon;regularPolygon`
-- [ ] IV.12 — To circumscribe an equilateral and equiangular pentagon about a given circle. NEEDS: `polygon;regularPolygon`
-- [ ] IV.13 — To inscribe a circle in a given equilateral and equiangular pentagon. NEEDS: `line;angleBisector`, `polygon;regularPolygon`
-- [ ] IV.14 — To circumscribe a circle about a given equilateral and equiangular pentagon. NEEDS: `polygon;regularPolygon`
+- [~] IV.11 — To inscribe an equilateral and equiangular pentagon in a given circle. (`polygon;regularPolygon` landed 2026-04-12.)
+- [~] IV.12 — To circumscribe an equilateral and equiangular pentagon about a given circle. (`polygon;regularPolygon` landed 2026-04-12.)
+- [ ] IV.13 — To inscribe a circle in a given equilateral and equiangular pentagon. NEEDS: `line;angleBisector` (`polygon;regularPolygon` landed 2026-04-12)
+- [~] IV.14 — To circumscribe a circle about a given equilateral and equiangular pentagon. (`polygon;regularPolygon` landed 2026-04-12.)
 - [ ] IV.15 — To inscribe an equilateral and equiangular hexagon in a given circle. NEEDS: `polygon;hexagon`
-- [ ] IV.16 — To inscribe a fifteen-angled equilateral and equiangular figure in a given circle. NEEDS: `line;angleBisector`, `polygon;regularPolygon`
+- [ ] IV.16 — To inscribe a fifteen-angled equilateral and equiangular figure in a given circle. NEEDS: `line;angleBisector` (`polygon;regularPolygon` landed 2026-04-12)
 
 ---
 

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -1168,18 +1168,31 @@ export class ParallelogramPolygonConstruction extends Construction {
     }
 }
 
+// polygon
+// regularPolygon (2D variant)
+// points A, B, integer n
+// the regular n-gon on side AB in the screen plane
+// (Java: Slate.java polygon case 7 — RegularPolygon(A, B, screen, n))
+export class RegularPolygonConstruction extends Construction {
+    constructionMethod: AllConstructions = PolygonConstructions.regularPolygon;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.Integer];
+
+    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const a = params[0] as PointElement;
+        const b = params[1] as PointElement;
+        const n = params[2] as number;
+        const g = new RegularPolygonElement(a, b, screen, n);
+        return [[g], g];
+    }
+}
+
 // TBD
 // polygon
-// regularPolygon
-// points A, B integer n
-// the regular polygon on a side AB given the number of vertices n
-
-
-// TBD
-// polygon
-// starPolygon
-// points A, B integers n, d
-// the star polygon on a side AB given the number of vertices n and the density d
+// starPolygon (2D variant)
+// points A, B, integers n, d
+// the star polygon {n/d} on side AB in the screen plane
+// (RegularPolygonElement already supports density param d — just needs dispatcher)
+// (Java: Slate.java polygon case 8 — RegularPolygon(A, B, screen, n, d))
 
 
 // polygon
@@ -1454,6 +1467,7 @@ export const constructions : Construction[] = [
     new LineFootConstruction(),
     new SimilarLineConstruction(),
     new TrianglePolygonConstruction(),
+    new RegularPolygonConstruction(),
     new SquarePolygonConstruction(),
     new EquilateralTriangleConstruction(),
     new ParallelogramPolygonConstruction(),

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -755,6 +755,28 @@ describe("slate", ()=> {
         almostEqual(sq.V[3].distance(sq.V[0]), side, 0.01);
     });
 
+    // polygon;regularPolygon — variable-n regular polygon via RegularPolygonElement
+    // n=5 (pentagon): A=(100,50), B=(200,50), side=100
+    // All sides should be equal and there should be 5 vertices
+    it("should create a regular pentagon with 5 equal sides", () => {
+        let data : IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [100, 50] },
+            { name: "B", construction: E.Point.free, params: [200, 50] },
+            { name: "ABCDE", construction: E.Polygon.regularPolygon, params: ["A", "B", 5] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let poly = slate.lookupElement("ABCDE") as PolygonElement;
+        assert.equal(poly.V.length, 5);
+        // All 5 sides should be equal to side AB = 100
+        let side = poly.V[0].distance(poly.V[1]);
+        almostEqual(side, 100, 0.01);
+        for (let i = 1; i < 5; i++) {
+            almostEqual(poly.V[i].distance(poly.V[(i+1) % 5]), side, 0.01);
+        }
+    });
+
     // polygon;quadrilateral — 4 free vertices passed through to PolygonElement
     it("should create a quadrilateral with 4 vertices", () => {
         let data : IConstructionInfo[] = [

--- a/view/applet-tests/poly/regularPolygon/applet.html
+++ b/view/applet-tests/poly/regularPolygon/applet.html
@@ -1,0 +1,25 @@
+<HTML><HEAD><TITLE>polygon;regularPolygon — applet form of view/test/poly/regularPolygon.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/poly/regularPolygon.html -->
+<!-- ORIGINAL: view/applet-tests/poly/regularPolygon/original.html (propIV11) -->
+<!--
+  PropIV11 variant 1: regular pentagon ABCDE inscribed in a circumcircle.
+  Exercises polygon;regularPolygon with n=5. Drag A or B to resize/rotate.
+  Canvas 400x400 (original is 320x250).
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="IV.11 — polygon;regularPolygon">
+<param name=e[1] value="A;point;free;98,30">
+<param name=e[2] value="B;point;free;30,80">
+<param name=e[3] value="ABCDE;polygon;regularPolygon;A,B,5;0;0;black;0">
+<param name=e[4] value="C;point;vertex;ABCDE,3">
+<param name=e[5] value="D;point;vertex;ABCDE,4">
+<param name=e[6] value="E;point;vertex;ABCDE,5">
+<param name=e[7] value="circ;circle;circumcircle;A,B,C;0;0;black;random">
+<param name=e[8] value="AC;line;connect;A,C">
+<param name=e[9] value="AD;line;connect;A,D">
+<param name=e[10] value="BD;line;connect;B,D">
+<param name=e[11] value="CE;line;connect;C,E">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/poly/regularPolygon/original.html
+++ b/view/applet-tests/poly/regularPolygon/original.html
@@ -1,0 +1,23 @@
+<HTML><HEAD><TITLE>IV.11 — polygon;regularPolygon (original)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=250 width=320>
+<param name=background value="35,19,100">
+<param name=title value="IV.11">
+<param name=e[1] value="A;point;free;98,30">
+<param name=e[2] value="B;point;free;30,80">
+<param name=e[3] value="ABCDE;polygon;regularPolygon;A,B,5;0;0;black;0">
+<param name=e[4] value="C;point;vertex;ABCDE,3">
+<param name=e[5] value="D;point;vertex;ABCDE,4">
+<param name=e[6] value="E;point;vertex;ABCDE,5">
+<param name=e[7] value="circ;circle;circumcircle;A,B,C;0;0;black;random">
+<param name=e[8] value="dupABCDE;polygon;regularPolygon;A,B,5;0;0;0;random">
+<param name=e[9] value="AC;line;connect;A,C">
+<param name=e[10] value="AD;line;connect;A,D">
+<param name=e[11] value="BD;line;connect;B,D">
+<param name=e[12] value="CE;line;connect;C,E">
+<param name=e[13] value="G;point;free;210,220">
+<param name=e[14] value="H;point;free;310,220">
+<param name=e[15] value="F;point;similar;G,H,C,D,A">
+<param name=e[16] value="FGH;polygon;triangle;F,G,H;0;0;black;random">
+</applet>
+</BODY></HTML>

--- a/view/test/poly/regularPolygon.html
+++ b/view/test/poly/regularPolygon.html
@@ -1,0 +1,36 @@
+<html>
+<head>
+    <title>Test View - Polygon.regularPolygon (IV.11)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "IV.11 — To inscribe an equilateral and equiangular pentagon in a given circle",
+        canvasid: "canvasId",
+        elements: [
+            // <param name=e[1] value="A;point;free;98,30">
+            { name: "A", construction: E.Point.free, params: [98, 30] },
+            // <param name=e[2] value="B;point;free;30,80">
+            { name: "B", construction: E.Point.free, params: [30, 80] },
+            // <param name=e[3] value="ABCDE;polygon;regularPolygon;A,B,5">  ← target
+            { name: "ABCDE", construction: E.Polygon.regularPolygon, params: ["A", "B", 5] },
+            // Extract vertices
+            { name: "C", construction: E.Point.vertex, params: ["ABCDE", 3] },
+            { name: "D", construction: E.Point.vertex, params: ["ABCDE", 4] },
+            { name: "E", construction: E.Point.vertex, params: ["ABCDE", 5] },
+            // Circumcircle through A, B, C
+            { name: "circ", construction: E.Circle.circumcircle, params: ["A", "B", "C"] },
+            // Diagonals
+            { name: "AC", construction: E.Line.connect, params: ["A", "C"] },
+            { name: "AD", construction: E.Line.connect, params: ["A", "D"] },
+            { name: "BD", construction: E.Line.connect, params: ["B", "D"] },
+            { name: "CE", construction: E.Line.connect, params: ["C", "E"] },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds `polygon;regularPolygon` — a variable-n regular polygon dispatcher that reuses the already-ported `RegularPolygonElement.ts`. First construction targeting Book IV. Unlocks IV.11, IV.12, IV.14 (+3 Book IV propositions). Book IV now at 13/16.

## What's in this branch

- `ac45c0a` polygon-regularPolygon: step 3 — add original.html from propIV11
- `83e5a67` polygon-regularPolygon: step 5 — wire RegularPolygonConstruction
- `f21f7c6` polygon-regularPolygon: step 6 — Mocha test (regular pentagon)
- `9f06e51` polygon-regularPolygon: step 7 — three-way view pair (TS page + applet.html)
- `cae5b60` polygon-regularPolygon: step 8 — tracker + journal — Book IV 13/16

Step 4 collapsed: `RegularPolygonElement.ts` was already fully ported (including density `d` parameter) during the polygon;square session.

## Construction details

- **Element class**: None new — reuses `RegularPolygonElement.ts`. The element already handles arbitrary n and density d.
- **Construction class**: `RegularPolygonConstruction` — signature `[PointElement, PointElement, Integer]`. Dispatches to `PolygonConstructions.regularPolygon = 308`. Registered BEFORE `SquarePolygonConstruction` and `EquilateralTriangleConstruction` (signature-ordering rule: 3-param before 2-param).
- **Java source**: `Slate.java` polygon case 7 → `new RegularPolygon(A, B, screen, n)`.

## Tests

35 → **36 passing**. One new test: regular pentagon (n=5), all-5-sides-equal check.

## Verification

- [x] `npm run build` clean
- [x] `npm test` passes (36/36)
- [x] `npx webpack` rebuilds `dist/bundle.js`
- [x] Three-way harness — **needs human verification**
- [x] Drag A or B to resize/rotate the pentagon; all 5 sides should stay equal; circumcircle should pass through all vertices

## Newly renderable propositions

- **Book IV** (10 → 13): IV.11, IV.12, IV.14
- **I–IV total** (109 → 112): +3

IV.13 and IV.16 remain blocked by `line;angleBisector`. IV.15 remains blocked by `polygon;hexagon`.
