### PR TITLE
Feature/trivial dispatchers 3points octagon cutoff

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -293,13 +293,10 @@ These affect the library as a whole, independent of individual constructions.
     [view/applet-tests/line/foot/{original,applet}.html](../view/applet-tests/line/foot/)
   - Used in: I.47 (Pythagoras' theorem)
 
-- [ ] **`cutoff`** — TBD
-  - Java source: `Slate.java` line case 7 — `Layoff(P[0],P[0],P[1],P[2],P[3])` +
-    `LineElement(P[0], layoff)`. Same dispatch-trick pattern as `line;extend`.
-  - Used in: compass geometry pages. No Books I–XIII proposition uses found,
-    but the enum `LineConstructions.cutoff = 108` exists and the TBD comment
-    stub is in Constructions.ts.
-  - Trivial port: same Layoff+LineElement pattern as line;extend/line;parallel.
+- [x] **`cutoff`** — `src/elements/Constructions.ts` (`LineCutoffConstruction`)
+  - Layoff+LineElement dispatch trick, same pattern as `line;extend`.
+  - Mocha test (1): cutoff length verification.
+  - Used in: compass geometry pages. No Books I–XIII proposition uses.
 
 - [x] **`similar`** — `src/elements/Constructions.ts` (`SimilarLineConstruction`)
   - No new element class — reuses `SimilarElement` (from `point;similar`) +
@@ -446,10 +443,10 @@ These affect the library as a whole, independent of individual constructions.
   - 6-point pass-through `PolyConstruction`. Same pattern as quadrilateral.
   - Used in: IV.15
 
-- [ ] **`octagon`** — TBD
-  - Java source: `PolygonElement.java` (8 free vertices, pass-through)
-  - Used in: Book XII (XII.2, XII.10, XII.11, XII.12 — blocks 4 propositions)
-  - Trivial port: same pattern as pentagon/hexagon (PolyConstruction subclass)
+- [x] **`octagon`** — `src/elements/Constructions.ts` (`OctagonPolygonConstruction`)
+  - 8-point pass-through `PolyConstruction`. Same pattern as pentagon/hexagon.
+  - Mocha test (1): 8-vertex correctness.
+  - Used in: Book XII (XII.2, XII.10 sole-blocker; XII.11, XII.12 also need polyhedron)
 
 - [ ] **`face`** — TBD
   - Returns the N-th face (a PolygonElement) of a PolyhedronElement.
@@ -494,11 +491,11 @@ These affect the library as a whole, independent of individual constructions.
 - [x] **`perpendicular`** — `src/elements/plane/PerpendicularPlane.ts`
   - no dedicated test page
 
-- [ ] **`3points`** — TBD
-  - Java source: `PlaneElement.java` — **element class already ported** as
-    `PlaneElement.ts` with `{A, B, C}` constructor + `update()` that computes
-    S, T, U frame. Only the Construction dispatcher is needed (trivial).
-  - Blocks **22 propositions** across Books XI–XIII (highest-impact TBD remaining)
+- [x] **`3points`** — `src/elements/Constructions.ts` (`Plane3PointsConstruction`)
+  - No new element class — `PlaneElement.ts` already has the full constructor
+    + `update()`. The dispatcher just creates `PlaneElement({A, B, C})`.
+  - Mocha test (1): S/T/U frame verification for xy-plane.
+  - Used in: Books XI–XIII (prerequisite for 22 propositions; 2 sole-blocker: XI.29, XI.38)
 
 - [ ] **`parallel`** — TBD
   - Java source: `ParallelP.java` (26 lines) — parallel plane through a point

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,34 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-12 — Trivial dispatchers: plane;3points + polygon;octagon + line;cutoff
+
+**Completed:**
+- Wired 3 trivial Construction dispatchers in one session (no new element
+  classes — all reuse existing TS classes):
+  - `Plane3PointsConstruction`: creates `PlaneElement({A, B, C})`. The
+    element class was already fully ported with `update()` that computes
+    the orthonormal S/T/U frame. This is the **#1 prerequisite** for
+    Books XI–XIII solid geometry (22 props depend on it).
+  - `OctagonPolygonConstruction`: 8-point `PolyConstruction` pass-through.
+    Same one-line pattern as pentagon/hexagon/quadrilateral.
+  - `LineCutoffConstruction`: `Layoff(A,A,B,C,D)` + `LineElement(A,lo)`.
+    Same dispatch trick as `line;extend`/`line;parallel`.
+- 3 Mocha tests: plane S/T/U frame, octagon 8-vertex check, cutoff
+  length verification. 39 → **42 passing**.
+- **4 propositions unblocked**: XI.29, XI.38 (plane;3points sole blocker),
+  XII.2, XII.10 (polygon;octagon sole blocker).
+- I–XIII total: 435 → **439** renderable (94.4%).
+
+**Next session:**
+- `point;planeSlider` — with `plane;3points` now landed, this is the key
+  that unlocks most of Book XI: XI.4, XI.30–XI.32, XI.34, XII.17 would
+  all become renderable with just planeSlider.
+- Then `plane;parallel` to finish the remaining XI props.
+- Then `point;sphereSlider` for Book XIII.
+
+---
+
 ## 2026-04-12 — Books XI–XIII deep analysis — 30 blocked props, 11 TBD constructions
 
 **Completed:**

--- a/doc/proposition-tracker.md
+++ b/doc/proposition-tracker.md
@@ -25,10 +25,10 @@ Tracks the port status of all propositions across Euclid's Elements.
 | Book IX | 36 | **36** | 0 |
 | Book X | 115 | **115** | 0 |
 | **I–X total** | **390** | **390** | **0** |
-| Book XI | 39 | 26 | 0 |
-| Book XII | 18 | 6 | 0 |
+| Book XI | 39 | 28 | 0 |
+| Book XII | 18 | 8 | 0 |
 | Book XIII | 18 | 13 | 0 |
-| **I–XIII total** | **465** | **435** | **0** |
+| **I–XIII total** | **465** | **439** | **0** |
 
 Update the summary table after each session.
 
@@ -245,7 +245,7 @@ Verified per-proposition against actual HTML param lists 2026-04-12.
 - [~] XI.24, XI.25 — renderable
 - [ ] XI.26 — NEEDS: `plane;3points`, `plane;parallel`, `point;planeSlider`
 - [~] XI.27, XI.28 — renderable
-- [ ] XI.29 — NEEDS: `plane;3points`
+- [~] XI.29 — (`plane;3points` landed 2026-04-12.)
 - [ ] XI.30 — NEEDS: `plane;3points`, `point;planeSlider`
 - [ ] XI.31 — NEEDS: `plane;3points`, `point;planeSlider`
 - [ ] XI.32 — NEEDS: `plane;3points`, `point;planeSlider`
@@ -254,7 +254,7 @@ Verified per-proposition against actual HTML param lists 2026-04-12.
 - [ ] XI.35 — NEEDS: `plane;3points`, `point;planeSlider`, `point;sphereSlider`
 - [~] XI.36 — renderable
 - [ ] XI.37 — NEEDS: `plane;3points`, `point;planeSlider`, `polyhedron;parallelepiped`
-- [ ] XI.38 — NEEDS: `plane;3points`
+- [~] XI.38 — (`plane;3points` landed 2026-04-12.)
 - [ ] XI.39 — NEEDS: `plane;3points`, `plane;parallel`, `point;planeSlider`, `polyhedron;prism`
 
 ---
@@ -264,7 +264,7 @@ Verified per-proposition against actual HTML param lists 2026-04-12.
 6 of 18 propositions are renderable. 12 blocked.
 
 - [~] XII.1 — renderable
-- [ ] XII.2 — NEEDS: `polygon;octagon`
+- [~] XII.2 — (`polygon;octagon` landed 2026-04-12.)
 - [ ] XII.3 — NEEDS: `plane;3points`, `point;planeSlider`, `polyhedron;tetrahedron`
 - [ ] XII.4 — NEEDS: `plane;3points`, `point;planeSlider`, `polyhedron;tetrahedron`
 - [ ] XII.5 — NEEDS: `plane;3points`, `point;planeSlider`, `polyhedron;parallelepiped`, `polyhedron;tetrahedron`
@@ -272,7 +272,7 @@ Verified per-proposition against actual HTML param lists 2026-04-12.
 - [ ] XII.7 — NEEDS: `plane;3points`, `point;planeSlider`, `polygon;face`, `polyhedron;prism`
 - [ ] XII.8 — NEEDS: `plane;3points`, `point;planeSlider`, `polyhedron;tetrahedron`
 - [ ] XII.9 — NEEDS: `plane;3points`, `point;planeSlider`, `polyhedron;parallelepiped`, `polyhedron;tetrahedron`
-- [ ] XII.10 — NEEDS: `polygon;octagon`
+- [~] XII.10 — (`polygon;octagon` landed 2026-04-12.)
 - [ ] XII.11 — NEEDS: `polygon;octagon`, `polyhedron;parallelepiped`
 - [ ] XII.12 — NEEDS: `polygon;octagon`, `polyhedron;parallelepiped`
 - [~] XII.13 through XII.16 — renderable

--- a/src/Slate.ts
+++ b/src/Slate.ts
@@ -264,13 +264,19 @@ export class Slate {
     }
 
     closestVisiblePoint(elements : GeomElement[], p : PointElement, tolerance : number = 30) : PointElement {
+        // Use 2D screen distance (x,y only, ignoring z) for picking,
+        // matching the Java applet's movePick() at Slate.java:887-889.
+        // The canvas is a 2D projection; a 3D point at (x,y,z) renders
+        // at screen position (x,y) regardless of z.
+        let screenDist2 = (a: PointElement, b: PointElement) =>
+            (a.x - b.x) * (a.x - b.x) + (a.y - b.y) * (a.y - b.y);
         let sortedDistanceElements = elements
             .filter(e => e instanceof PointElement)
             .map(e => e as PointElement)
             .filter(e => e.vertexColor != null)
             .sort((a,b) => {
-                let adcp = a.distance2(p);
-                let bdcp = b.distance2(p);
+                let adcp = screenDist2(a, p);
+                let bdcp = screenDist2(b, p);
                 if(adcp < bdcp) {
                     return -1;
                 } else if (bdcp < adcp) {
@@ -280,7 +286,7 @@ export class Slate {
             });
         if (sortedDistanceElements.length == 0) return null;
         let bestDistPoint = sortedDistanceElements[0];
-        if(bestDistPoint.distance(p) > tolerance) return null;
+        if(Math.sqrt(screenDist2(bestDistPoint, p)) > tolerance) return null;
         return bestDistPoint;
     }
 

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -987,13 +987,23 @@ export class LinePerpendicular5Construction extends PointPerpendicular5Construct
     }
 }
 
-// TBD
 // line
 // cutoff
 // points A, B, C, D
 // the line AE equal to CD along the line AB
+// (Java: Slate.java line case 7 — Layoff(A,A,B,C,D) + LineElement(A,layoff))
+export class LineCutoffConstruction extends Construction {
+    constructionMethod: AllConstructions = LineConstructions.cutoff;
+    signature: ConstructionTypes[] = (new Array(4)).fill(ct.PointElement);
 
-// TBD
+    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let lo = new Layoff(ps[0], ps[0], ps[1], ps[2], ps[3]);
+        let g = new LineElement({A: ps[0], B: lo});
+        return [[lo, g], g];
+    }
+}
+
 // line
 // extend
 // points A, B, C, D
