### PR TITLE
Feature/polyhedron base pyramid

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -546,18 +546,24 @@ These affect the library as a whole, independent of individual constructions.
 
 ## Polyhedra constructions (solid geometry)
 
-- [ ] **`tetrahedron`** — TBD
-  - Needs `PolyhedronElement.java` base class (78 lines) ported first
-  - Blocks 7 propositions (XII.3–XII.5, XII.8–XII.9, XIII.13, XIII.15)
+- [x] **`tetrahedron`** — `src/elements/Constructions.ts` (`TetrahedronConstruction`)
+  - Creates a triangle base `PolygonElement([A,B,C])` then `PyramidElement(base, D)`.
+  - Java source: `Slate.java` polyhedron case 0 — dispatch trick on Pyramid.
+  - Mocha test (1): tetrahedron has 4 faces.
+  - Blocks 7 propositions (XII.3–XII.5, XII.8–XII.9, XIII.13, XIII.15 — also need prism/parallelepiped)
 - [ ] **`parallelepiped`** — TBD
   - Needs `PolyhedronElement.java` base class ported first
   - Blocks 6 propositions (XI.37, XII.5, XII.9, XII.11, XII.12, XIII.15)
 - [ ] **`prism`** — TBD (Java source: `Prism.java`, 41 lines)
   - Needs `PolyhedronElement.java` base class ported first
   - Blocks 3 propositions (XI.39, XII.7, XIII.14)
-- [ ] **`pyramid`** — TBD (Java source: `Pyramid.java`, 11 lines)
-  - Needs `PolyhedronElement.java` base class ported first
-  - Blocks 3 propositions (XI.23, XII.6, XIII.14)
+- [x] **`pyramid`** — `src/elements/polyhedron/PyramidElement.ts`
+  - Extends `PolyhedronElement`. Creates n triangular side faces from apex
+    to each base edge. Java source: `Pyramid.java` — 11 lines.
+  - [x] test view: [view/test/polyhedron/pyramid.html](../view/test/polyhedron/pyramid.html)
+  - [x] applet-tests pair:
+    [view/applet-tests/polyhedron/pyramid/{original,applet}.html](../view/applet-tests/polyhedron/pyramid/)
+  - Used in: XI.23 (sole blocker, now renderable), XII.6, XIII.14
 
 ---
 

--- a/doc/java-port-tracker.md
+++ b/doc/java-port-tracker.md
@@ -26,7 +26,7 @@ implementation status. Updated as constructions are ported.
 | `PolygonElement.java` | PORTED | `src/elements/polygon/PolygonElement.ts` | `area()` method added 2026-04-12. |
 | `SectorElement.java` | PORTED | `src/elements/sector/SectorElement.ts` | |
 | `SphereElement.java` | PORTED | `src/elements/sphere/SphereElement.ts` | |
-| `PolyhedronElement.java` | TBD | — | Base class for 3D polyhedra. Needed for Books XI–XIII. |
+| `PolyhedronElement.java` | PORTED | `src/elements/polyhedron/PolyhedronElement.ts` | Base class for 3D polyhedra. Ported 2026-04-12. |
 
 ---
 
@@ -106,7 +106,7 @@ implementation status. Updated as constructions are ported.
 | Java File | Status | TS Location | Notes |
 |---|---|---|---|
 | `Prism.java` | TBD | — | Prism construction. Needed for Books XI–XIII. |
-| `Pyramid.java` | TBD | — | Pyramid construction. Needed for Books XI–XIII. |
+| `Pyramid.java` | PORTED | `src/elements/polyhedron/PyramidElement.ts` | Pyramid construction. 11 lines. Ported 2026-04-12. |
 
 ---
 
@@ -125,10 +125,9 @@ implementation status. Updated as constructions are ported.
 
 | Status | Count | Files |
 |--------|-------|-------|
-| PORTED | 33 | Core element classes + all ported constructions (incl. ParallelP, SphereSlider, InvertPoint ported 2026-04-12) |
+| PORTED | 35 | Core element classes + all ported constructions (incl. PolyhedronElement, Pyramid ported 2026-04-12) |
 | PARTIAL | 3 | IntersectionPL, PerpendicularPL, Slate |
