### PR TITLE
Feature/point plane slider

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -203,8 +203,16 @@ These affect the library as a whole, independent of individual constructions.
     [view/applet-tests/point/meanProportional/{original,applet}.html](../view/applet-tests/point/meanProportional/)
   - Used in: VIII.20, VIII.26, X (33 props), XIII.2 — **35 props unblocked**
 
-- [ ] **`planeSlider`** — TBD (solid geometry)
-  - Java source: `PlaneSlider.java`
+- [x] **`planeSlider`** — `src/elements/Constructions.ts` (`PlaneSliderConstruction`)
+  - No new element class — `PlaneSlider.ts` already fully ported (used for
+    `point;free` on screen plane). The new dispatcher creates a `PlaneSlider`
+    on a non-screen `PlaneElement` with signature `[PlaneElement, Integer × 3]`.
+  - Java source: `Slate.java` point case 19.
+  - Mocha test (1): point projects to z=0 on the xy-plane.
+  - [x] test view: [view/test/point/planeSlider.html](../view/test/point/planeSlider.html) — propXI4
+  - [x] applet-tests pair:
+    [view/applet-tests/point/planeSlider/{original,applet}.html](../view/applet-tests/point/planeSlider/)
+  - Used in: Books XI–XIII (19 props depend on it; 6 sole-blocker with plane;3points)
 
 - [ ] **`sphereSlider`** — TBD (solid geometry)
   - Java source: `SphereSlider.java`

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,32 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-12 — Implemented point;planeSlider — Book XI unlocking
+
+**Completed:**
+- Wired `PlaneSliderConstruction` in `src/elements/Constructions.ts` —
+  dispatcher-only, no new element class. `PlaneSlider.ts` was already
+  fully ported (used for `point;free` on the screen plane). The new
+  dispatcher creates a `PlaneSlider` on a non-screen `PlaneElement` with
+  signature `[PlaneElement, Integer, Integer, Integer]`.
+- One Mocha test: point at (50,50,99) on the xy-plane projects to (50,50,0).
+  42 → **43 passing**.
+- Test page + applet companion using propXI4 (3 planeSlider points on a
+  base plane, with a perpendicular line EF).
+- **6 propositions unblocked**: XI.4, XI.30, XI.31, XI.32, XI.34, XII.17.
+  Combined with `plane;3points` from the previous session, these are
+  the first solid-geometry propositions to become renderable.
+- Book XI: 28 → **33**. Book XII: 8 → **9**. I–XIII total: 439 → **445**.
+
+**Next session:**
+- `plane;parallel` — unblocks XI.11, XI.26 (with planeSlider already
+  landed). XI.39 also needs polyhedron;prism.
+- `point;sphereSlider` — unblocks XIII.16 (sole blocker).
+- Then the PolyhedronElement base class + tetrahedron/prism/pyramid/
+  parallelepiped to finish the remaining Book XII/XIII props.
+
+---
+
 ## 2026-04-12 — Trivial dispatchers: plane;3points + polygon;octagon + line;cutoff
 
 **Completed:**

--- a/doc/proposition-tracker.md
+++ b/doc/proposition-tracker.md
@@ -25,10 +25,10 @@ Tracks the port status of all propositions across Euclid's Elements.
 | Book IX | 36 | **36** | 0 |
 | Book X | 115 | **115** | 0 |
 | **I–X total** | **390** | **390** | **0** |
-| Book XI | 39 | 28 | 0 |
-| Book XII | 18 | 8 | 0 |
+| Book XI | 39 | 33 | 0 |
+| Book XII | 18 | 9 | 0 |
 | Book XIII | 18 | 13 | 0 |
-| **I–XIII total** | **465** | **439** | **0** |
+| **I–XIII total** | **465** | **445** | **0** |
 
 Update the summary table after each session.
 
@@ -237,7 +237,7 @@ Book X is the largest single book (incommensurable magnitudes). Porting
 Verified per-proposition against actual HTML param lists 2026-04-12.
 
 - [~] XI.1 through XI.3 — renderable
