### PR TITLE
Feature/point mean proportional

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -192,11 +192,16 @@ These affect the library as a whole, independent of individual constructions.
 
 - [ ] **`invert`** — TBD
   - Java source: `InvertPoint.java`
-  - No Books I–III uses
+  - No Books I–X uses found
 
-- [ ] **`meanProportional`** — TBD
-  - Java source: `MeanProportional.java`
-  - No Books I–III uses
+- [x] **`meanProportional`** — `src/elements/point/MeanProportionalElement.ts`
+  - Extends `PointElement`. Geometric mean: |U'| = sqrt(|S|*|T|).
+  - Java source: `MeanProportional.java` — 23 lines, line-for-line port.
+  - Mocha test (1): geometric mean, proportion S:U'=U':T verified.
+  - [x] test view: [view/test/point/meanProportional.html](../view/test/point/meanProportional.html)
+  - [x] applet-tests pair:
+    [view/applet-tests/point/meanProportional/{original,applet}.html](../view/applet-tests/point/meanProportional/)
+  - Used in: VIII.20, VIII.26, X (33 props), XIII.2 — **35 props unblocked**
 
 - [ ] **`planeSlider`** — TBD (solid geometry)
   - Java source: `PlaneSlider.java`
@@ -303,9 +308,10 @@ These affect the library as a whole, independent of individual constructions.
   - Java source: `Proportion.java`
   - No Books I–III uses
 
-- [ ] **`meanProportional`** — TBD
-  - Java source: `MeanProportional.java`
-  - No Books I–III uses
+- [x] **`meanProportional`** — `src/elements/Constructions.ts` (`MeanProportionalLineConstruction`)
+  - Reuses `MeanProportionalElement` + `LineElement` wrapper.
+  - Java source: `Slate.java` line case 12.
+  - No standalone test view (covered by point variant test page).
 
 ---
 

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,34 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-12 — Implemented point;meanProportional — Books I–X COMPLETE
+
+**Completed:**
+- Ported `MeanProportional.java` as `src/elements/point/MeanProportionalElement.ts`
+  (23 lines, line-for-line port). Computes the geometric mean: given
+  segments S, T, U, finds the point U' on U where |U'| = sqrt(|S|*|T|)
+  so that S:U' = U':T.
+- Both point and line variants wired (`MeanProportionalPointConstruction`,
+  `MeanProportionalLineConstruction`). Full Java class conversion.
+- One Mocha test: geometric mean (sqrt(100*25)=50), proportion verified.
+  38 → **39 passing**.
+- **35 propositions unblocked** across Books VIII (2), X (33), XIII (via
+  XIII.2). This is the single highest-impact construction port in the
+  entire project.
+- **Books I through X are now 100% renderable: 390/390.**
+- Overall: 429 of 465 propositions renderable (**92%**). Only 36 remain
+  blocked, all in Books XI–XIII (solid geometry constructions).
+
+**Next session:**
+- The remaining 36 blocked propositions all need solid-geometry
+  constructions: `plane;3points` (the key blocker), `point;planeSlider`,
+  `point;sphereSlider`, `polygon;face`, `polygon;octagon`,
+  `circle;intersection`. These are the Phase 1 frontier.
+- `plane;3points` is likely the highest-impact next port — it blocks
+  propositions across all three remaining books.
+
+---
+
 ## 2026-04-12 — Books V–X analysis — 391/465 renderable (84%), zero new code
 
 **Completed:**

--- a/doc/proposition-tracker.md
+++ b/doc/proposition-tracker.md
@@ -21,14 +21,14 @@ Tracks the port status of all propositions across Euclid's Elements.
 | Book V | 25 | **25** | 0 |
 | Book VI | 33 | **33** | 0 |
 | Book VII | 39 | **39** | 0 |
-| Book VIII | 27 | 25 | 0 |
+| Book VIII | 27 | **27** | 0 |
 | Book IX | 36 | **36** | 0 |
-| Book X | 115 | 82 | 0 |
-| **I–X total** | **390** | **355** | **0** |
+| Book X | 115 | **115** | 0 |
+| **I–X total** | **390** | **390** | **0** |
 | Book XI | 39 | 20 | 0 |
 | Book XII | 18 | 6 | 0 |
