### PR TITLE
Feature/parallel sphereslider invert

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -190,9 +190,14 @@ These affect the library as a whole, independent of individual constructions.
   - Java source: `AngleDivider.java`.
   - No Books I–IV uses found
 
-- [ ] **`invert`** — TBD
-  - Java source: `InvertPoint.java`
-  - No Books I–X uses found
+- [x] **`invert`** — `src/elements/point/InvertPointElement.ts`
+  - Extends `PointElement`. Inverts point A in circle C via `toInvertPoint()`.
+  - Java source: `InvertPoint.java` — 16 lines, line-for-line port.
+  - Mocha test (1): inversion of (150,100) in circle center (100,100) radius 100 → (300,100).
+  - [x] test view: [view/test/point/invert.html](../view/test/point/invert.html)
+  - [x] applet-tests pair:
+    [view/applet-tests/point/invert/{original,applet}.html](../view/applet-tests/point/invert/)
+  - Used in: compass + round geometry pages. No Books I–XIII proposition uses.
 
 - [x] **`meanProportional`** — `src/elements/point/MeanProportionalElement.ts`
   - Extends `PointElement`. Geometric mean: |U'| = sqrt(|S|*|T|).
@@ -214,8 +219,14 @@ These affect the library as a whole, independent of individual constructions.
     [view/applet-tests/point/planeSlider/{original,applet}.html](../view/applet-tests/point/planeSlider/)
   - Used in: Books XI–XIII (19 props depend on it; 6 sole-blocker with plane;3points)
 
-- [ ] **`sphereSlider`** — TBD (solid geometry)
-  - Java source: `SphereSlider.java`
+- [x] **`sphereSlider`** — `src/elements/point/SphereSliderElement.ts`
+  - Extends `PointElement`. Draggable point constrained to sphere surface.
+  - Java source: `SphereSlider.java` — 43 lines, line-for-line port.
+  - Mocha test (1): point projects to sphere surface (distance = radius).
+  - [x] test view: [view/test/point/sphereSlider.html](../view/test/point/sphereSlider.html)
+  - [x] applet-tests pair:
+    [view/applet-tests/point/sphereSlider/{original,applet}.html](../view/applet-tests/point/sphereSlider/)
+  - Used in: XI.35, XIII.13–XVII, compass + round geometry pages
 
 - [x] **`harmonic`** — `src/elements/point/HarmonicElement.ts`
   - Extends `PointElement`. Computes the harmonic conjugate of B w.r.t. C
@@ -512,9 +523,14 @@ These affect the library as a whole, independent of individual constructions.
   - Mocha test (1): S/T/U frame verification for xy-plane.
   - Used in: Books XI–XIII (prerequisite for 22 propositions; 2 sole-blocker: XI.29, XI.38)
 
-- [ ] **`parallel`** — TBD
-  - Java source: `ParallelP.java` (26 lines) — parallel plane through a point
-  - Blocks 3 propositions (XI.11, XI.26, XI.39)
+- [x] **`parallel`** — `src/elements/plane/ParallelPlane.ts`
+  - Extends `PlaneElement`. Creates a plane parallel to P through point A.
+  - Java source: `ParallelP.java` — 26 lines, line-for-line port.
+  - Mocha test (1): parallel plane passes through point A.
+  - [x] test view: [view/test/plane/parallel.html](../view/test/plane/parallel.html) — propXI11
+  - [x] applet-tests pair:
+    [view/applet-tests/plane/parallel/{original,applet}.html](../view/applet-tests/plane/parallel/)
+  - Used in: XI.11, XI.26, XI.39 (XI.39 also needs polyhedron;prism)
 
 - [ ] **`ambient`** — TBD (the default screen plane)
   - No Books I–XIII uses found in applet HTML

--- a/doc/java-port-tracker.md
+++ b/doc/java-port-tracker.md
@@ -43,14 +43,14 @@ implementation status. Updated as constructions are ported.
 | `LineSlider.java` | PORTED | `src/elements/point/LineSlider.ts` | 2D, 3D, and segment variants. |
 | `Midpoint.java` | PORTED | `src/elements/point/Midpoint.ts` | |
 | `Perpendicular.java` | PORTED | `src/elements/point/Perpendicular*.ts` + `src/elements/line/Perpendicular.ts` | 5 signature variants across point and line constructions. |
-| `PlaneSlider.java` | PARTIAL | `src/elements/point/PlaneSlider.ts` | Used for `point;free` (draggable screen-plane points). The `point;planeSlider` construction for non-screen planes is TBD — blocks 19 propositions in Books XI–XIII. |
+| `PlaneSlider.java` | PORTED | `src/elements/point/PlaneSlider.ts` | Used for `point;free` (screen plane) and `point;planeSlider` (non-screen planes, wired 2026-04-12). |
 | `Proportion.java` | PORTED | `src/elements/point/ProportionElement.ts` | Fourth proportional. Ported 2026-04-12. |
 | `Similar.java` | PORTED | `src/elements/point/SimilarElement.ts` | All three type variants ported: `SimilarPointConstruction`, `SimilarLineConstruction`, `SimilarPolygonConstruction` (all in Constructions.ts). Ported 2026-04-12. |
 | `AngleDivider.java` | PORTED | `src/elements/point/AngleDividerElement.ts` | All four variants ported 2026-04-12: point/line × bisector/divider. Used in Book IV (IV.4, IV.13, IV.16). |
 | `Harmonic.java` | PORTED | `src/elements/point/HarmonicElement.ts` | Harmonic conjugate. 2D (complex arithmetic) + 3D (midpoint reflection) cases. Ported 2026-04-12. Used in round geometry pages. |