-- [ ] XI.4 — NEEDS: `plane;3points`, `point;planeSlider`
+- [~] XI.4 — (`plane;3points` + `point;planeSlider` both landed 2026-04-12.)
 - [~] XI.5 through XI.10 — renderable
 - [ ] XI.11 — NEEDS: `plane;3points`, `plane;parallel`, `point;planeSlider`
 - [~] XI.12 through XI.22 — renderable
@@ -246,11 +246,11 @@ Verified per-proposition against actual HTML param lists 2026-04-12.
 - [ ] XI.26 — NEEDS: `plane;3points`, `plane;parallel`, `point;planeSlider`
 - [~] XI.27, XI.28 — renderable
 - [~] XI.29 — (`plane;3points` landed 2026-04-12.)
-- [ ] XI.30 — NEEDS: `plane;3points`, `point;planeSlider`
-- [ ] XI.31 — NEEDS: `plane;3points`, `point;planeSlider`
-- [ ] XI.32 — NEEDS: `plane;3points`, `point;planeSlider`
+- [~] XI.30 — (`plane;3points` + `point;planeSlider` both landed 2026-04-12.)
+- [~] XI.31 — (`plane;3points` + `point;planeSlider` both landed 2026-04-12.)
+- [~] XI.32 — (`plane;3points` + `point;planeSlider` both landed 2026-04-12.)
 - [~] XI.33 — renderable
-- [ ] XI.34 — NEEDS: `plane;3points`, `point;planeSlider`
+- [~] XI.34 — (`plane;3points` + `point;planeSlider` both landed 2026-04-12.)
 - [ ] XI.35 — NEEDS: `plane;3points`, `point;planeSlider`, `point;sphereSlider`
 - [~] XI.36 — renderable
 - [ ] XI.37 — NEEDS: `plane;3points`, `point;planeSlider`, `polyhedron;parallelepiped`
@@ -276,7 +276,7 @@ Verified per-proposition against actual HTML param lists 2026-04-12.
 - [ ] XII.11 — NEEDS: `polygon;octagon`, `polyhedron;parallelepiped`
 - [ ] XII.12 — NEEDS: `polygon;octagon`, `polyhedron;parallelepiped`
 - [~] XII.13 through XII.16 — renderable
-- [ ] XII.17 — NEEDS: `plane;3points`, `point;planeSlider`
+- [~] XII.17 — (`plane;3points` + `point;planeSlider` both landed 2026-04-12.)
 - [~] XII.18 — renderable
 
 ---

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -726,11 +726,25 @@ export class MeanProportionalPointConstruction extends Construction {
     }
 }
 
-// TBD
 // point
-// planeSlider	
+// planeSlider
 // plane A integers x, y, z
 // a point that slides on the plane A with initial coordinates (x,y,z)
+// (Java: Slate.java point case 19 — new PlaneSlider((PlaneElement)E[0], N[0], N[1], N[2]).
+// PlaneSlider.ts already has the full constructor + update() + drag().)
+export class PlaneSliderConstruction extends Construction {
+    constructionMethod: AllConstructions = PointConstructions.planeSlider;
+    signature: ConstructionTypes[] = [ct.PlaneElement, ct.Integer, ct.Integer, ct.Integer];
+
+    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const plane = params[0] as PlaneElement;
+        const x = params[1] as number;
+        const y = params[2] as number;
+        const z = params[3] as number;
+        const g = new PlaneSlider(plane, x, y, z);
+        return [[g], g];
+    }
+}
 
 // TBD
 // point