-| Book XIII | 18 | 10 | 0 |
-| **I–XIII total** | **465** | **391** | **0** |
+| Book XIII | 18 | 13 | 0 |
+| **I–XIII total** | **465** | **429** | **0** |
 
 Update the summary table after each session.
 
@@ -208,11 +208,7 @@ uses only basic constructions. No new constructions needed.
 
 25 of 27 propositions are renderable. 2 blocked by `point;meanProportional`.
 
-- [~] VIII.1 through VIII.19 — all renderable (verified 2026-04-12)
-- [ ] VIII.20 — NEEDS: `point;meanProportional`
-- [~] VIII.21 through VIII.25 — all renderable
-- [ ] VIII.26 — NEEDS: `point;meanProportional`
-- [~] VIII.27 — renderable
+- [~] VIII.1 through VIII.27 — all renderable (`point;meanProportional` landed 2026-04-12)
 
 ---
 
@@ -231,16 +227,7 @@ only basic constructions. No new constructions needed.
 Book X is the largest single book (incommensurable magnitudes). Porting
 `MeanProportional.java` would unblock all 33 at once.
 
-- [~] X.1 through X.9 — renderable
-- [ ] X.10 — NEEDS: `point;meanProportional`
-- [~] X.11 through X.26 — renderable
-- [ ] X.27 through X.32 — NEEDS: `point;meanProportional` (6 props)
-- [~] X.33 through X.47 — renderable
-- [ ] X.48 through X.59 — NEEDS: `point;meanProportional` (12 props)
-- [~] X.60 through X.84 — renderable
-- [ ] X.85 through X.96 — NEEDS: `point;meanProportional` (12 props)
-- [~] X.97 through X.113 — renderable
-- [ ] X.114, X.115 — NEEDS: `point;meanProportional` (2 props)
+- [~] X.1 through X.115 — all renderable (`point;meanProportional` landed 2026-04-12)
 
 ---
 

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -39,6 +39,7 @@ import {Chord} from "./line/Chord";
 import {SimilarElement} from "./point/SimilarElement";
 import {ProportionElement} from "./point/ProportionElement";
 import {AngleDividerElement} from "./point/AngleDividerElement";
+import {MeanProportionalElement} from "./point/MeanProportionalElement";
 import {ApplicationElement} from "./polygon/ApplicationElement";
 import {PolygonElement} from "./polygon/PolygonElement";
 import {RegularPolygonElement} from "./polygon/RegularPolygonElement";
@@ -709,11 +710,21 @@ export class ProportionPointConstruction extends Construction {
 // point A circle B
 // the image of a point A inverted in the circle B
 
-// TBD
 // point
 // meanProportional
-// 6 points A, B, C, D, E, F
-// the point G on EF so that AB:CD = CD:EG
+// 6 points S0, S1, T0, T1, U0, U1
+// the point U' on U0U1 so that S:U' = U':T (geometric mean)
+// (Java: MeanProportional.java — 23 lines, line-for-line port)
+export class MeanProportionalPointConstruction extends Construction {
+    constructionMethod: AllConstructions = PointConstructions.meanProportional;
+    signature: ConstructionTypes[] = (new Array(6)).fill(ct.PointElement);
+
+    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let g = new MeanProportionalElement(ps[0], ps[1], ps[2], ps[3], ps[4], ps[5]);
+        return [[g], g];
+    }
+}
 
 // TBD
 // point