@@ -1304,12 +1314,14 @@ export class ApplicationPolygonConstruction extends Construction {
     }
 }
 
-// TBD
 // polygon
-// octagon	
+// octagon
 // 8 points A, B, C, D, E, F, G, H
-// the octagon given 8 vertices
-
+// the octagon given 8 vertices (free points, pass-through)
+export class OctagonPolygonConstruction extends PolyConstruction {
+    constructionMethod: AllConstructions = PolygonConstructions.octagon;
+    signature: ConstructionTypes[] = (new Array(8)).fill(ct.PointElement);
+}
 
 // TBD
 // *Solid Geometry Only*
@@ -1378,13 +1390,22 @@ export class ArcConstruction extends Construction {
  * Element Class Plane *
  ***********************/
 
-// TBD
-// *Solid Geometry Only*
 // plane
 // 3points
 // points A, B, C
 // the plane passing through points A, B, and C
+// (Java: Slate.java plane case 0 — new PlaneElement(A, B, C).
+// PlaneElement.ts already has the full constructor + update() that computes S, T, U.)
+export class Plane3PointsConstruction extends Construction {
+    constructionMethod: AllConstructions = PlaneConstructions.threePoints;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
 
+    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let g = new PlaneElement({A: ps[0], B: ps[1], C: ps[2]});
+        return [[g], g];
+    }
+}
 
 // *Solid Geometry Only*
 // plane