-| `InvertPoint.java` | TBD | — | Point inversion in circle. No Books I–X uses found; may appear in later analysis. |
+| `InvertPoint.java` | PORTED | `src/elements/point/InvertPointElement.ts` | Point inversion in circle. Ported 2026-04-12. Used in compass + round geometry pages. |
 | `MeanProportional.java` | PORTED | `src/elements/point/MeanProportionalElement.ts` | Geometric mean. Both point and line variants wired. Ported 2026-04-12. Unblocked 35 propositions (VIII, X, XIII). |
-| `SphereSlider.java` | TBD | — | Point slider on sphere surface. Blocks XIII.13, XIII.14, XIII.15, XIII.16, XIII.17 + XI.35. |
+| `SphereSlider.java` | PORTED | `src/elements/point/SphereSliderElement.ts` | Point slider on sphere surface. Ported 2026-04-12. |
 
 ---
 
@@ -97,7 +97,7 @@ implementation status. Updated as constructions are ported.
 | Java File | Status | TS Location | Notes |
 |---|---|---|---|
 | `PlanePerpendicular.java` | PORTED | `src/elements/plane/PerpendicularPlane.ts` | |
-| `ParallelP.java` | TBD | — | Parallel plane construction (solid geometry). NOT `line;parallel` — that uses Layoff dispatch. |
+| `ParallelP.java` | PORTED | `src/elements/plane/ParallelPlane.ts` | Parallel plane through a point. Ported 2026-04-12. NOT `line;parallel` — that uses Layoff dispatch. |
 
 ---
 
@@ -125,9 +125,9 @@ implementation status. Updated as constructions are ported.
 
 | Status | Count | Files |
 |--------|-------|-------|
-| PORTED | 30 | Core element classes + all ported constructions (incl. Harmonic ported 2026-04-12) |
-| PARTIAL | 4 | IntersectionPL, PerpendicularPL, PlaneSlider (screen-only), Slate |
-| TBD | 6 | InvertPoint, InvertCircle, SphereSlider, PlaneFoot, Prism, Pyramid |
+| PORTED | 33 | Core element classes + all ported constructions (incl. ParallelP, SphereSlider, InvertPoint ported 2026-04-12) |
+| PARTIAL | 3 | IntersectionPL, PerpendicularPL, Slate |
+| TBD | 4 | InvertCircle, PlaneFoot, Prism, Pyramid |
 | TBD (base) | 1 | PolyhedronElement |
 | TBD (plane/circle) | 2 | ParallelP (plane;parallel), IntersectionSS (circle;intersection) |
 | N/A | 3 | Geometry, ClientFrame, Remote |

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,35 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-12 — Bundle: plane;parallel + point;sphereSlider + point;invert
+
+**Completed:**
+- Ported 3 constructions in one session:
+  - `ParallelPlane.ts` (26 lines) — plane parallel to P through point A.
+    Overrides `update()`, `translate()`, `rotate()`.
+  - `SphereSliderElement.ts` (43 lines) — draggable point on sphere
+    surface via `toSphere()`. Full `drag()` implementation handles both
+    inside and outside the sphere's screen shadow.
+  - `InvertPointElement.ts` (16 lines) — point inversion in a circle
+    via `toInvertPoint()`.
+- Also: added `Center` getter to `SphereElement.ts` (was protected-only),
+  fixed `SphereElement` `validateSignature` stub (was TODO no-op),
+  fixed `radius()`/`radius2()` call syntax.
+- 3 Mocha tests: parallel plane passes through A, sphere slider projects
+  to surface (distance = radius), point inversion (factor = r²/d²).
+  44 → **47 passing**.
+- **3 propositions unblocked**: XI.11, XI.26 (plane;parallel completes
+  the set with plane;3points + planeSlider), XIII.16 (sphereSlider sole
+  blocker).
+- I–XIII total: 445 → **448** renderable (96.3%).
+
+**Next session:**
+- `PolyhedronElement` base class (78 lines) — the prerequisite for the
+  final 17 blocked propositions. Then tetrahedron, prism, pyramid,
+  parallelepiped, polygon;face, circle;intersection.
+
+---
+
 ## 2026-04-12 — Implemented point;harmonic + archived round geometry pages
 
 **Completed:**

--- a/doc/proposition-tracker.md
+++ b/doc/proposition-tracker.md
@@ -25,10 +25,10 @@ Tracks the port status of all propositions across Euclid's Elements.
 | Book IX | 36 | **36** | 0 |
 | Book X | 115 | **115** | 0 |
 | **I–X total** | **390** | **390** | **0** |
-| Book XI | 39 | 33 | 0 |
+| Book XI | 39 | 35 | 0 |
 | Book XII | 18 | 9 | 0 |
-| Book XIII | 18 | 13 | 0 |
-| **I–XIII total** | **465** | **445** | **0** |
+| Book XIII | 18 | 14 | 0 |
+| **I–XIII total** | **465** | **448** | **0** |
 
 Update the summary table after each session.
 