@@ -1041,11 +1052,22 @@ export class SimilarLineConstruction extends Construction {
 // 8 points A, B, C, D, E, F, G, H
 // the line GI along GH so that AB:CD = EF:GI
 
-// TBD
 // line
 // meanProportional
-// 6 points A, B, C, D, E, F
-// the line EG along EF so that AB:CD = CD:EG
+// 6 points S0, S1, T0, T1, U0, U1
+// the line U0U' along U0U1 so that S:U' = U':T
+// (Java: Slate.java line case 12 — MeanProportional + LineElement(U0, result))
+export class MeanProportionalLineConstruction extends Construction {
+    constructionMethod: AllConstructions = LineConstructions.meanProportional;
+    signature: ConstructionTypes[] = (new Array(6)).fill(ct.PointElement);
+
+    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let mp = new MeanProportionalElement(ps[0], ps[1], ps[2], ps[3], ps[4], ps[5]);
+        let g = new LineElement({A: ps[4], B: mp});
+        return [[mp, g], g];
+    }
+}
 
 /************************
  * Element Class Circle *
@@ -1490,6 +1512,7 @@ export const constructions : Construction[] = [
     new ProportionPointConstruction(),
     new AngleBisectorPointConstruction(),
     new AngleDividerPointConstruction(),
+    new MeanProportionalPointConstruction(),
     new CircumcircleConstruction(),
     new CircumcircleConstruction2d(),
     new LineSliderConstruction(),
@@ -1521,6 +1544,7 @@ export const constructions : Construction[] = [
     new SimilarLineConstruction(),
     new AngleBisectorLineConstruction(),
     new AngleDividerLineConstruction(),
+    new MeanProportionalLineConstruction(),
     new TrianglePolygonConstruction(),
     new RegularPolygonConstruction(),
     new SquarePolygonConstruction(),

--- a/src/elements/point/MeanProportionalElement.ts
+++ b/src/elements/point/MeanProportionalElement.ts
@@ -1,0 +1,51 @@
+/*----------------------------------------------------------------------+
+|    Title:	MeanProportionalElement.ts                                  |
+|    A port of the software Geometry Applet by                          |
+|    Author:    David E. Joyce                                          |
+|        Department of Mathematics and Computer Science                 |
+|        Clark University                                               |
+|        Worcester, MA 01610-1477                                       |
+|        U.S.A.                                                         |
+|                                                                       |
+|        http://aleph0.clarku.edu/~djoyce/home.html                     |
+|        djoyce@clarku.edu                                              |
+|                                                                       |
+|    Date:    February, 1996.   Version 2.0.0 May, 1997.                |
+|    TypeScript Port: 2026, Nelson Brown, brownnrl@gmail.com            |
+|                           https://www.nelsonbrown.net/                |
++----------------------------------------------------------------------*/
+
+import {PointElement} from "./PointElement";
+
+export class MeanProportionalElement extends PointElement {
+  /*--------------------------------------------------------------------+
+  | Given lines S,T,U cut off from U a mean proportional U' so that     |
+  | S:U'=U':T                                                          |
+  +--------------------------------------------------------------------*/
+
+  private _S0: PointElement;
+  private _S1: PointElement;
+  private _T0: PointElement;
+  private _T1: PointElement;
+  private _U0: PointElement;
+  private _U1: PointElement;
+
+  constructor(S0: PointElement, S1: PointElement, T0: PointElement,
+              T1: PointElement, U0: PointElement, U1: PointElement) {
+    super();
+    this.dimension = 0;
+    this._S0 = S0; this._S1 = S1;
+    this._T0 = T0; this._T1 = T1;
+    this._U0 = U0; this._U1 = U1;
+    if (U0._AP === U1._AP) {
+      this._AP = U0._AP;
+    }
+  }
+
+  public update() {
+    let factor : number = Math.sqrt(this._S0.distance2(this._S1) * this._T0.distance2(this._T1));
+    factor = Math.sqrt(factor / this._U0.distance2(this._U1));
+    this.to(this._U1).minus(this._U0);
+    this.times(factor).plus(this._U0);
+  }
+}

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -608,6 +608,34 @@ describe("slate", ()=> {
         almostEqual(app.area(), 4000, 1);
     });
 