@@ -1540,6 +1561,7 @@ export const constructions : Construction[] = [
     new BichordConstruction(),
     new ChordConstruction(),
     new LineParallelConstruction(),
+    new LineCutoffConstruction(),
     new LineFootConstruction(),
     new SimilarLineConstruction(),
     new AngleBisectorLineConstruction(),
@@ -1551,11 +1573,13 @@ export const constructions : Construction[] = [
     new EquilateralTriangleConstruction(),
     new ParallelogramPolygonConstruction(),
     new QuadrilateralPolygonConstruction(),
+    new OctagonPolygonConstruction(),
     new PentagonPolygonConstruction(),
     new HexagonPolygonConstruction(),
     new SimilarPolygonConstruction(),
     new ApplicationPolygonConstruction(),
     new VertexConstruction(),
+    new Plane3PointsConstruction(),
     new PerpendicularPlaneConstruction(),
     new SphereRadiusConstruction()
 ];

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -787,6 +787,77 @@ describe("slate", ()=> {
     // Right angle at B=(0,0), rays to A=(0,100) and C=(100,0)
     // Bisector of 90° at B → 45° ray hits AC (line from (0,100) to (100,0), x+y=100)
     // at (50, 50)
+    // plane;3points — plane through 3 non-collinear points
+    it("should create a plane through 3 points with computed S,T,U frame", () => {
+        let data : IConstructionInfo[] = [
+            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "P", construction: E.Plane.threePoints, params: ["A", "B", "C"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let plane = slate.lookupElement("P") as PlaneElement;
+        // S should be unit vector in direction A→B = (1,0,0)
+        almostEqual(plane.S.x, 1, 0.01);
+        almostEqual(plane.S.y, 0, 0.01);
+        almostEqual(plane.S.z, 0, 0.01);
+        // T should be unit vector perpendicular to S in the plane = (0,1,0)
+        almostEqual(plane.T.x, 0, 0.01);
+        almostEqual(plane.T.y, 1, 0.01);
+        almostEqual(plane.T.z, 0, 0.01);
+        // U should be normal = (0,0,1)
+        almostEqual(plane.U.x, 0, 0.01);
+        almostEqual(plane.U.y, 0, 0.01);
+        almostEqual(plane.U.z, 1, 0.01);
+    });
+
+    // polygon;octagon — 8 free vertices pass-through
+    it("should create an octagon with 8 vertices", () => {
+        let data : IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [100, 50] },
+            { name: "B", construction: E.Point.free, params: [150, 50] },
+            { name: "C", construction: E.Point.free, params: [175, 100] },
+            { name: "D", construction: E.Point.free, params: [150, 150] },
+            { name: "E", construction: E.Point.free, params: [100, 150] },
+            { name: "F", construction: E.Point.free, params: [75, 100] },
+            { name: "G", construction: E.Point.free, params: [85, 70] },
+            { name: "H", construction: E.Point.free, params: [115, 70] },
+            { name: "OCT", construction: E.Polygon.octagon, params: ["A","B","C","D","E","F","G","H"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        let poly = slate.lookupElement("OCT") as PolygonElement;
+        assert.equal(poly.V.length, 8);
+        almostEqual(poly.V[0].x, 100, 0.01);
+        almostEqual(poly.V[7].x, 115, 0.01);
+    });
+
+    // line;cutoff — line AE equal to CD along line AB
+    // A=(50,100), B=(200,100), C=(0,0), D=(60,0) → |CD|=60
+    // Layoff(A,A,B,C,D): E on ray AB from A with |AE|=60 → E=(110,100)
+    // Line from A=(50,100) to E=(110,100)
+    it("should create a line cutoff equal to a given length", () => {
+        let data : IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [50, 100] },
+            { name: "B", construction: E.Point.free, params: [200, 100] },
+            { name: "C", construction: E.Point.free, params: [0, 0] },
+            { name: "D", construction: E.Point.free, params: [60, 0] },
+            { name: "AE", construction: E.Line.cutoff, params: ["A", "B", "C", "D"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let line = slate.lookupElement("AE") as LineElement;
+        // Line starts at A
+        almostEqual(line.A.x, 50, 0.01);
+        almostEqual(line.A.y, 100, 0.01);
+        // Line ends at E = A + 60 along AB direction (horizontal)
+        almostEqual(line.B.x, 110, 0.01);
+        almostEqual(line.B.y, 100, 0.01);
+    });
+
     it("should bisect a right angle and intersect the opposite side", () => {
         let data : IConstructionInfo[] = [
             { name: "A", construction: E.Point.free, params: [0, 100] },

--- a/view/applet-tests/line/cutoff/applet.html
+++ b/view/applet-tests/line/cutoff/applet.html
@@ -1,0 +1,21 @@
+<HTML><HEAD><TITLE>line;cutoff — applet form of view/test/line/cutoff.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/line/cutoff.html -->
+<!-- ORIGINAL: view/applet-tests/line/cutoff/original.html (standalone) -->
+<!--
+  Standalone line;cutoff test: line AB, reference segment CD, cutoff AE
+  along AB with |AE| = |CD|. Drag C or D to change the cutoff length.
+  Canvas 400x400.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="Line.cutoff">
+<param name=e[1] value="A;point;free;50,150">
+<param name=e[2] value="B;point;free;300,150">
+<param name=e[3] value="AB;line;connect;A,B">
+<param name=e[4] value="C;point;free;50,250">
+<param name=e[5] value="D;point;free;130,250">
+<param name=e[6] value="CD;line;connect;C,D">
+<param name=e[7] value="AE;line;cutoff;AB,CD">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/line/cutoff/original.html
+++ b/view/applet-tests/line/cutoff/original.html
@@ -1,0 +1,14 @@
+<HTML><HEAD><TITLE>line;cutoff (standalone)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="Line.cutoff">
+<param name=e[1] value="A;point;free;50,150">
+<param name=e[2] value="B;point;free;300,150">
+<param name=e[3] value="AB;line;connect;A,B">
+<param name=e[4] value="C;point;free;50,250">
+<param name=e[5] value="D;point;free;130,250">
+<param name=e[6] value="CD;line;connect;C,D">
+<param name=e[7] value="AE;line;cutoff;AB,CD">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/plane/3points/applet.html
+++ b/view/applet-tests/plane/3points/applet.html
@@ -1,0 +1,30 @@
+<HTML><HEAD><TITLE>plane;3points — applet form of view/test/plane/3points.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/plane/3points.html -->
+<!-- ORIGINAL: view/applet-tests/plane/3points/original.html (propXI29) -->
+<!--
+  PropXI29: parallelepipedal solids on the same base. Uses plane;3points
+  twice (ceiling and floor planes). Trimmed to first 16 elements.
+  Canvas 400x400.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="XI.29 — plane;3points">
+<param name=e[1] value="F;point;fixed;70,130,0;black;green">
+<param name=e[2] value="1X;point;fixed;270,103,36;0;0">
+<param name=e[3] value="1Y;point;fixed;25,10,160;0;0">
+<param name=e[4] value="1Z;point;fixed;70,274,123;0;0">
+<param name=e[5] value="M;point;lineSlider;F,1X,210,60,0">
+<param name=e[6] value="D;point;lineSlider;F,1Y,60,60,100">
+<param name=e[7] value="A;point;lineSlider;F,1Z,210,210,180">
+<param name=e[8] value="ceiling;plane;3points;F,M,D;0;0;black;60,50,100">
+<param name=e[9] value="L;point;parallelogram;A,F,M">
+<param name=e[10] value="C;point;parallelogram;A,F,D">
+<param name=e[11] value="B;point;parallelogram;L,A,C">
+<param name=e[12] value="H;point;parallelogram;M,F,D">
+<param name=e[13] value="floor;plane;3points;A,L,C;0;0;black;0">
+<param name=e[14] value="AFDC;polygon;quadrilateral;A,F,D,C;0;0;black;60,75,100">
+<param name=e[15] value="ALMF;polygon;quadrilateral;A,L,M,F;0;0;black;60,100,100">
+<param name=e[16] value="HB;line;connect;H,B">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/plane/3points/original.html
+++ b/view/applet-tests/plane/3points/original.html
@@ -1,0 +1,31 @@
+<HTML><HEAD><TITLE>XI.29 — plane;3points (original)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=300 width=300>
+<param name=background value="35,19,100">
+<param name=title value="XI.29">
+<param name=e[1] value="F;point;fixed;70,130,0;black;green">
+<param name=e[2] value="1X;point;fixed;270,103,36;0;0">
+<param name=e[3] value="1Y;point;fixed;25,10,160;0;0">
+<param name=e[4] value="1Z;point;fixed;70,274,123;0;0">
+<param name=e[5] value="M;point;lineSlider;F,1X,210,60,0">
+<param name=e[6] value="D;point;lineSlider;F,1Y,60,60,100">
+<param name=e[7] value="A;point;lineSlider;F,1Z,210,210,180">
+<param name=e[8] value="ceiling;plane;3points;F,M,D;0;0;black;60,50,100">
+<param name=e[9] value="L;point;parallelogram;A,F,M">
+<param name=e[10] value="C;point;parallelogram;A,F,D">
+<param name=e[11] value="B;point;parallelogram;L,A,C">
+<param name=e[12] value="H;point;parallelogram;M,F,D">
+<param name=e[13] value="floor;plane;3points;A,L,C;0;0;black;0">
+<param name=e[14] value="AFDC;polygon;quadrilateral;A,F,D,C;0;0;black;60,75,100">
+<param name=e[15] value="ALMF;polygon;quadrilateral;A,L,M,F;0;0;black;60,100,100">
+<param name=e[16] value="HB;line;connect;H,B">
+<param name=e[17] value="N;point;lineSlider;F,M,280,210,10">
+<param name=e[18] value="G;point;parallelogram;N,L,A">
+<param name=e[19] value="K;point;parallelogram;N,L,B">
+<param name=e[20] value="E;point;parallelogram;N,L,C">
+<param name=e[21] value="ACEG;polygon;quadrilateral;A,C,E,G;0;0;black;0">
+<param name=e[22] value="LBKN;polygon;quadrilateral;L,B,K,N;0;0;black;0">
+<param name=e[23] value="HK;line;connect;H,K">
+<param name=e[24] value="M,N;line;connect;M,N">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/poly/octagon/applet.html
+++ b/view/applet-tests/poly/octagon/applet.html
@@ -1,0 +1,31 @@
+<HTML><HEAD><TITLE>polygon;octagon — applet form of view/test/poly/octagon.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/poly/octagon.html -->
+<!-- ORIGINAL: view/applet-tests/poly/octagon/original.html (propXII2) -->
+<!--
+  PropXII2 excerpt: circle EFGH with inscribed octagon EKFLGMHN.
+  Canvas 400x400.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="XII.2 — polygon;octagon">
+<param name=e[1] value="X0;point;free;-10000,145;0;0">
+<param name=e[2] value="X1;point;free;10000,145;0;0">
+<param name=e[3] value="F;point;lineSlider;X0,X1,120,0">
+<param name=e[4] value="H;point;lineSlider;X0,X1,280,0">
+<param name=e[5] value="FH;line;connect;F,H">
+<param name=e[6] value="FHcenter;point;midpoint;FH;0;0">
+<param name=e[7] value="EFGH;circle;radius;FHcenter,F;0;0;black;random">
+<param name=e[8] value="E;point;perpendicular;FHcenter,H">
+<param name=e[9] value="G;point;extend;E,FHcenter,E,FHcenter">
+<param name=e[10] value="K';point;midpoint;E,F;0;0">
+<param name=e[11] value="K;point;cutoff;FHcenter,K',FHcenter,F">
+<param name=e[12] value="L';point;midpoint;F,G;0;0">
+<param name=e[13] value="L;point;cutoff;FHcenter,L',FHcenter,F">
+<param name=e[14] value="M';point;midpoint;G,H;0;0">
+<param name=e[15] value="M;point;cutoff;FHcenter,M',FHcenter,F">
+<param name=e[16] value="N';point;midpoint;H,E;0;0">
+<param name=e[17] value="N;point;cutoff;FHcenter,N',FHcenter,F">
+<param name=e[18] value="EKFLGMHN;polygon;octagon;E,K,F,L,G,M,H,N;0;0;black;0">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/poly/octagon/original.html
+++ b/view/applet-tests/poly/octagon/original.html
@@ -1,0 +1,39 @@
+<HTML><HEAD><TITLE>XII.2 — polygon;octagon (original)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=300 width=400>
+<param name=background value="35,19,100">
+<param name=title value="XII.2">
+<param name=e[1] value="X0;point;free;-10000,145;0;0">
+<param name=e[2] value="X1;point;free;10000,145;0;0">
+<param name=e[3] value="B;point;lineSlider;X0,X1,35,0">
+<param name=e[4] value="D;point;lineSlider;X0,X1,150,0">
+<param name=e[5] value="F;point;lineSlider;X0,X1,190,0">
+<param name=e[6] value="H;point;lineSlider;X0,X1,320,0">
+<param name=e[7] value="BD;line;connect;B,D">
+<param name=e[8] value="FH;line;connect;F,H">
+<param name=e[9] value="BDcenter;point;midpoint;BD;0;0">
+<param name=e[10] value="ABCD;circle;radius;BDcenter,B;0;0;black;random">
+<param name=e[11] value="FHcenter;point;midpoint;FH;0;0">
+<param name=e[12] value="EFGH;circle;radius;FHcenter,F;0;0;black;random">
+<param name=e[13] value="A;point;perpendicular;BDcenter,D">
+<param name=e[14] value="C;point;extend;A,BDcenter,A,BDcenter">
+<param name=e[15] value="E;point;perpendicular;FHcenter,H">
+<param name=e[16] value="G;point;extend;E,FHcenter,E,FHcenter">
+<param name=e[17] value="S0;point;lineSlider;X0,X1,355,125;0">
+<param name=e[18] value="S1;point;cutoff;S0,X1,FHcenter,F;0;0">
+<param name=e[19] value="S2;point;perpendicular;S1,S0;0;0">
+<param name=e[20] value="S3;point;parallelogram;S2,S1,S0;0;0">
+<param name=e[21] value="S4;point;extend;S3,S0,F,H;0;0">
+<param name=e[22] value="S;polygon;parallelogram;S2,S3,S4;black;0;black;random">
+<param name=e[23] value="EFGHsquare;polygon;quadrilateral;E,F,G,H;0;0;black;random">
+<param name=e[24] value="K';point;midpoint;E,F;0;0">
+<param name=e[25] value="K;point;cutoff;FHcenter,K',FHcenter,F">
+<param name=e[26] value="L';point;midpoint;F,G;0;0">
+<param name=e[27] value="L;point;cutoff;FHcenter,L',FHcenter,F">
+<param name=e[28] value="M';point;midpoint;G,H;0;0">
+<param name=e[29] value="M;point;cutoff;FHcenter,M',FHcenter,F">
+<param name=e[30] value="N';point;midpoint;H,E;0;0">
+<param name=e[31] value="N;point;cutoff;FHcenter,N',FHcenter,F">
+<param name=e[32] value="EKFLGMHN;polygon;octagon;E,K,F,L,G,M,H,N;0;0;black;0">
+</applet>
+</BODY></HTML>

--- a/view/test/line/cutoff.html
+++ b/view/test/line/cutoff.html
@@ -1,0 +1,29 @@
+<html>
+<head>
+    <title>Test View - Line.cutoff (standalone)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "Line.cutoff — cut off a length from a line",
+        canvasid: "canvasId",
+        elements: [
+            // Line AB
+            { name: "A", construction: E.Point.free, params: [50, 150] },
+            { name: "B", construction: E.Point.free, params: [300, 150] },
+            { name: "AB", construction: E.Line.connect, params: ["A", "B"] },
+            // Reference segment CD (length to cut off)
+            { name: "C", construction: E.Point.free, params: [50, 250] },
+            { name: "D", construction: E.Point.free, params: [130, 250] },
+            { name: "CD", construction: E.Line.connect, params: ["C", "D"] },
+            // line;cutoff: line AE along AB with |AE| = |CD|
+            { name: "AE", construction: E.Line.cutoff, params: ["A", "B", "C", "D"] },
+        ]
+    });
+</script>
+</body>
+</html>

--- a/view/test/plane/3points.html
+++ b/view/test/plane/3points.html
@@ -1,0 +1,36 @@
+<html>
+<head>
+    <title>Test View - Plane.3points (XI.29)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "XI.29 — Parallelepipedal solids on the same base and same height",
+        canvasid: "canvasId",
+        elements: [
+            { name: "F", construction: E.Point.fixed, params: [70, 130, 0] },
+            { name: "1X", construction: E.Point.fixed, params: [270, 103, 36] },
+            { name: "1Y", construction: E.Point.fixed, params: [25, 10, 160] },
+            { name: "1Z", construction: E.Point.fixed, params: [70, 274, 123] },
+            { name: "M", construction: E.Point.lineSlider, params: ["F", "1X", 210, 60, 0] },
+            { name: "D", construction: E.Point.lineSlider, params: ["F", "1Y", 60, 60, 100] },
+            { name: "A", construction: E.Point.lineSlider, params: ["F", "1Z", 210, 210, 180] },
+            // plane;3points — the target construction (2 uses)
+            { name: "ceiling", construction: E.Plane.threePoints, params: ["F", "M", "D"] },
+            { name: "L", construction: E.Point.parallelogram, params: ["A", "F", "M"] },
+            { name: "C", construction: E.Point.parallelogram, params: ["A", "F", "D"] },
+            { name: "B", construction: E.Point.parallelogram, params: ["L", "A", "C"] },
+            { name: "H", construction: E.Point.parallelogram, params: ["M", "F", "D"] },
+            { name: "floor", construction: E.Plane.threePoints, params: ["A", "L", "C"] },
+            { name: "AFDC", construction: E.Polygon.quadrilateral, params: ["A", "F", "D", "C"] },
+            { name: "ALMF", construction: E.Polygon.quadrilateral, params: ["A", "L", "M", "F"] },
+            { name: "HB", construction: E.Line.connect, params: ["H", "B"] },
+        ]
+    });
+</script>
+</body>
+</html>

--- a/view/test/poly/octagon.html
+++ b/view/test/poly/octagon.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+    <title>Test View - Polygon.octagon (XII.2 excerpt)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "XII.2 — Circles are to one another as the squares on their diameters",
+        canvasid: "canvasId",
+        elements: [
+            // Right circle EFGH with inscribed octagon
+            { name: "X0", construction: E.Point.free, params: [-10000, 145] },
+            { name: "X1", construction: E.Point.free, params: [10000, 145] },
+            { name: "F", construction: E.Point.lineSlider, params: ["X0", "X1", 120, 145] },
+            { name: "H", construction: E.Point.lineSlider, params: ["X0", "X1", 280, 145] },
+            { name: "FH", construction: E.Line.connect, params: ["F", "H"] },
+            { name: "FHcenter", construction: E.Point.midpoint, params: ["FH"] },
+            { name: "EFGH", construction: E.Circle.radius, params: ["FHcenter", "F"] },
+            { name: "E", construction: E.Point.perpendicular, params: ["FHcenter", "H"] },
+            { name: "G", construction: E.Point.extend, params: ["E", "FHcenter", "E", "FHcenter"] },
+            // Compute octagon midpoints on the circle
+            { name: "K'", construction: E.Point.midpoint, params: ["E", "F"] },
+            { name: "K", construction: E.Point.cutoff, params: ["FHcenter", "K'", "FHcenter", "F"] },
+            { name: "L'", construction: E.Point.midpoint, params: ["F", "G"] },
+            { name: "L", construction: E.Point.cutoff, params: ["FHcenter", "L'", "FHcenter", "F"] },
+            { name: "M'", construction: E.Point.midpoint, params: ["G", "H"] },
+            { name: "M", construction: E.Point.cutoff, params: ["FHcenter", "M'", "FHcenter", "F"] },
+            { name: "N'", construction: E.Point.midpoint, params: ["H", "E"] },
+            { name: "N", construction: E.Point.cutoff, params: ["FHcenter", "N'", "FHcenter", "F"] },
+            // The octagon ← target construction
+            { name: "EKFLGMHN", construction: E.Polygon.octagon, params: ["E","K","F","L","G","M","H","N"] },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Wires 3 trivial Construction dispatchers (plane;3points, polygon;octagon, line;cutoff) and fixes a porting bug in 3D point picking. `plane;3points` is the #1 prerequisite for Books XI–XIII solid geometry. Unblocks 4 propositions. Also fixes a porting bug where 3D points were un-draggable because picking used 3D distance instead of 2D screen distance.

## What's in this branch

- `f7b9941` trivial-dispatchers: wire plane;3points + polygon;octagon + line;cutoff
- `c2da16f` trivial-dispatchers: Mocha tests for plane;3points, polygon;octagon, line;cutoff
- `49bde2a` trivial-dispatchers: tracker + journal — 439/465 renderable (+4 props)
- `c18bc9f` trivial-dispatchers: step 7 — three-way view pairs for plane;3points, polygon;octagon, line;cutoff
- `6d69f6f` fix: use 2D screen distance for point picking (porting bug)

`6d69f6f` is an out-of-band platform bugfix discovered during harness verification of the plane;3points test page — point D (a 3D lineSlider with z≈94.6) was un-draggable because `closestVisiblePoint()` used 3D `distance2()` instead of 2D screen distance. The Java applet's `movePick()` at Slate.java:887-889 correctly uses `(x-c)*(x-c) + (y-d)*(y-d)` (2D only). Now matches.

## Construction details

- **`plane;3points`** (`Plane3PointsConstruction`): Creates `PlaneElement({A, B, C})`. Element class already had full constructor + `update()` computing S/T/U orthonormal frame. Signature `[Point × 3]`. Prerequisite for 22 solid-geometry propositions.
- **`polygon;octagon`** (`OctagonPolygonConstruction`): 8-point `PolyConstruction` pass-through. One-line subclass.
- **`line;cutoff`** (`LineCutoffConstruction`): `Layoff(A,A,B,C,D) + LineElement(A,lo)`. Same dispatch trick as `line;extend`.

## Bug fix: 3D point picking

`closestVisiblePoint()` in Slate.ts used `PointElement.distance2()` which includes z. For 3D points with significant z values (like lineSliders in Book XI solid geometry), the 3D distance exceeded the pick tolerance of 30 even when the mouse was directly over the point's screen position. The Java applet correctly uses 2D screen distance. Now the TS port matches. Affects all 3D interactions in Books XI–XIII.

## Tests

39 → **42 passing**. Three new tests: plane S/T/U frame, octagon 8-vertex, cutoff length.

## Verification

- [x] `npm run build` clean
- [x] `npm test` passes (42/42)
- [x] `npx webpack` rebuilds `dist/bundle.js`
- [x] Three-way harness verified for plane;3points — D point is now draggable after the pick fix
- [x] polygon;octagon and line;cutoff harness entries present

## Newly renderable propositions

- **Book XI** (26 → 28): XI.29, XI.38
- **Book XII** (6 → 8): XII.2, XII.10
- **I–XIII total** (435 → 439): +4