@@ -239,11 +239,11 @@ Verified per-proposition against actual HTML param lists 2026-04-12.
 - [~] XI.1 through XI.3 — renderable
 - [~] XI.4 — (`plane;3points` + `point;planeSlider` both landed 2026-04-12.)
 - [~] XI.5 through XI.10 — renderable
-- [ ] XI.11 — NEEDS: `plane;3points`, `plane;parallel`, `point;planeSlider`
+- [~] XI.11 — (`plane;3points`, `plane;parallel`, `point;planeSlider` all landed 2026-04-12.)
 - [~] XI.12 through XI.22 — renderable
 - [ ] XI.23 — NEEDS: `polyhedron;pyramid`
 - [~] XI.24, XI.25 — renderable
-- [ ] XI.26 — NEEDS: `plane;3points`, `plane;parallel`, `point;planeSlider`
+- [~] XI.26 — (`plane;3points`, `plane;parallel`, `point;planeSlider` all landed 2026-04-12.)
 - [~] XI.27, XI.28 — renderable
 - [~] XI.29 — (`plane;3points` landed 2026-04-12.)
 - [~] XI.30 — (`plane;3points` + `point;planeSlider` both landed 2026-04-12.)
@@ -289,7 +289,7 @@ Verified per-proposition against actual HTML param lists 2026-04-12.
 - [ ] XIII.13 — NEEDS: `point;sphereSlider`, `polyhedron;tetrahedron`
 - [ ] XIII.14 — NEEDS: `plane;3points`, `point;sphereSlider`, `polyhedron;prism`, `polyhedron;pyramid`
 - [ ] XIII.15 — NEEDS: `circle;intersection`, `point;sphereSlider`, `polyhedron;parallelepiped`, `polyhedron;tetrahedron`
-- [ ] XIII.16 — NEEDS: `point;sphereSlider`
+- [~] XIII.16 — (`point;sphereSlider` landed 2026-04-12.)
 - [ ] XIII.17 — NEEDS: `circle;intersection`, `plane;3points`, `point;planeSlider`, `point;sphereSlider`
 - [~] XIII.18 — renderable
 

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -41,6 +41,9 @@ import {ProportionElement} from "./point/ProportionElement";
 import {AngleDividerElement} from "./point/AngleDividerElement";
 import {MeanProportionalElement} from "./point/MeanProportionalElement";
 import {HarmonicElement} from "./point/HarmonicElement";
+import {InvertPointElement} from "./point/InvertPointElement";
+import {SphereSliderElement} from "./point/SphereSliderElement";
+import {ParallelPlane} from "./plane/ParallelPlane";
 import {ApplicationElement} from "./polygon/ApplicationElement";
 import {PolygonElement} from "./polygon/PolygonElement";
 import {RegularPolygonElement} from "./polygon/RegularPolygonElement";
@@ -225,7 +228,9 @@ export abstract class Construction {
                     }
                     break;
                 case ConstructionTypes.SphereElement:
-                    // TODO:
+                    if (!(param instanceof SphereElement)) {
+                        return false;
+                    }
                     break;
                 case ConstructionTypes.PolygonElement:
                     if (!(param instanceof PolygonElement)) {
@@ -706,11 +711,22 @@ export class ProportionPointConstruction extends Construction {
     }
 }
 
-// TBD
 // point
 // invert
 // point A circle B
 // the image of a point A inverted in the circle B
+// (Java: InvertPoint.java — 16 lines, calls toInvertPoint(A, C))
+export class InvertPointConstruction extends Construction {
+    constructionMethod: AllConstructions = PointConstructions.invert;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.CircleElement];
+
+    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const A = params[0] as PointElement;
+        const C = params[1] as CircleElement;
+        const g = new InvertPointElement(A, C);
+        return [[g], g];
+    }
+}
 
 // point
 // meanProportional
@@ -748,11 +764,24 @@ export class PlaneSliderConstruction extends Construction {
     }
 }
 
-// TBD
 // point
 // sphereSlider
 // sphere A integers x, y, z
 // a point that slides on the sphere A with initial coordinates (x,y,z)
+// (Java: SphereSlider.java — 43 lines, line-for-line port)
+export class SphereSliderConstruction extends Construction {
+    constructionMethod: AllConstructions = PointConstructions.sphereSlider;
+    signature: ConstructionTypes[] = [ct.SphereElement, ct.Integer, ct.Integer, ct.Integer];
+
+    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const S = params[0] as SphereElement;
+        const x = params[1] as number;
+        const y = params[2] as number;
+        const z = params[3] as number;
+        const g = new SphereSliderElement(S, x, y, z);
+        return [[g], g];
+    }
+}
 
 // point
 // angleBisector (2D variant)
@@ -1451,13 +1480,22 @@ export class PerpendicularPlaneConstruction extends Construction {
 
 
 
-// TBD
-// *Solid Geometry Only*
 // plane
-// parallel	
-// plane A point B
-// the plane passing through point A and parallel to plane B
+// parallel
+// plane P, point A
+// the plane passing through point A and parallel to plane P
+// (Java: ParallelP.java — 26 lines, line-for-line port)
+export class PlaneParallelConstruction extends Construction {
+    constructionMethod: AllConstructions = PlaneConstructions.parallel;
+    signature: ConstructionTypes[] = [ct.PlaneElement, ct.PointElement];
 
+    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const P = params[0] as PlaneElement;
+        const A = params[1] as PointElement;
+        const g = new ParallelPlane(P, A);
+        return [[g], g];
+    }
+}
 
 // TBD
 // *Solid Geometry Only*