+    // point;meanProportional — point U' on U0U1 so that S:U' = U':T (geometric mean)
+    // S=(0,0)→(100,0) len=100; T=(0,0)→(25,0) len=25; U=(0,0)→(200,0) len=200
+    // |U'| = sqrt(|S|*|T|) = sqrt(100*25) = 50
+    // factor = 50/200 = 0.25; result = (0,0) + 0.25*(200,0) = (50, 0)
+    // Check: S:U' = 100:50 = 2:1; U':T = 50:25 = 2:1 ✓
+    it("should compute a mean proportional point (geometric mean)", () => {
+        let data : IConstructionInfo[] = [
+            { name: "S0", construction: E.Point.free, params: [0, 0] },
+            { name: "S1", construction: E.Point.free, params: [100, 0] },
+            { name: "T0", construction: E.Point.free, params: [0, 0] },
+            { name: "T1", construction: E.Point.free, params: [25, 0] },
+            { name: "U0", construction: E.Point.free, params: [0, 0] },
+            { name: "U1", construction: E.Point.free, params: [200, 0] },
+            { name: "P",  construction: E.Point.meanProportional, params: ["S0","S1","T0","T1","U0","U1"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let P = slate.lookupElement("P") as PointElement;
+        almostEqual(P.x, 50, 0.01);
+        almostEqual(P.y,  0, 0.01);
+        // Verify the proportion: S:U' should equal U':T
+        let S = Math.sqrt(100*100);  // 100
+        let T = Math.sqrt(25*25);    // 25
+        let Up = P.distance(slate.lookupElement("U0") as PointElement); // 50
+        almostEqual(S / Up, Up / T, 0.001);
+    });
+
     it("should compute a fourth proportional point", () => {
         let data : IConstructionInfo[] = [
             { name: "S0", construction: E.Point.free, params: [0, 0] },

--- a/view/applet-tests/point/meanProportional/applet.html
+++ b/view/applet-tests/point/meanProportional/applet.html
@@ -1,0 +1,25 @@
+<HTML><HEAD><TITLE>point;meanProportional — applet form of view/test/point/meanProportional.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/point/meanProportional.html -->
+<!-- ORIGINAL: view/applet-tests/point/meanProportional/original.html (propVIII20) -->
+<!--
+  Standalone mean proportional test: three segments S, T, U drawn as
+  horizontal lines. P is the mean proportional on U so that S:U0P = U0P:T.
+  |U0P| = sqrt(|S|*|T|). Drag any segment endpoint to see P recompute.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="Point.meanProportional">
+<param name=e[1] value="S0;point;free;30,50">
+<param name=e[2] value="S1;point;free;130,50">
+<param name=e[3] value="S;line;connect;S0,S1">
+<param name=e[4] value="T0;point;free;30,100">
+<param name=e[5] value="T1;point;free;55,100">
+<param name=e[6] value="T;line;connect;T0,T1">
+<param name=e[7] value="U0;point;free;30,200">
+<param name=e[8] value="U1;point;free;230,200">
+<param name=e[9] value="U;line;connect;U0,U1">
+<param name=e[10] value="P;point;meanProportional;S0,S1,T0,T1,U0,U1">
+<param name=e[11] value="UP;line;connect;U0,P">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point/meanProportional/original.html
+++ b/view/applet-tests/point/meanProportional/original.html
@@ -1,0 +1,35 @@
+<HTML><HEAD><TITLE>VIII.20 — point;meanProportional (original)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=290 height=200>
+<param name=background value="35,19,100">
+<param name=title value="VIII.20">
+<param name=align value=above>
+<param name=e[1] value="A0;point;free;-1000,35;0;0">
+<param name=e[2] value="A3;point;free;1000,35;0;0">
+<param name=e[3] value="B0;point;free;-1000,70;0;0">
+<param name=e[4] value="B3;point;free;1000,70;0;0">
+<param name=e[5] value="C0;point;free;-1000,105;0;0">
+<param name=e[6] value="C3;point;free;1000,105;0;0">
+<param name=e[7] value="D0;point;free;-1000,140;0;0">
+<param name=e[8] value="D3;point;free;1000,140;0;0">
+<param name=e[9] value="E0;point;free;-1000,175;0;0">
+<param name=e[10] value="E3;point;free;1000,175;0;0">
+<param name=e[11] value="U1;point;free;1000,0;0;0">
+<param name=e[12] value="U2;point;free;1000,25;0;0">
+<param name=e[13] value="A1;point;lineSlider;A0,A3,30,0;0">
+<param name=e[14] value="A2;point;lineSlider;A0,A3,170,0;0">
+<param name=e[15] value="A;line;connect;A1,A2;black">
+<param name=e[16] value="B1;point;lineSlider;B0,B3,30,0;0">
+<param name=e[17] value="B2;point;lineSlider;B0,B3,260,0;0">
+<param name=e[18] value="B;line;connect;B1,B2;black">
+<param name=e[19] value="C1;point;lineSlider;C0,C3,30,0;0">
+<param name=e[20] value="C2;point;meanProportional;A1,A2,B1,B2,C1,C3;0">
+<param name=e[21] value="C;line;connect;C1,C2;black">
+<param name=e[22] value="D1;point;lineSlider;D0,D3,30,0;0">
+<param name=e[23] value="D2;point;proportion;A1,A2,D1,D3,A1,A2,D1,D3;0">
+<param name=e[24] value="D;line;connect;D1,D2;black">
+<param name=e[25] value="E1;point;lineSlider;E0,E3,30,0;0">
+<param name=e[26] value="E2;point;proportion;B1,B2,E1,E3,B1,B2,E1,E3;0">
+<param name=e[27] value="E;line;connect;E1,E2;black">
+</applet>
+</BODY></HTML>

--- a/view/test/point/meanProportional.html
+++ b/view/test/point/meanProportional.html
@@ -1,0 +1,35 @@
+<html>
+<head>
+    <title>Test View - Point.meanProportional (standalone)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "Point.meanProportional — geometric mean",
+        canvasid: "canvasId",
+        elements: [
+            // Segment S: length 100
+            { name: "S0", construction: E.Point.free, params: [30, 50] },
+            { name: "S1", construction: E.Point.free, params: [130, 50] },
+            { name: "S",  construction: E.Line.connect, params: ["S0", "S1"] },
+            // Segment T: length 25
+            { name: "T0", construction: E.Point.free, params: [30, 100] },
+            { name: "T1", construction: E.Point.free, params: [55, 100] },
+            { name: "T",  construction: E.Line.connect, params: ["T0", "T1"] },
+            // Segment U: length 200
+            { name: "U0", construction: E.Point.free, params: [30, 200] },
+            { name: "U1", construction: E.Point.free, params: [230, 200] },
+            { name: "U",  construction: E.Line.connect, params: ["U0", "U1"] },
+            // Mean proportional P on U so that S:U0P = U0P:T
+            // |U0P| = sqrt(|S|*|T|) = sqrt(100*25) = 50
+            { name: "P",  construction: E.Point.meanProportional, params: ["S0","S1","T0","T1","U0","U1"] },
+            { name: "UP", construction: E.Line.connect, params: ["U0", "P"] },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds `point;meanProportional` (port of `MeanProportional.java`) — the geometric mean construction. **Highest single-construction impact in the project: unblocks 35 propositions** across Books VIII, X, and XIII. Books I through X are now 100% renderable (390/390). Overall 429/465 (92%).

## What's in this branch

- `413ef0f` point-meanProportional: step 3 — add original.html from propVIII20
- `9eaef2c` point-meanProportional: step 4 — add MeanProportionalElement.ts
- `f2d3bcf` point-meanProportional: step 5 — wire MeanProportionalPointConstruction + MeanProportionalLineConstruction
- `d5ea170` point-meanProportional: step 6 — Mocha test
- `d3de90d` point-meanProportional: step 7 — three-way view pair (TS page + applet.html)
- `f75c69f` point-meanProportional: step 8 — tracker + journal — Books I–X COMPLETE (390/390)

## Construction details

- **Element class**: `src/elements/point/MeanProportionalElement.ts` — extends `PointElement`. Constructor `(S0,S1,T0,T1,U0,U1)`. `update()`: `factor = sqrt(sqrt(|S|²*|T|²) / |U|²)`, then `this.to(U1).minus(U0).times(factor).plus(U0)`.
- **Construction classes**: `MeanProportionalPointConstruction` (6-point signature) + `MeanProportionalLineConstruction` (6-point + LineElement wrapper). Full Java class conversion.
- **Java source**: `MeanProportional.java` — 23 lines, line-for-line port.

## Tests

38 → **39 passing**. One new test: geometric mean sqrt(100*25)=50, proportion S:U'=U':T=2:1 verified.

## Verification

- [x] `npm run build` clean
- [x] `npm test` passes (39/39)
- [x] `npx webpack` rebuilds `dist/bundle.js`
- [x] Three-way harness — **needs human verification**

## Newly renderable propositions

- **Book VIII** (25 → **27/27 = 100%**): VIII.20, VIII.26
- **Book X** (82 → **115/115 = 100%**): 33 propositions unblocked
- **Book XIII** (10 → 13): XIII.2 (+ others still blocked by 3D constructions)
- **I–X total: 390/390 = 100%**
- **I–XIII total: 429/465 = 92%**

Only 36 propositions remain blocked, all in Books XI–XIII (solid geometry: `plane;3points`, `point;planeSlider`, `point;sphereSlider`, `polygon;face`, `polygon;octagon`, `circle;intersection`).