-| TBD | 4 | InvertCircle, PlaneFoot, Prism, Pyramid |
-| TBD (base) | 1 | PolyhedronElement |
+| TBD | 3 | InvertCircle, PlaneFoot, Prism |
 | TBD (plane/circle) | 2 | ParallelP (plane;parallel), IntersectionSS (circle;intersection) |
 | N/A | 3 | Geometry, ClientFrame, Remote |
 | **Total** | **44** | |

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,33 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-12 — PolyhedronElement base class + pyramid + tetrahedron
+
+**Completed:**
+- Ported `PolyhedronElement.java` (78 lines) as the base class for all
+  polyhedra at `src/elements/polyhedron/PolyhedronElement.ts`. Holds an
+  array of `PolygonElement` faces. Implements `drawEdge` (all face edges),
+  `drawFace` (all faces), `drawVertex` (all vertices), `drawName`
+  (centroid label), and `defined` (all faces defined).
+- Ported `Pyramid.java` (11 lines) as `src/elements/polyhedron/PyramidElement.ts`.
+  Extends `PolyhedronElement`. Creates n triangular side faces from apex
+  to each base edge.
+- Wired both `TetrahedronConstruction` (4 points → triangle base + Pyramid)
+  and `PyramidConstruction` (polygon + point). Added `PolyhedronElement` to
+  `ConstructionTypes` enum and `validateSignature` switch.
+- One Mocha test: tetrahedron has 4 faces. 47 → **48 passing**.
+- **1 proposition unblocked**: XI.23 (pyramid sole blocker).
+- I–XIII total: 448 → **449** renderable (96.6%).
+
+**Next session:**
+- `Prism.java` (41 lines) — needed for parallelepiped, prism, and
+  `polygon;face` constructions. Unblocks XI.37 (parallelepiped),
+  XI.39 (prism), XII.5–XII.9, XIII.14–XIII.15.
+- Then `circle;intersection` (IntersectionSS.java, 41 lines) for the
+  last 2 props (XIII.15, XIII.17).
+
+---
+
 ## 2026-04-12 — Bundle: plane;parallel + point;sphereSlider + point;invert
 
 **Completed:**

--- a/doc/proposition-tracker.md
+++ b/doc/proposition-tracker.md
@@ -25,10 +25,10 @@ Tracks the port status of all propositions across Euclid's Elements.
 | Book IX | 36 | **36** | 0 |
 | Book X | 115 | **115** | 0 |
 | **I–X total** | **390** | **390** | **0** |
-| Book XI | 39 | 35 | 0 |
+| Book XI | 39 | 36 | 0 |
 | Book XII | 18 | 9 | 0 |
 | Book XIII | 18 | 14 | 0 |
-| **I–XIII total** | **465** | **448** | **0** |
+| **I–XIII total** | **465** | **449** | **0** |
 
 Update the summary table after each session.
 
@@ -241,7 +241,7 @@ Verified per-proposition against actual HTML param lists 2026-04-12.
 - [~] XI.5 through XI.10 — renderable
 - [~] XI.11 — (`plane;3points`, `plane;parallel`, `point;planeSlider` all landed 2026-04-12.)
 - [~] XI.12 through XI.22 — renderable
-- [ ] XI.23 — NEEDS: `polyhedron;pyramid`
+- [~] XI.23 — (`polyhedron;pyramid` landed 2026-04-12.)
 - [~] XI.24, XI.25 — renderable
 - [~] XI.26 — (`plane;3points`, `plane;parallel`, `point;planeSlider` all landed 2026-04-12.)
 - [~] XI.27, XI.28 — renderable

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -44,6 +44,8 @@ import {HarmonicElement} from "./point/HarmonicElement";
 import {InvertPointElement} from "./point/InvertPointElement";
 import {SphereSliderElement} from "./point/SphereSliderElement";
 import {ParallelPlane} from "./plane/ParallelPlane";
+import {PolyhedronElement} from "./polyhedron/PolyhedronElement";
+import {PyramidElement} from "./polyhedron/PyramidElement";
 import {ApplicationElement} from "./polygon/ApplicationElement";
 import {PolygonElement} from "./polygon/PolygonElement";
 import {RegularPolygonElement} from "./polygon/RegularPolygonElement";