@@ -1562,7 +1600,9 @@ export const constructions : Construction[] = [
     new AngleDividerPointConstruction(),
     new MeanProportionalPointConstruction(),
     new PlaneSliderConstruction(),
+    new SphereSliderConstruction(),
     new HarmonicPointConstruction(),
+    new InvertPointConstruction(),
     new CircumcircleConstruction(),
     new CircumcircleConstruction2d(),
     new LineSliderConstruction(),
@@ -1610,5 +1650,6 @@ export const constructions : Construction[] = [
     new VertexConstruction(),
     new Plane3PointsConstruction(),
     new PerpendicularPlaneConstruction(),
+    new PlaneParallelConstruction(),
     new SphereRadiusConstruction()
 ];

--- a/src/elements/plane/ParallelPlane.ts
+++ b/src/elements/plane/ParallelPlane.ts
@@ -1,0 +1,55 @@
+/*----------------------------------------------------------------------+
+|    Title:	ParallelPlane.ts                                            |
+|    A port of the software Geometry Applet by                          |
+|    Author:    David E. Joyce                                          |
+|        Department of Mathematics and Computer Science                 |
+|        Clark University                                               |
+|        Worcester, MA 01610-1477                                       |
+|        U.S.A.                                                         |
+|                                                                       |
+|        http://aleph0.clarku.edu/~djoyce/home.html                     |
+|        djoyce@clarku.edu                                              |
+|                                                                       |
+|    Date:    February, 1996.   Version 2.0.0 May, 1997.                |
+|    TypeScript Port: 2026, Nelson Brown, brownnrl@gmail.com            |
+|                           https://www.nelsonbrown.net/                |
++----------------------------------------------------------------------*/
+
+import {PlaneElement} from "./PlaneElement";
+import {PointElement} from "../point/PointElement";
+
+export class ParallelPlane extends PlaneElement {
+  /*--------------------------------------------------------------------+
+  | this is the plane parallel to the plane P passing through the       |
+  | point A                                                             |
+  +--------------------------------------------------------------------*/
+
+  private _P: PlaneElement;
+
+  constructor(P: PlaneElement, A: PointElement) {
+    super();
+    this.dimension = 2;
+    this._P = P;
+    this.A = A;
+    this.B = new PointElement();
+    this.C = new PointElement();
+    this.S = P.S;
+    this.T = P.T;
+    this.U = P.U;
+  }
+
+  public translate(dx: number, dy: number) {
+    this.B.translate(dx, dy);
+    this.C.translate(dx, dy);
+  }
+
+  public rotate(pivot: PointElement, ac: number, as: number) {
+    this.B.rotate(pivot, ac, as);
+    this.C.rotate(pivot, ac, as);
+  }
+
+  public update() {
+    this.B.to(this._P.B).minus(this._P.A).plus(this.A);
+    this.C.to(this._P.C).minus(this._P.A).plus(this.A);
+  }
+}

--- a/src/elements/point/InvertPointElement.ts
+++ b/src/elements/point/InvertPointElement.ts
@@ -1,0 +1,40 @@
+/*----------------------------------------------------------------------+
+|    Title:	InvertPointElement.ts                                       |
+|    A port of the software Geometry Applet by                          |
+|    Author:    David E. Joyce                                          |
+|        Department of Mathematics and Computer Science                 |
+|        Clark University                                               |
+|        Worcester, MA 01610-1477                                       |
+|        U.S.A.                                                         |
+|                                                                       |
+|        http://aleph0.clarku.edu/~djoyce/home.html                     |
+|        djoyce@clarku.edu                                              |
+|                                                                       |
+|    Date:    February, 1996.   Version 2.0.0 May, 1997.                |
+|    TypeScript Port: 2026, Nelson Brown, brownnrl@gmail.com            |
+|                           https://www.nelsonbrown.net/                |
++----------------------------------------------------------------------*/
+
+import {PointElement} from "./PointElement";
+import {CircleElement} from "../circle/CircleElement";
+
+export class InvertPointElement extends PointElement {
+  /*--------------------------------------------------------------------+
+  | Invert the point A in the circle C to get this point                |
+  +--------------------------------------------------------------------*/
+
+  private _A: PointElement;
+  private _C: CircleElement;
+
+  constructor(A: PointElement, C: CircleElement) {
+    super();
+    this.dimension = 0;
+    this._A = A;
+    this._C = C;
+    this._AP = C.AP;
+  }
+
+  public update() {
+    this.toInvertPoint(this._A, this._C);
+  }
+}

--- a/src/elements/point/SphereSliderElement.ts
+++ b/src/elements/point/SphereSliderElement.ts
@@ -1,0 +1,75 @@
+/*----------------------------------------------------------------------+
+|    Title:	SphereSliderElement.ts                                      |
+|    A port of the software Geometry Applet by                          |
+|    Author:    David E. Joyce                                          |
+|        Department of Mathematics and Computer Science                 |
+|        Clark University                                               |
+|        Worcester, MA 01610-1477                                       |
+|        U.S.A.                                                         |
+|                                                                       |
+|        http://aleph0.clarku.edu/~djoyce/home.html                     |
+|        djoyce@clarku.edu                                              |
+|                                                                       |
+|    Date:    February, 1996.   Version 2.0.0 May, 1997.                |
+|    TypeScript Port: 2026, Nelson Brown, brownnrl@gmail.com            |
+|                           https://www.nelsonbrown.net/                |
++----------------------------------------------------------------------*/
+
+import {PointElement} from "./PointElement";
+import {SphereElement} from "../sphere/SphereElement";
+
+export class SphereSliderElement extends PointElement {
+
+  private _S: SphereElement;
+  private _initx: number;
+  private _inity: number;
+  private _initz: number;
+
+  constructor(S: SphereElement, x: number, y: number, z: number) {
+    super();
+    this.dimension = 0;
+    this.draggable = true;
+    this._S = S;
+    this._x = this._initx = x;
+    this._y = this._inity = y;
+    this._z = this._initz = z;
+  }
+
+  public reset() {
+    this._x = this._initx;
+    this._y = this._inity;
+    this._z = this._initz;
+    this.toSphere(this._S.Center, this._S.radius);
+  }
+
+  public update() {
+    this.toSphere(this._S.Center, this._S.radius);
+  }
+
+  public drag(tox: number, toy: number): boolean {
+    let dist2 = (this._S.Center.x - tox) * (this._S.Center.x - tox)
+              + (this._S.Center.y - toy) * (this._S.Center.y - toy);
+    let r2 = this._S.radius2;
+    if (dist2 <= r2) {
+      this._x = tox;
+      this._y = toy;
+      if (this._z > this._S.Center.z)
+        this._z = this._S.Center.z + Math.sqrt(r2 - dist2);
+      else
+        this._z = this._S.Center.z - Math.sqrt(r2 - dist2);
+    } else {
+      // beyond shadow of sphere
+      tox -= this._S.Center.x;
+      toy -= this._S.Center.y;
+      let factor = Math.sqrt((tox * tox + toy * toy) / r2);
+      tox = tox / factor + this._S.Center.x;
+      toy = toy / factor + this._S.Center.y;
+      if ((tox - this._x) * (tox - this._x) + (toy - this._y) * (toy - this._y) < 0.5)
+        return false;
+      this._x = tox;
+      this._y = toy;
+      this._z = this._S.Center.z;
+    }
+    return true;
+  }
+}

--- a/src/elements/point/SphereSliderElement.ts
+++ b/src/elements/point/SphereSliderElement.ts
@@ -39,17 +39,17 @@ export class SphereSliderElement extends PointElement {
     this._x = this._initx;
     this._y = this._inity;
     this._z = this._initz;
-    this.toSphere(this._S.Center, this._S.radius);
+    this.toSphere(this._S.Center, this._S.radius());
   }
 
   public update() {
-    this.toSphere(this._S.Center, this._S.radius);
+    this.toSphere(this._S.Center, this._S.radius());
   }
 
   public drag(tox: number, toy: number): boolean {
     let dist2 = (this._S.Center.x - tox) * (this._S.Center.x - tox)
               + (this._S.Center.y - toy) * (this._S.Center.y - toy);
-    let r2 = this._S.radius2;
+    let r2 = this._S.radius2();
     if (dist2 <= r2) {
       this._x = tox;
       this._y = toy;

--- a/src/elements/sphere/SphereElement.ts
+++ b/src/elements/sphere/SphereElement.ts
@@ -58,13 +58,13 @@ export class SphereElement extends GeomElement {
         ctx.save();
         ctx.strokeStyle = this.edgeColor;
         let r = this.radius();
-        let d = Math.round(2*r);
         ctx.beginPath();
+        // ellipse() takes (centerX, centerY, radiusX, radiusY, ...)
         ctx.ellipse(
-            this._Center.x-r,
-            this._Center.y-r,
-            d,
-            d,
+            this._Center.x,
+            this._Center.y,
+            r,
+            r,
             0,
             0,
             2*Math.PI);
@@ -78,13 +78,12 @@ export class SphereElement extends GeomElement {
         ctx.save();
         ctx.fillStyle = this.faceColor;
         let r = this.radius();
-        let d = Math.round(2*r);
         ctx.beginPath();
         ctx.ellipse(
-            this._Center.x-r,
-            this._Center.y-r,
-            d,
-            d,
+            this._Center.x,
+            this._Center.y,
+            r,
+            r,
             0,
             0,
             2*Math.PI);

--- a/src/elements/sphere/SphereElement.ts
+++ b/src/elements/sphere/SphereElement.ts
@@ -32,6 +32,8 @@ export class SphereElement extends GeomElement {
     protected _A : PointElement; // radius is AB
     protected _B : PointElement;
 
+    get Center() : PointElement { return this._Center; }
+
     constructor(ip? : ISphereElementConstruction) {
         super();
         this.dimension = 2;

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -787,6 +787,72 @@ describe("slate", ()=> {
     // Right angle at B=(0,0), rays to A=(0,100) and C=(100,0)
     // Bisector of 90° at B → 45° ray hits AC (line from (0,100) to (100,0), x+y=100)
     // at (50, 50)
+    // point;sphereSlider — point constrained to sphere surface
+    // Sphere center (100,100,0), radius point (200,100,0) → radius=100
+    // Point starts at (150,100,50), should project onto sphere surface
+    // Distance from center = sqrt(50²+0²+50²) = sqrt(5000) ≈ 70.71
+    // factor = 100/70.71 ≈ 1.414
+    // Projected: center + factor*(P-center) = (100+1.414*50, 100, 0+1.414*50) ≈ (170.71, 100, 70.71)
+    it("should project a sphereSlider point onto the sphere surface", () => {
+        let data : IConstructionInfo[] = [
+            { name: "O", construction: E.Point.fixed, params: [100, 100, 0] },
+            { name: "R", construction: E.Point.fixed, params: [200, 100, 0] },
+            { name: "S", construction: E.Sphere.radius, params: ["O", "R"] },
+            { name: "A", construction: E.Point.sphereSlider, params: ["S", 150, 100, 50] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let A = slate.lookupElement("A") as PointElement;
+        // Distance from center should equal radius (100)
+        let O = slate.lookupElement("O") as PointElement;
+        let dist = Math.sqrt((A.x-O.x)*(A.x-O.x) + (A.y-O.y)*(A.y-O.y) + (A.z-O.z)*(A.z-O.z));
+        almostEqual(dist, 100, 0.1);
+        // Should be draggable
+        assert.ok((A as any).draggable);
+    });
+
+    // plane;parallel — plane through point A parallel to plane P
+    it("should create a parallel plane through a point", () => {
+        let data : IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "P", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 50, 100] },
+            { name: "Q", construction: E.Plane.parallel, params: ["P", "A"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let Q = slate.lookupElement("Q") as PlaneElement;
+        // Parallel plane should pass through A
+        almostEqual(Q.A.x, 50, 0.01);
+        almostEqual(Q.A.y, 50, 0.01);
+        almostEqual(Q.A.z, 100, 0.01);
+    });
+
+    // point;invert — inversion of a point in a circle
+    // Circle center (100,100), radius point (200,100) → radius=100
+    // Point A at (150,100) → distance from center = 50
+    // Inverted: factor = r²/d² = 10000/2500 = 4
+    // Result = center + 4*(A-center) = (100,100) + 4*(50,0) = (300,100)
+    it("should compute the inversion of a point in a circle", () => {
+        let data : IConstructionInfo[] = [
+            { name: "O", construction: E.Point.free, params: [100, 100] },
+            { name: "R", construction: E.Point.free, params: [200, 100] },
+            { name: "C", construction: E.Circle.radius, params: ["O", "R"] },
+            { name: "A", construction: E.Point.free, params: [150, 100] },
+            { name: "B", construction: E.Point.invert, params: ["A", "C"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let B = slate.lookupElement("B") as PointElement;
+        almostEqual(B.x, 300, 0.01);
+        almostEqual(B.y, 100, 0.01);
+    });
+
     // point;harmonic — harmonic conjugate of B with respect to C and D
     // Collinear case: C=(0,0), D=(100,0), B=(25,0)
     // Complex formula: A = (C(B-D) + D(B-C)) / ((B-D) + (B-C))

--- a/view/applet-tests/plane/parallel/applet.html
+++ b/view/applet-tests/plane/parallel/applet.html
@@ -1,0 +1,23 @@
+<HTML><HEAD><TITLE>plane;parallel — applet form of view/test/plane/parallel.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/plane/parallel.html -->
+<!-- ORIGINAL: view/applet-tests/plane/parallel/original.html (propXI11) -->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="XI.11 — plane;parallel">
+<param name=e[1] value="origin;point;free;120,160;0;0,50,100">
+<param name=e[2] value="x;point;fixed;280,160,100;0;darkGray">
+<param name=e[3] value="yzplane;plane;perpendicular;origin,x;0;0;0;0">
+<param name=e[4] value="y;point;planeSlider;yzplane,-90,260,40;0;0,50,100">
+<param name=e[5] value="xyplane;plane;3points;origin,x,y;0;0;lightGray">
+<param name=e[6] value="z1;point;perpendicular;origin,y,yzplane;0;0">
+<param name=e[7] value="z;point;lineSlider;origin,z1,50,50,100;0">
+<param name=e[8] value="ceiling;plane;parallel;xyplane,z;0;0;0;0">
+<param name=e[9] value="A;point;planeSlider;ceiling,140,100,180">
+<param name=e[10] value="B;point;planeSlider;xyplane,208,270,140">
+<param name=e[11] value="C;point;planeSlider;xyplane,245,190,80">
+<param name=e[12] value="BC;line;connect;B,C">
+<param name=e[13] value="D;point;foot;A,BC">
+<param name=e[14] value="AD;line;connect;A,D">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/plane/parallel/original.html
+++ b/view/applet-tests/plane/parallel/original.html
@@ -1,0 +1,22 @@
+<HTML><HEAD><TITLE>XI.11 — plane;parallel (original)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=300 width=300>
+<param name=background value="35,19,100">
+<param name=title value="XI.11">
+<param name=e[1] value="origin;point;free;120,160;0;0,50,100">
+<param name=e[2] value="x;point;fixed;280,160,100;0;darkGray">
+<param name=e[3] value="yzplane;plane;perpendicular;origin,x;0;0;0;0">
+<param name=e[4] value="y;point;planeSlider;yzplane,-90,260,40;0;0,50,100">
+<param name=e[5] value="xyplane;plane;3points;origin,x,y;0;0;lightGray">
+<param name=e[6] value="z1;point;perpendicular;origin,y,yzplane;0;0">
+<param name=e[7] value="z;point;lineSlider;origin,z1,50,50,100;0">
+<param name=e[8] value="Oz;line;connect;origin,z;0;0;lightGray">
+<param name=e[9] value="ceiling;plane;parallel;xyplane,z;0;0;0;0">
+<param name=e[10] value="A;point;planeSlider;ceiling,140,100,180">
+<param name=e[11] value="B;point;planeSlider;xyplane,208,270,140">
+<param name=e[12] value="C;point;planeSlider;xyplane,245,190,80">
+<param name=e[13] value="BC;line;connect;B,C">
+<param name=e[14] value="D;point;foot;A,BC">
+<param name=e[15] value="AD;line;connect;A,D">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point/invert/applet.html
+++ b/view/applet-tests/point/invert/applet.html
@@ -1,0 +1,17 @@
+<HTML><HEAD><TITLE>point;invert — applet form of view/test/point/invert.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/point/invert.html -->
+<!-- ORIGINAL: view/applet-tests/point/invert/original.html (standalone) -->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="Point Inversion">
+<param name=e[1] value="O;point;free;150,150">
+<param name=e[2] value="R;point;free;250,150">
+<param name=e[3] value="C;circle;radius;O,R;0;0;black;0">
+<param name=e[4] value="A;point;free;175,150">
+<param name=e[5] value="A';point;invert;A,C">
+<param name=e[6] value="B;point;circleSlider;C,200,100">
+<param name=e[7] value="B';point;invert;B,C">
+<param name=e[8] value="OA;line;connect;O,A">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point/invert/original.html
+++ b/view/applet-tests/point/invert/original.html
@@ -1,0 +1,15 @@
+<HTML><HEAD><TITLE>point;invert (standalone)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=300 width=300>
+<param name=background value="35,19,100">
+<param name=title value="Point Inversion">
+<param name=e[1] value="O;point;free;150,150">
+<param name=e[2] value="R;point;free;250,150">
+<param name=e[3] value="C;circle;radius;O,R;0;0;black;0">
+<param name=e[4] value="A;point;free;175,150">
+<param name=e[5] value="A';point;invert;A,C">
+<param name=e[6] value="B;point;circleSlider;C,200,100">
+<param name=e[7] value="B';point;invert;B,C">
+<param name=e[8] value="OA;line;connect;O,A">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point/sphereSlider/applet.html
+++ b/view/applet-tests/point/sphereSlider/applet.html
@@ -1,0 +1,15 @@
+<HTML><HEAD><TITLE>point;sphereSlider — applet form of view/test/point/sphereSlider.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/point/sphereSlider.html -->
+<!-- ORIGINAL: view/applet-tests/point/sphereSlider/original.html (standalone) -->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="Sphere Slider">
+<param name=e[1] value="O;point;fixed;150,150,0;black;green">
+<param name=e[2] value="R;point;fixed;250,150,0;0;0">
+<param name=e[3] value="S;sphere;radius;O,R">
+<param name=e[4] value="A;point;sphereSlider;S,200,100,50">
+<param name=e[5] value="B;point;sphereSlider;S,100,200,50">
+<param name=e[6] value="AB;line;connect;A,B">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point/sphereSlider/original.html
+++ b/view/applet-tests/point/sphereSlider/original.html
@@ -1,0 +1,13 @@
+<HTML><HEAD><TITLE>point;sphereSlider (standalone)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=300 width=300>
+<param name=background value="35,19,100">
+<param name=title value="Sphere Slider">
+<param name=e[1] value="O;point;fixed;150,150,0;black;green">
+<param name=e[2] value="R;point;fixed;250,150,0;0;0">
+<param name=e[3] value="S;sphere;radius;O,R">
+<param name=e[4] value="A;point;sphereSlider;S,200,100,50">
+<param name=e[5] value="B;point;sphereSlider;S,100,200,50">
+<param name=e[6] value="AB;line;connect;A,B">
+</applet>
+</BODY></HTML>

--- a/view/test/plane/parallel.html
+++ b/view/test/plane/parallel.html
@@ -1,0 +1,31 @@
+<html>
+<head><title>Test View - Plane.parallel (XI.11)</title></head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "XI.11 — plane;parallel",
+        canvasid: "canvasId",
+        elements: [
+            { name: "origin", construction: E.Point.free, params: [120, 160] },
+            { name: "x", construction: E.Point.fixed, params: [280, 160, 100] },
+            { name: "yzplane", construction: E.Plane.perpendicular, params: ["origin", "x"] },
+            { name: "y", construction: E.Point.planeSlider, params: ["yzplane", -90, 260, 40] },
+            { name: "xyplane", construction: E.Plane.threePoints, params: ["origin", "x", "y"] },
+            { name: "z1", construction: E.Point.perpendicular, params: ["origin", "y", "yzplane"] },
+            { name: "z", construction: E.Point.lineSlider, params: ["origin", "z1", 50, 50, 100] },
+            { name: "ceiling", construction: E.Plane.parallel, params: ["xyplane", "z"] },
+            { name: "A", construction: E.Point.planeSlider, params: ["ceiling", 140, 100, 180] },
+            { name: "B", construction: E.Point.planeSlider, params: ["xyplane", 208, 270, 140] },
+            { name: "C", construction: E.Point.planeSlider, params: ["xyplane", 245, 190, 80] },
+            { name: "BC", construction: E.Line.connect, params: ["B", "C"] },
+            { name: "D", construction: E.Point.foot, params: ["A", "BC"] },
+            { name: "AD", construction: E.Line.connect, params: ["A", "D"] },
+        ]
+    });
+</script>
+</body>
+</html>

--- a/view/test/point/invert.html
+++ b/view/test/point/invert.html
@@ -1,0 +1,25 @@
+<html>
+<head><title>Test View - Point.invert (standalone)</title></head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "Point.invert — inversion in a circle",
+        canvasid: "canvasId",
+        elements: [
+            { name: "O", construction: E.Point.free, params: [150, 150] },
+            { name: "R", construction: E.Point.free, params: [250, 150] },
+            { name: "C", construction: E.Circle.radius, params: ["O", "R"] },
+            { name: "A", construction: E.Point.free, params: [175, 150] },
+            { name: "A'", construction: E.Point.invert, params: ["A", "C"] },
+            { name: "B", construction: E.Point.circleSlider, params: ["C", 200, 100] },
+            { name: "B'", construction: E.Point.invert, params: ["B", "C"] },
+            { name: "OA", construction: E.Line.connect, params: ["O", "A"] },
+        ]
+    });
+</script>
+</body>
+</html>

--- a/view/test/point/sphereSlider.html
+++ b/view/test/point/sphereSlider.html
@@ -1,0 +1,23 @@
+<html>
+<head><title>Test View - Point.sphereSlider (standalone)</title></head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "Point.sphereSlider — point on sphere surface",
+        canvasid: "canvasId",
+        elements: [
+            { name: "O", construction: E.Point.fixed, params: [150, 150, 0] },
+            { name: "R", construction: E.Point.fixed, params: [250, 150, 0] },
+            { name: "S", construction: E.Sphere.radius, params: ["O", "R"] },
+            { name: "A", construction: E.Point.sphereSlider, params: ["S", 200, 100, 50] },
+            { name: "B", construction: E.Point.sphereSlider, params: ["S", 100, 200, 50] },
+            { name: "AB", construction: E.Line.connect, params: ["A", "B"] },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Ports 3 constructions (`plane;parallel`, `point;sphereSlider`, `point;invert`) and fixes a pre-existing sphere rendering bug. Unblocks 3 propositions (XI.11, XI.26, XIII.16). 448/465 renderable (96.3%).

## What's in this branch

- `7e9305b` parallel-sphereslider-invert: step 4 — add element classes (3 new .ts files)
- `68fea84` parallel-sphereslider-invert: step 5 — wire all three constructions + fix SphereElement validation stub + add Center getter
- `d4161ec` parallel-sphereslider-invert: step 6 — Mocha tests (plane;parallel + point;sphereSlider + point;invert)
- `a6a78d2` parallel-sphereslider-invert: step 7 — three-way view pairs for all three
- `d2a2ff4` parallel-sphereslider-invert: step 8 — tracker + journal
- `1533358` fix: SphereElement drawEdge/drawFace used wrong ellipse() API (porting bug)

## Construction details

- **`plane;parallel`**: `ParallelPlane.ts` extends `PlaneElement`. B and C track P's frame translated to A. Overrides `update()`, `translate()`, `rotate()`. Signature `[PlaneElement, PointElement]`.
- **`point;sphereSlider`**: `SphereSliderElement.ts` extends `PointElement`. Constrained to sphere via `toSphere()`. `drag()` handles inside (computes z from sphere equation) and outside shadow (projects to equator). Signature `[SphereElement, Integer×3]`.
- **`point;invert`**: `InvertPointElement.ts` extends `PointElement`. Inverts via existing `toInvertPoint()`. Signature `[PointElement, CircleElement]`.

## Bug fixes

**SphereElement.drawEdge()/drawFace()**: Canvas `ellipse()` takes `(centerX, centerY, radiusX, radiusY, ...)` but the code was passing `(center.x - r, center.y - r, diameter, diameter, ...)` as if it were Java's `drawOval(topLeftX, topLeftY, width, height)`. The sphere rendered at 2× the correct size and offset by `r` pixels. Pre-existing bug from the original TS port — discovered during harness verification of the sphereSlider test page.

**SphereElement.validateSignature()**: Was a TODO no-op stub that always passed. Now checks `instanceof SphereElement`.

**SphereElement.Center**: Added public getter (was protected-only, inaccessible to SphereSliderElement).

## Tests

44 → **47 passing**. Three new tests: parallel plane through A, sphereSlider projects to sphere surface (distance = radius), point inversion (factor = r²/d²).

## Verification

- [x] `npm run build` clean
- [x] `npm test` passes (47/47)
- [x] `npx webpack` rebuilds `dist/bundle.js`
- [x] Sphere rendering fix verified — sphere now renders at correct size with slider points inside the circle
- [x] Three-way harness for all three — **needs human verification**

## Newly renderable propositions

- **Book XI** (33 → 35): XI.11, XI.26
- **Book XIII** (13 → 14): XIII.16
- **I–XIII total** (445 → 448): +3

Only **17 propositions remain**, all needing `PolyhedronElement` base class + polyhedra constructions + `polygon;face` + `circle;intersection`.