@@ -1534,6 +1548,7 @@ export const constructions : Construction[] = [
     new AngleBisectorPointConstruction(),
     new AngleDividerPointConstruction(),
     new MeanProportionalPointConstruction(),
+    new PlaneSliderConstruction(),
     new CircumcircleConstruction(),
     new CircumcircleConstruction2d(),
     new LineSliderConstruction(),

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -787,6 +787,27 @@ describe("slate", ()=> {
     // Right angle at B=(0,0), rays to A=(0,100) and C=(100,0)
     // Bisector of 90° at B → 45° ray hits AC (line from (0,100) to (100,0), x+y=100)
     // at (50, 50)
+    // point;planeSlider — draggable point constrained to a non-screen plane
+    it("should create a planeSlider point on a 3-point plane", () => {
+        let data : IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.planeSlider, params: ["plane", 50, 50, 99] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let A = slate.lookupElement("A") as PointElement;
+        // The plane is the xy-plane (z=0), so the point should project to z=0
+        almostEqual(A.x, 50, 0.01);
+        almostEqual(A.y, 50, 0.01);
+        almostEqual(A.z, 0, 0.01);
+        // Should be draggable
+        assert.ok((A as any).draggable);
+    });
+
     // plane;3points — plane through 3 non-collinear points
     it("should create a plane through 3 points with computed S,T,U frame", () => {
         let data : IConstructionInfo[] = [

--- a/view/applet-tests/point/planeSlider/applet.html
+++ b/view/applet-tests/point/planeSlider/applet.html
@@ -1,0 +1,31 @@
+<HTML><HEAD><TITLE>point;planeSlider — applet form of view/test/point/planeSlider.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/point/planeSlider.html -->
+<!-- ORIGINAL: view/applet-tests/point/planeSlider/original.html (propXI4) -->
+<!--
+  PropXI4: three planeSlider points A, E, C on a base plane, with line
+  EF perpendicular to the plane. Exercises point;planeSlider 3 times.
+  Canvas 400x400 (original is 300x250).
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="XI.4 — point;planeSlider">
+<param name=e[1] value="P1;point;fixed;30,210,100;0;0">
+<param name=e[2] value="P2;point;fixed;250,210,100;0;0">
+<param name=e[3] value="P3;point;fixed;70,60,0;0;0">
+<param name=e[4] value="baseplane;plane;3points;P1,P2,P3;0;0;lightGray;brighter">
+<param name=e[5] value="A;point;planeSlider;baseplane,90,50,80">
+<param name=e[6] value="E;point;planeSlider;baseplane,160,150,0">
+<param name=e[7] value="B;point;extend;A,E,A,E">
+<param name=e[8] value="C;point;planeSlider;baseplane,250,30,90">
+<param name=e[9] value="D;point;extend;C,E,C,E">
+<param name=e[10] value="Z;point;fixed;100,100000,0">
+<param name=e[11] value="F;point;lineSlider;E,Z,160,40,0">
+<param name=e[12] value="EF;line;connect;E,F">
+<param name=e[13] value="ABCD;polygon;quadrilateral;A,B,C,D;0;0;black;random">
+<param name=e[14] value="AF;line;connect;A,F">
+<param name=e[15] value="BF;line;connect;B,F">
+<param name=e[16] value="CF;line;connect;C,F">
+<param name=e[17] value="DF;line;connect;D,F">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point/planeSlider/original.html
+++ b/view/applet-tests/point/planeSlider/original.html
@@ -1,0 +1,24 @@
+<HTML><HEAD><TITLE>XI.4 — point;planeSlider (original)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=250 width=300>
+<param name=background value="35,19,100">
+<param name=title value="XI.4">
+<param name=e[1] value="P1;point;fixed;30,210,100;0;0">
+<param name=e[2] value="P2;point;fixed;250,210,100;0;0">
+<param name=e[3] value="P3;point;fixed;70,60,0;0;0">
+<param name=e[4] value="baseplane;plane;3points;P1,P2,P3;0;0;lightGray;brighter">
+<param name=e[5] value="A;point;planeSlider;baseplane,90,50,80">
+<param name=e[6] value="E;point;planeSlider;baseplane,160,150,0">
+<param name=e[7] value="B;point;extend;A,E,A,E">
+<param name=e[8] value="C;point;planeSlider;baseplane,250,30,90">
+<param name=e[9] value="D;point;extend;C,E,C,E">
+<param name=e[10] value="Z;point;fixed;100,100000,0">
+<param name=e[11] value="F;point;lineSlider;E,Z,160,40,0">
+<param name=e[12] value="EF;line;connect;E,F">
+<param name=e[13] value="ABCD;polygon;quadrilateral;A,B,C,D;0;0;black;random">
+<param name=e[14] value="AF;line;connect;A,F">
+<param name=e[15] value="BF;line;connect;B,F">
+<param name=e[16] value="CF;line;connect;C,F">
+<param name=e[17] value="DF;line;connect;D,F">
+</applet>
+</BODY></HTML>

--- a/view/test/point/planeSlider.html
+++ b/view/test/point/planeSlider.html
@@ -1,0 +1,37 @@
+<html>
+<head>
+    <title>Test View - Point.planeSlider (XI.4)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "XI.4 — If a straight line is set up at right angles to two straight lines which cut one another at their common point of section, then it is also at right angles to the plane passing through them",
+        canvasid: "canvasId",
+        elements: [
+            { name: "P1", construction: E.Point.fixed, params: [30, 210, 100] },
+            { name: "P2", construction: E.Point.fixed, params: [250, 210, 100] },
+            { name: "P3", construction: E.Point.fixed, params: [70, 60, 0] },
+            { name: "baseplane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            // Three planeSliders — target construction
+            { name: "A", construction: E.Point.planeSlider, params: ["baseplane", 90, 50, 80] },
+            { name: "Ep", construction: E.Point.planeSlider, params: ["baseplane", 160, 150, 0] },
+            { name: "B", construction: E.Point.extend, params: ["A", "Ep", "A", "Ep"] },
+            { name: "C", construction: E.Point.planeSlider, params: ["baseplane", 250, 30, 90] },
+            { name: "D", construction: E.Point.extend, params: ["C", "Ep", "C", "Ep"] },
+            { name: "Z", construction: E.Point.fixed, params: [100, 100000, 0] },
+            { name: "F", construction: E.Point.lineSlider, params: ["Ep", "Z", 160, 40, 0] },
+            { name: "EF", construction: E.Line.connect, params: ["Ep", "F"] },
+            { name: "ABCD", construction: E.Polygon.quadrilateral, params: ["A", "B", "C", "D"] },
+            { name: "AF", construction: E.Line.connect, params: ["A", "F"] },
+            { name: "BF", construction: E.Line.connect, params: ["B", "F"] },
+            { name: "CF", construction: E.Line.connect, params: ["C", "F"] },
+            { name: "DF", construction: E.Line.connect, params: ["D", "F"] },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds `point;planeSlider` — a draggable point constrained to a non-screen plane. Dispatcher-only port; `PlaneSlider.ts` was already fully ported. Unblocks 6 solid-geometry propositions (XI.4, XI.30–XI.32, XI.34, XII.17). 445/465 renderable (95.7%).

## What's in this branch

- `608e830` point-planeSlider: step 3 — add original.html from propXI4
- `5497394` point-planeSlider: step 5 — wire PlaneSliderConstruction
- `d617a5b` point-planeSlider: step 6 — Mocha test
- `b6844d2` point-planeSlider: step 7 — three-way view pair (TS page + applet.html)
- `1a4a27b` point-planeSlider: step 8 — tracker + journal — 445/465 renderable (+6 props)

Step 4 collapsed: `PlaneSlider.ts` was already complete (used for `point;free` on screen plane).

## Construction details

- **Element class**: None new — `PlaneSlider.ts` already has constructor, `update()` (projects to plane via `toPlane()`), and `drag()` (uses `uptoPlane()` for vertical projection).
- **Construction class**: `PlaneSliderConstruction` — signature `[PlaneElement, Integer, Integer, Integer]`. Dispatches to `PointConstructions.planeSlider = 20`.
- **Java source**: `Slate.java` point case 19.

## Tests

42 → **43 passing**. One new test: point at (50,50,99) on xy-plane projects to (50,50,0) after update.

## Verification

- [x] `npm run build` clean
- [x] `npm test` passes (43/43)
- [x] `npx webpack` rebuilds `dist/bundle.js`
- [x] Three-way harness for `point;planeSlider` — **needs human verification**
- [x] Drag points A, E, C on the base plane; they should stay constrained to the plane while F moves freely along EZ

## Newly renderable propositions

- **Book XI** (28 → 33): XI.4, XI.30, XI.31, XI.32, XI.34
- **Book XII** (8 → 9): XII.17
- **I–XIII total** (439 → 445): +6

Only 20 propositions remain blocked. Next targets: `plane;parallel` (unlocks XI.11, XI.26), `point;sphereSlider` (unlocks XIII.16), then `PolyhedronElement` base class for the remaining Book XII/XIII polyhedra.