@@ -55,7 +57,8 @@ export enum ConstructionTypes {
     CircleElement,
     PlaneElement,
     SphereElement,
-    PolygonElement
+    PolygonElement,
+    PolyhedronElement
 }
 
 export enum PointConstructions {
@@ -234,6 +237,11 @@ export abstract class Construction {
                     break;
                 case ConstructionTypes.PolygonElement:
                     if (!(param instanceof PolygonElement)) {
+                        return false;
+                    }
+                    break;
+                case ConstructionTypes.PolyhedronElement:
+                    if (!(param instanceof PolyhedronElement)) {
                         return false;
                     }
                     break;
@@ -1546,13 +1554,22 @@ export class SphereRadiusConstruction extends Construction {
  * Element Class Polyhedron *
  ****************************/
 
-// TBD
-// *Solid Geometry Only*
 // polyhedron
 // tetrahedron
 // points A, B, C, D
-// the tetrahedron given four vertices
+// the tetrahedron given four vertices (creates a triangle base + Pyramid)
+// (Java: Slate.java polyhedron case 0 — PolygonElement(A,B,C) + Pyramid(base,D))
+export class TetrahedronConstruction extends Construction {
+    constructionMethod: AllConstructions = PolyhedraConstructions.tetrahedron;
+    signature: ConstructionTypes[] = (new Array(4)).fill(ct.PointElement);
 
+    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let base = new PolygonElement([ps[0], ps[1], ps[2]]);
+        let g = new PyramidElement(base, ps[3]);
+        return [[base, g], g];
+    }
+}
 
 // TBD
 // *Solid Geometry Only*
@@ -1570,12 +1587,22 @@ export class SphereRadiusConstruction extends Construction {
 // the prism with base A and side edges parallel and equal to BC
 
 
-// TBD
-// *Solid Geometry Only*
 // polyhedron
 // pyramid
 // polygon A point B
 // the pyramid with base A and apex B
+// (Java: Pyramid.java — 11 lines, line-for-line port)
+export class PyramidConstruction extends Construction {
+    constructionMethod: AllConstructions = PolyhedraConstructions.pyramid;
+    signature: ConstructionTypes[] = [ct.PolygonElement, ct.PointElement];
+
+    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const base = params[0] as PolygonElement;
+        const apex = params[1] as PointElement;
+        const g = new PyramidElement(base, apex);
+        return [[g], g];
+    }
+}
 
 
 export const constructions : Construction[] = [
@@ -1651,5 +1678,7 @@ export const constructions : Construction[] = [
     new Plane3PointsConstruction(),
     new PerpendicularPlaneConstruction(),
     new PlaneParallelConstruction(),
-    new SphereRadiusConstruction()
+    new SphereRadiusConstruction(),
+    new TetrahedronConstruction(),
+    new PyramidConstruction(),
 ];

--- a/src/elements/polyhedron/PolyhedronElement.ts
+++ b/src/elements/polyhedron/PolyhedronElement.ts
@@ -1,0 +1,94 @@
+/*----------------------------------------------------------------------+
+|    Title:	PolyhedronElement.ts                                        |
+|    A port of the software Geometry Applet by                          |
+|    Author:    David E. Joyce                                          |
+|        Department of Mathematics and Computer Science                 |
+|        Clark University                                               |
+|        Worcester, MA 01610-1477                                       |
+|        U.S.A.                                                         |
+|                                                                       |
+|        http://aleph0.clarku.edu/~djoyce/home.html                     |
+|        djoyce@clarku.edu                                              |
+|                                                                       |
+|    Date:    May, 1997.                                                |
+|    TypeScript Port: 2026, Nelson Brown, brownnrl@gmail.com            |
+|                           https://www.nelsonbrown.net/                |
++----------------------------------------------------------------------*/
+
+import {GeomElement} from "../GeomElement";
+import {PolygonElement} from "../polygon/PolygonElement";
+import {PointElement} from "../point/PointElement";
+import {SlateCanvas} from "../../Slate";
+
+export class PolyhedronElement extends GeomElement {
+
+    public P: PolygonElement[];   // array of face polygons
+
+    constructor() {
+        super();
+        this.dimension = 2;
+        this.P = [];
+    }
+
+    public defined(): boolean {
+        for (let i = 0; i < this.P.length; ++i) {
+            if (!this.P[i].defined()) return false;
+        }
+        return true;
+    }
+
+    public drawName(c: SlateCanvas): void {
+        if (this.nameColor != null && this.name != null && this.defined()) {
+            let x = 0, y = 0, ct = 0;
+            for (let j = 0; j < this.P.length; ++j) {
+                for (let i = 0; i < this.P[j].V.length; ++i) {
+                    x += this.P[j].V[i].x;
+                    y += this.P[j].V[i].y;
+                    ++ct;
+                }
+            }
+            x /= ct;
+            y /= ct;
+            this.drawString(Math.round(x), Math.round(y), c);
+        }
+    }
+
+    public drawVertex(c: SlateCanvas): void {
+        if (this.vertexColor != null && this.defined()) {
+            for (let j = 0; j < this.P.length; ++j) {
+                for (let i = 0; i < this.P[j].V.length; ++i) {
+                    this.P[j].V[i].drawVertex(c, this.vertexColor);
+                }
+            }
+        }
+    }
+
+    public drawEdge(c: SlateCanvas): void {
+        if (this.edgeColor != null && this.defined()) {
+            let ctx = c.getContext("2d") as CanvasRenderingContext2D;
+            ctx.strokeStyle = this.edgeColor;
+            for (let j = 0; j < this.P.length; ++j) {
+                for (let i = 0; i < this.P[j].V.length; ++i) {
+                    let a = this.P[j].V[i];
+                    let b = this.P[j].V[(i + 1) % this.P[j].V.length];
+                    ctx.beginPath();
+                    ctx.moveTo(a.x, a.y);
+                    ctx.lineTo(b.x, b.y);
+                    ctx.stroke();
+                }
+            }
+        }
+    }
+
+    public drawFace(c: SlateCanvas): void {
+        if (this.faceColor != null && this.defined()) {
+            for (let j = 0; j < this.P.length; ++j) {
+                this.P[j].drawFace(c);
+            }
+        }
+    }
+
+    public update(): void {}
+    public translate(dx: number, dy: number): void {}
+    public rotate(pivot: PointElement, ac: number, as: number): void {}
+}

--- a/src/elements/polyhedron/PyramidElement.ts
+++ b/src/elements/polyhedron/PyramidElement.ts
@@ -1,0 +1,34 @@
+/*----------------------------------------------------------------------+
+|    Title:	PyramidElement.ts                                           |
+|    A port of the software Geometry Applet by                          |
+|    Author:    David E. Joyce                                          |
+|        Department of Mathematics and Computer Science                 |
+|        Clark University                                               |
+|        Worcester, MA 01610-1477                                       |
+|        U.S.A.                                                         |
+|                                                                       |
+|        http://aleph0.clarku.edu/~djoyce/home.html                     |
+|        djoyce@clarku.edu                                              |
+|                                                                       |
+|    Date:    May, 1997.                                                |
+|    TypeScript Port: 2026, Nelson Brown, brownnrl@gmail.com            |
+|                           https://www.nelsonbrown.net/                |
++----------------------------------------------------------------------*/
+
+import {PolyhedronElement} from "./PolyhedronElement";
+import {PolygonElement} from "../polygon/PolygonElement";
+import {PointElement} from "../point/PointElement";
+
+export class PyramidElement extends PolyhedronElement {
+
+    constructor(Base: PolygonElement, Apex: PointElement) {
+        super();
+        this.dimension = 2;
+        let n = 1 + Base.V.length;
+        this.P = new Array(n);
+        this.P[0] = Base;
+        for (let i = 1; i < n; ++i) {
+            this.P[i] = new PolygonElement([Apex, Base.V[i - 1], Base.V[i % Base.V.length]]);
+        }
+    }
+}

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -832,6 +832,24 @@ describe("slate", ()=> {
         almostEqual(Q.A.z, 100, 0.01);
     });
 
+    // polyhedron;tetrahedron — 4 points → triangle base + pyramid
+    it("should create a tetrahedron with 4 triangular faces", () => {
+        let data : IConstructionInfo[] = [
+            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [50, 87, 0] },
+            { name: "D", construction: E.Point.fixed, params: [50, 29, 82] },
+            { name: "T", construction: E.Polyhedra.tetrahedron, params: ["A", "B", "C", "D"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        // The tetrahedron should have 4 faces (1 base + 3 sides)
+        // Find it — it's the last PolyhedronElement in the elements list
+        let tetra = slate.lookupElement("T");
+        assert.ok(tetra != null);
+        assert.equal((tetra as any).P.length, 4);
+    });
+
     // point;invert — inversion of a point in a circle
     // Circle center (100,100), radius point (200,100) → radius=100
     // Point A at (150,100) → distance from center = 50

--- a/view/applet-tests/polyhedron/pyramid/applet.html
+++ b/view/applet-tests/polyhedron/pyramid/applet.html
@@ -1,0 +1,15 @@
+<HTML><HEAD><TITLE>polyhedron;pyramid — applet form of view/test/polyhedron/pyramid.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/polyhedron/pyramid.html -->
+<!-- ORIGINAL: view/applet-tests/polyhedron/pyramid/original.html (standalone) -->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="Pyramid">
+<param name=e[1] value="A;point;fixed;50,250,0">
+<param name=e[2] value="B;point;fixed;250,250,0">
+<param name=e[3] value="C;point;fixed;150,250,100">
+<param name=e[4] value="base;polygon;triangle;A,B,C;0;0;black;random">
+<param name=e[5] value="D;point;fixed;150,100,50;black;green">
+<param name=e[6] value="pyr;polyhedron;pyramid;base,D;0;0;black;random">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/polyhedron/pyramid/original.html
+++ b/view/applet-tests/polyhedron/pyramid/original.html
@@ -1,0 +1,13 @@
+<HTML><HEAD><TITLE>polyhedron;pyramid (standalone)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=300 width=300>
+<param name=background value="35,19,100">
+<param name=title value="Pyramid">
+<param name=e[1] value="A;point;fixed;50,250,0">
+<param name=e[2] value="B;point;fixed;250,250,0">
+<param name=e[3] value="C;point;fixed;150,250,100">
+<param name=e[4] value="base;polygon;triangle;A,B,C;0;0;black;random">
+<param name=e[5] value="D;point;fixed;150,100,50;black;green">
+<param name=e[6] value="pyr;polyhedron;pyramid;base,D;0;0;black;random">
+</applet>
+</BODY></HTML>

--- a/view/test/polyhedron/pyramid.html
+++ b/view/test/polyhedron/pyramid.html
@@ -1,0 +1,23 @@
+<html>
+<head><title>Test View - Polyhedron.pyramid (standalone)</title></head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "Pyramid — triangular base + apex",
+        canvasid: "canvasId",
+        elements: [
+            { name: "A", construction: E.Point.fixed, params: [50, 250, 0] },
+            { name: "B", construction: E.Point.fixed, params: [250, 250, 0] },
+            { name: "C", construction: E.Point.fixed, params: [150, 250, 100] },
+            { name: "base", construction: E.Polygon.triangle, params: ["A", "B", "C"] },
+            { name: "D", construction: E.Point.fixed, params: [150, 100, 50] },
+            { name: "pyr", construction: E.Polyhedra.pyramid, params: ["base", "D"] },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Ports the `PolyhedronElement` base class (78 lines) and `Pyramid` (11 lines) — the prerequisite for all remaining solid geometry. Wires both `polyhedron;pyramid` and `polyhedron;tetrahedron` (tetrahedron is a dispatch trick on Pyramid with a triangle base). Unblocks XI.23. 449/465 renderable (96.6%).

## What's in this branch

- `01ff500` polyhedron-base-pyramid: step 4 — add PolyhedronElement.ts + PyramidElement.ts
- `56c3de8` polyhedron-base-pyramid: step 5 — wire TetrahedronConstruction + PyramidConstruction + PolyhedronElement validation
- `911eaf9` polyhedron-base-pyramid: step 6 — Mocha test (tetrahedron with 4 faces)
- `b760f82` polyhedron-base-pyramid: step 7 — three-way view pair for pyramid
- `985a3ca` polyhedron-base-pyramid: step 8 — tracker + journal

## Construction details

- **`PolyhedronElement.ts`**: Base class for all polyhedra. Holds `P[]` array of `PolygonElement` faces. Implements `drawEdge` (all face edges), `drawFace` (all faces), `drawVertex` (all vertices), `drawName` (centroid label). Added `PolyhedronElement` to `ConstructionTypes` enum + `validateSignature`.
- **`PyramidElement.ts`**: Extends `PolyhedronElement`. Constructor `(Base, Apex)` creates n triangular side faces. 11 lines, line-for-line port of `Pyramid.java`.
- **`TetrahedronConstruction`**: Dispatch trick — creates `PolygonElement([A,B,C])` (triangle base) then `PyramidElement(base, D)`. Signature `[Point × 4]`.
- **`PyramidConstruction`**: Signature `[PolygonElement, PointElement]`.

## Tests

47 → **48 passing**. One new test: tetrahedron has 4 faces.

## Verification

- [x] `npm run build` clean
- [x] `npm test` passes (48/48)
- [x] `npx webpack` rebuilds `dist/bundle.js`
- [x] Three-way harness for pyramid — **needs human verification**

## Newly renderable propositions

- **Book XI** (35 → 36): XI.23
- **I–XIII total** (448 → 449): +1

Remaining 16 propositions need: `polyhedron;prism` (→ parallelepiped), `polygon;face`, `circle;intersection`. The PolyhedronElement base class is now in place for all of them.
