### PR TITLE
Feature/prism parallelepiped face

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -474,12 +474,11 @@ These affect the library as a whole, independent of individual constructions.
   - Mocha test (1): 8-vertex correctness.
   - Used in: Book XII (XII.2, XII.10 sole-blocker; XII.11, XII.12 also need polyhedron)
 
-- [ ] **`face`** — TBD
-  - Returns the N-th face (a PolygonElement) of a PolyhedronElement.
-    Same pattern as `point;vertex` (returns the N-th vertex of a polygon).
-  - Needs `PolyhedronElement` base class ported first.
-  - Java dispatch: `Slate.java` polygon case 12 → `((PolyhedronElement)E[0]).P[N[0]-1]`
-  - Blocks 1 proposition (XII.7)
+- [x] **`face`** — `src/elements/Constructions.ts` (`FacePolygonConstruction`)
+  - Returns the N-th face (1-based) of a PolyhedronElement.
+    Same pattern as `point;vertex`.
+  - Java dispatch: `Slate.java` polygon case 12.
+  - Used in: XII.7
 
 ---
 
@@ -551,12 +550,18 @@ These affect the library as a whole, independent of individual constructions.
   - Java source: `Slate.java` polyhedron case 0 — dispatch trick on Pyramid.
   - Mocha test (1): tetrahedron has 4 faces.
   - Blocks 7 propositions (XII.3–XII.5, XII.8–XII.9, XIII.13, XIII.15 — also need prism/parallelepiped)
-- [ ] **`parallelepiped`** — TBD
-  - Needs `PolyhedronElement.java` base class ported first
-  - Blocks 6 propositions (XI.37, XII.5, XII.9, XII.11, XII.12, XIII.15)
-- [ ] **`prism`** — TBD (Java source: `Prism.java`, 41 lines)
-  - Needs `PolyhedronElement.java` base class ported first
-  - Blocks 3 propositions (XI.39, XII.7, XIII.14)
+- [x] **`parallelepiped`** — `src/elements/Constructions.ts` (`ParallelepipedConstruction`)
+  - Dispatch trick: Layoff(B,A,C,A,C) → parallelogram base → PrismElement.
+  - Used in: XI.37, XII.5, XII.9, XII.11, XII.12, XIII.15
+- [x] **`prism`** — `src/elements/polyhedron/PrismElement.ts`
+  - Extends `PolyhedronElement`. Base + top + side quads. Overrides
+    `update()`, `translate()`, `rotate()`.
+  - Java source: `Prism.java` — 41 lines, line-for-line port.
+  - Mocha test (1): triangular prism has 5 faces.
+  - [x] test view: [view/test/polyhedron/prism.html](../view/test/polyhedron/prism.html)
+  - [x] applet-tests pair:
+    [view/applet-tests/polyhedron/prism/{original,applet}.html](../view/applet-tests/polyhedron/prism/)
+  - Used in: XI.39, XII.7, XIII.14
 - [x] **`pyramid`** — `src/elements/polyhedron/PyramidElement.ts`
   - Extends `PolyhedronElement`. Creates n triangular side faces from apex
     to each base edge. Java source: `Pyramid.java` — 11 lines.

--- a/doc/java-port-tracker.md
+++ b/doc/java-port-tracker.md
@@ -105,7 +105,7 @@ implementation status. Updated as constructions are ported.
 
 | Java File | Status | TS Location | Notes |
 |---|---|---|---|
-| `Prism.java` | TBD | — | Prism construction. Needed for Books XI–XIII. |
+| `Prism.java` | PORTED | `src/elements/polyhedron/PrismElement.ts` | Prism construction. 41 lines. Ported 2026-04-12. |
 | `Pyramid.java` | PORTED | `src/elements/polyhedron/PyramidElement.ts` | Pyramid construction. 11 lines. Ported 2026-04-12. |
 
 ---
@@ -125,9 +125,9 @@ implementation status. Updated as constructions are ported.
 
 | Status | Count | Files |
 |--------|-------|-------|
-| PORTED | 35 | Core element classes + all ported constructions (incl. PolyhedronElement, Pyramid ported 2026-04-12) |
+| PORTED | 36 | Core element classes + all ported constructions (incl. Prism ported 2026-04-12) |
 | PARTIAL | 3 | IntersectionPL, PerpendicularPL, Slate |
-| TBD | 3 | InvertCircle, PlaneFoot, Prism |
+| TBD | 2 | InvertCircle, PlaneFoot |
 | TBD (plane/circle) | 2 | ParallelP (plane;parallel), IntersectionSS (circle;intersection) |
 | N/A | 3 | Geometry, ClientFrame, Remote |
 | **Total** | **44** | |

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,32 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-12 — Prism + parallelepiped + polygon;face — BOOKS XI & XII COMPLETE
+
+**Completed:**
+- Ported `Prism.java` (41 lines) as `src/elements/polyhedron/PrismElement.ts`.
+  Extends `PolyhedronElement`. Creates a prism with a base polygon and
+  side edges parallel to a given line segment CD. Top vertices are
+  base vertices translated by (D-C). `update()` recomputes top each frame.
+- Wired `PrismConstruction` (polygon + 2 points),
+  `ParallelepipedConstruction` (4 points → Layoff + parallelogram base +
+  Prism dispatch trick), and `FacePolygonConstruction` (returns N-th face
+  of a polyhedron, same pattern as `point;vertex`).
+- 2 Mocha tests: prism with 5 faces (triangle base), parallelepiped with
+  6 faces. 48 → **50 passing**.
+- **14 propositions unblocked**: XI.35, XI.37, XI.39, XII.3–XII.9,
+  XII.11–XII.12, XIII.13, XIII.14.
+- **Book XI: 39/39 COMPLETE! Book XII: 18/18 COMPLETE!**
+- I–XIII total: 449 → **463**. Only **2 propositions remain**: XIII.15
+  and XIII.17 (both need `circle;intersection`).
+
+**Next session:**
+- `circle;intersection` (`IntersectionSS.java`, 41 lines) — the **FINAL
+  construction**. Landing it makes XIII.15 and XIII.17 renderable,
+  reaching **465/465 = 100% for ALL of Euclid's Elements**.
+
+---
+
 ## 2026-04-12 — PolyhedronElement base class + pyramid + tetrahedron
 
 **Completed:**

--- a/doc/proposition-tracker.md
+++ b/doc/proposition-tracker.md
@@ -25,10 +25,10 @@ Tracks the port status of all propositions across Euclid's Elements.
 | Book IX | 36 | **36** | 0 |
 | Book X | 115 | **115** | 0 |
 | **I–X total** | **390** | **390** | **0** |
-| Book XI | 39 | 36 | 0 |
-| Book XII | 18 | 9 | 0 |
-| Book XIII | 18 | 14 | 0 |
-| **I–XIII total** | **465** | **449** | **0** |
+| Book XI | 39 | **39** | 0 |
+| Book XII | 18 | **18** | 0 |
+| Book XIII | 18 | 16 | 0 |
+| **I–XIII total** | **465** | **463** | **0** |
 
 Update the summary table after each session.
 
@@ -251,11 +251,11 @@ Verified per-proposition against actual HTML param lists 2026-04-12.
 - [~] XI.32 — (`plane;3points` + `point;planeSlider` both landed 2026-04-12.)
 - [~] XI.33 — renderable
 - [~] XI.34 — (`plane;3points` + `point;planeSlider` both landed 2026-04-12.)
-- [ ] XI.35 — NEEDS: `plane;3points`, `point;planeSlider`, `point;sphereSlider`
+- [~] XI.35 — (All blockers landed by 2026-04-12.)
 - [~] XI.36 — renderable
-- [ ] XI.37 — NEEDS: `plane;3points`, `point;planeSlider`, `polyhedron;parallelepiped`
+- [~] XI.37 — (All blockers landed by 2026-04-12.)
 - [~] XI.38 — (`plane;3points` landed 2026-04-12.)
-- [ ] XI.39 — NEEDS: `plane;3points`, `plane;parallel`, `point;planeSlider`, `polyhedron;prism`
+- [~] XI.39 — (All blockers landed by 2026-04-12.)
 
 ---
 
@@ -265,16 +265,16 @@ Verified per-proposition against actual HTML param lists 2026-04-12.
 
 - [~] XII.1 — renderable
 - [~] XII.2 — (`polygon;octagon` landed 2026-04-12.)
-- [ ] XII.3 — NEEDS: `plane;3points`, `point;planeSlider`, `polyhedron;tetrahedron`
-- [ ] XII.4 — NEEDS: `plane;3points`, `point;planeSlider`, `polyhedron;tetrahedron`
-- [ ] XII.5 — NEEDS: `plane;3points`, `point;planeSlider`, `polyhedron;parallelepiped`, `polyhedron;tetrahedron`
-- [ ] XII.6 — NEEDS: `plane;3points`, `point;planeSlider`, `polyhedron;pyramid`
-- [ ] XII.7 — NEEDS: `plane;3points`, `point;planeSlider`, `polygon;face`, `polyhedron;prism`
-- [ ] XII.8 — NEEDS: `plane;3points`, `point;planeSlider`, `polyhedron;tetrahedron`
-- [ ] XII.9 — NEEDS: `plane;3points`, `point;planeSlider`, `polyhedron;parallelepiped`, `polyhedron;tetrahedron`
+- [~] XII.3 — (All blockers landed by 2026-04-12.)
+- [~] XII.4 — (All blockers landed by 2026-04-12.)
+- [~] XII.5 — (All blockers landed by 2026-04-12.)
+- [~] XII.6 — (All blockers landed by 2026-04-12.)
+- [~] XII.7 — (All blockers landed by 2026-04-12.)
+- [~] XII.8 — (All blockers landed by 2026-04-12.)
+- [~] XII.9 — (All blockers landed by 2026-04-12.)
 - [~] XII.10 — (`polygon;octagon` landed 2026-04-12.)
-- [ ] XII.11 — NEEDS: `polygon;octagon`, `polyhedron;parallelepiped`
-- [ ] XII.12 — NEEDS: `polygon;octagon`, `polyhedron;parallelepiped`
+- [~] XII.11 — (All blockers landed by 2026-04-12.)
+- [~] XII.12 — (All blockers landed by 2026-04-12.)
 - [~] XII.13 through XII.16 — renderable
 - [~] XII.17 — (`plane;3points` + `point;planeSlider` both landed 2026-04-12.)
 - [~] XII.18 — renderable
@@ -286,8 +286,8 @@ Verified per-proposition against actual HTML param lists 2026-04-12.
 13 of 18 propositions are renderable. 5 blocked.
 
 - [~] XIII.1 through XIII.12 — renderable
-- [ ] XIII.13 — NEEDS: `point;sphereSlider`, `polyhedron;tetrahedron`
-- [ ] XIII.14 — NEEDS: `plane;3points`, `point;sphereSlider`, `polyhedron;prism`, `polyhedron;pyramid`
+- [~] XIII.13 — (All blockers landed by 2026-04-12.)
+- [~] XIII.14 — (All blockers landed by 2026-04-12.)
 - [ ] XIII.15 — NEEDS: `circle;intersection`, `point;sphereSlider`, `polyhedron;parallelepiped`, `polyhedron;tetrahedron`
 - [~] XIII.16 — (`point;sphereSlider` landed 2026-04-12.)
 - [ ] XIII.17 — NEEDS: `circle;intersection`, `plane;3points`, `point;planeSlider`, `point;sphereSlider`

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -46,6 +46,7 @@ import {SphereSliderElement} from "./point/SphereSliderElement";
 import {ParallelPlane} from "./plane/ParallelPlane";
 import {PolyhedronElement} from "./polyhedron/PolyhedronElement";
 import {PyramidElement} from "./polyhedron/PyramidElement";
+import {PrismElement} from "./polyhedron/PrismElement";
 import {ApplicationElement} from "./polygon/ApplicationElement";
 import {PolygonElement} from "./polygon/PolygonElement";
 import {RegularPolygonElement} from "./polygon/RegularPolygonElement";
@@ -1387,13 +1388,23 @@ export class OctagonPolygonConstruction extends PolyConstruction {
     signature: ConstructionTypes[] = (new Array(8)).fill(ct.PointElement);
 }
 
-// TBD
-// *Solid Geometry Only*
 // polygon
-// face	
+// face
 // polyhedron A integer n
-// the nth face of polyhedron A
+// the nth face (1-based) of polyhedron A
+// (Java: Slate.java polygon case 12 — ((PolyhedronElement)E[0]).P[N[0]-1])
+// Same pattern as point;vertex (returns polygon from polyhedron, not point from polygon)
+export class FacePolygonConstruction extends Construction {
+    constructionMethod: AllConstructions = PolygonConstructions.face;
+    signature: ConstructionTypes[] = [ct.PolyhedronElement, ct.Integer];
 
+    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const polyhedron = params[0] as PolyhedronElement;
+        const n = params[1] as number;
+        const face = polyhedron.P[n - 1];
+        return [[face], face];
+    }
+}
 
 /************************
  * Element Class Sector *
@@ -1571,21 +1582,41 @@ export class TetrahedronConstruction extends Construction {
     }
 }
 
-// TBD
-// *Solid Geometry Only*
 // polyhedron
 // parallelepiped
 // points A, B, C, D
 // the parallelepiped with three edges AB, AC, and AD
+// (Java: Slate.java polyhedron case 1 — Layoff(B,A,C,A,C) + PolygonElement(B,A,C,fourth) + Prism(base,A,D))
+export class ParallelepipedConstruction extends Construction {
+    constructionMethod: AllConstructions = PolyhedraConstructions.parallelepiped;
+    signature: ConstructionTypes[] = (new Array(4)).fill(ct.PointElement);
 
+    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let fourth = new Layoff(ps[1], ps[0], ps[2], ps[0], ps[2]);
+        let base = new PolygonElement([ps[1], ps[0], ps[2], fourth]);
+        let g = new PrismElement(base, ps[0], ps[3]);
+        return [[fourth, base, g], g];
+    }
+}
 
-// TBD
-// *Solid Geometry Only*
 // polyhedron
 // prism
 // polygon A points B, C
 // the prism with base A and side edges parallel and equal to BC
+// (Java: Prism.java — 41 lines, line-for-line port)
+export class PrismConstruction extends Construction {
+    constructionMethod: AllConstructions = PolyhedraConstructions.prism;
+    signature: ConstructionTypes[] = [ct.PolygonElement, ct.PointElement, ct.PointElement];
 
+    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const base = params[0] as PolygonElement;
+        const C = params[1] as PointElement;
+        const D = params[2] as PointElement;
+        const g = new PrismElement(base, C, D);
+        return [[g], g];
+    }
+}
 
 // polyhedron
 // pyramid
@@ -1680,5 +1711,8 @@ export const constructions : Construction[] = [
     new PlaneParallelConstruction(),
     new SphereRadiusConstruction(),
     new TetrahedronConstruction(),
+    new ParallelepipedConstruction(),
+    new PrismConstruction(),
     new PyramidConstruction(),
+    new FacePolygonConstruction(),
 ];

--- a/src/elements/polyhedron/PrismElement.ts
+++ b/src/elements/polyhedron/PrismElement.ts
@@ -1,0 +1,74 @@
+/*----------------------------------------------------------------------+
+|    Title:	PrismElement.ts                                             |
+|    A port of the software Geometry Applet by                          |
+|    Author:    David E. Joyce                                          |
+|        Department of Mathematics and Computer Science                 |
+|        Clark University                                               |
+|        Worcester, MA 01610-1477                                       |
+|        U.S.A.                                                         |
+|                                                                       |
+|        http://aleph0.clarku.edu/~djoyce/home.html                     |
+|        djoyce@clarku.edu                                              |
+|                                                                       |
+|    Date:    May, 1997.                                                |
+|    TypeScript Port: 2026, Nelson Brown, brownnrl@gmail.com            |
+|                           https://www.nelsonbrown.net/                |
++----------------------------------------------------------------------*/
+
+import {PolyhedronElement} from "./PolyhedronElement";
+import {PolygonElement} from "../polygon/PolygonElement";
+import {PointElement} from "../point/PointElement";
+
+export class PrismElement extends PolyhedronElement {
+
+  // The base is given as well as a line segment CD for the sides to be
+  // parallel to.
+
+  private _C: PointElement;
+  private _D: PointElement;
+
+  constructor(Base: PolygonElement, C: PointElement, D: PointElement) {
+    super();
+    this.dimension = 2;
+    this._C = C;
+    this._D = D;
+    let baseN = Base.V.length;
+    let n = 2 + baseN;
+    this.P = new Array(n);
+    this.P[0] = Base;
+    // create the top — vertices translated by (D-C) from base
+    let topVerts : PointElement[] = new Array(baseN);
+    for (let j = 0; j < baseN; ++j) {
+      topVerts[j] = new PointElement();
+      topVerts[j].to(Base.V[j]).plus(D).minus(C);
+    }
+    this.P[1] = new PolygonElement(topVerts);
+    // create the sides — quadrilaterals connecting base and top edges
+    for (let i = 2; i < n; ++i) {
+      this.P[i] = new PolygonElement([
+        Base.V[i - 2],
+        Base.V[(i - 1) % baseN],
+        this.P[1].V[(i - 1) % baseN],
+        this.P[1].V[i - 2]
+      ]);
+    }
+  }
+
+  public translate(dx: number, dy: number) {
+    for (let i = 0; i < this.P[1].V.length; ++i) {
+      this.P[1].V[i].translate(dx, dy);
+    }
+  }
+
+  public rotate(pivot: PointElement, ac: number, as: number) {
+    for (let i = 0; i < this.P[1].V.length; ++i) {
+      this.P[1].V[i].rotate(pivot, ac, as);
+    }
+  }
+
+  public update() {
+    for (let j = 0; j < this.P[1].V.length; ++j) {
+      this.P[1].V[j].to(this.P[0].V[j]).plus(this._D).minus(this._C);
+    }
+  }
+}

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -850,6 +850,50 @@ describe("slate", ()=> {
         assert.equal((tetra as any).P.length, 4);
     });
 
+    // polyhedron;prism — base polygon + direction vector → prism
+    // Triangle base + extrusion direction (0,0,100) → 5 faces (2 triangles + 3 quads)
+    it("should create a prism with base+2 triangles and 3 side quads", () => {
+        let data : IConstructionInfo[] = [
+            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [50, 87, 0] },
+            { name: "base", construction: E.Polygon.triangle, params: ["A", "B", "C"] },
+            { name: "D", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "E", construction: E.Point.fixed, params: [0, 0, 100] },
+            { name: "P", construction: E.Polyhedra.prism, params: ["base", "D", "E"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let prism = slate.lookupElement("P");
+        assert.ok(prism != null);
+        // 2 + base.V.length = 2 + 3 = 5 faces
+        assert.equal((prism as any).P.length, 5);
+        // Top vertices should be base + (E-D) = base + (0,0,100)
+        let top = (prism as any).P[1] as PolygonElement;
+        almostEqual(top.V[0].z, 100, 0.01);
+        almostEqual(top.V[1].z, 100, 0.01);
+        almostEqual(top.V[2].z, 100, 0.01);
+    });
+
+    // polyhedron;parallelepiped — 4 points → parallelogram base + prism
+    it("should create a parallelepiped with 6 faces", () => {
+        let data : IConstructionInfo[] = [
+            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "D", construction: E.Point.fixed, params: [0, 0, 100] },
+            { name: "PP", construction: E.Polyhedra.parallelepiped, params: ["A", "B", "C", "D"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let pp = slate.lookupElement("PP");
+        assert.ok(pp != null);
+        // parallelepiped = prism on parallelogram base = 2 + 4 = 6 faces
+        assert.equal((pp as any).P.length, 6);
+    });
+
     // point;invert — inversion of a point in a circle
     // Circle center (100,100), radius point (200,100) → radius=100
     // Point A at (150,100) → distance from center = 50

--- a/view/applet-tests/polyhedron/prism/applet.html
+++ b/view/applet-tests/polyhedron/prism/applet.html
@@ -1,0 +1,16 @@
+<HTML><HEAD><TITLE>polyhedron;prism — applet form of view/test/polyhedron/prism.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/polyhedron/prism.html -->
+<!-- ORIGINAL: view/applet-tests/polyhedron/prism/original.html (standalone) -->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=title value="Prism">
+<param name=e[1] value="A;point;fixed;50,250,0">
+<param name=e[2] value="B;point;fixed;200,250,0">
+<param name=e[3] value="C;point;fixed;125,250,100">
+<param name=e[4] value="base;polygon;triangle;A,B,C;0;0;black;random">
+<param name=e[5] value="D;point;fixed;50,250,0">
+<param name=e[6] value="E;point;fixed;80,100,50">
+<param name=e[7] value="prism;polyhedron;prism;base,D,E;0;0;black;random">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/polyhedron/prism/original.html
+++ b/view/applet-tests/polyhedron/prism/original.html
@@ -1,0 +1,14 @@
+<HTML><HEAD><TITLE>polyhedron;prism (standalone)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=300 width=300>
+<param name=background value="35,19,100">
+<param name=title value="Prism">
+<param name=e[1] value="A;point;fixed;50,250,0">
+<param name=e[2] value="B;point;fixed;200,250,0">
+<param name=e[3] value="C;point;fixed;125,250,100">
+<param name=e[4] value="base;polygon;triangle;A,B,C;0;0;black;random">
+<param name=e[5] value="D;point;fixed;50,250,0">
+<param name=e[6] value="E;point;fixed;80,100,50">
+<param name=e[7] value="prism;polyhedron;prism;base,D,E;0;0;black;random">
+</applet>
+</BODY></HTML>

--- a/view/test/polyhedron/prism.html
+++ b/view/test/polyhedron/prism.html
@@ -1,0 +1,24 @@
+<html>
+<head><title>Test View - Polyhedron.prism (standalone)</title></head>
+<body>
+<canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
+<script src="../../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "Prism — triangular base extruded along DE",
+        canvasid: "canvasId",
+        elements: [
+            { name: "A", construction: E.Point.fixed, params: [50, 250, 0] },
+            { name: "B", construction: E.Point.fixed, params: [200, 250, 0] },
+            { name: "C", construction: E.Point.fixed, params: [125, 250, 100] },
+            { name: "base", construction: E.Polygon.triangle, params: ["A", "B", "C"] },
+            { name: "D", construction: E.Point.fixed, params: [50, 250, 0] },
+            { name: "Ep", construction: E.Point.fixed, params: [80, 100, 50] },
+            { name: "prism", construction: E.Polyhedra.prism, params: ["base", "D", "Ep"] },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Ports `Prism.java` and wires 3 constructions (prism, parallelepiped, polygon;face). **Massive unlock: +14 propositions. Books XI (39/39) and XII (18/18) are now 100% complete.** Only 2 propositions remain in the entire Elements: XIII.15 and XIII.17 (both need `circle;intersection`). 463/465 renderable (99.6%).

## What's in this branch

- `0aa1811` prism-parallelepiped-face: step 4 — add PrismElement.ts
- `5a740c2` prism-parallelepiped-face: step 5 — wire PrismConstruction + ParallelepipedConstruction + FacePolygonConstruction
- `cb05be2` prism-parallelepiped-face: step 6 — Mocha tests (prism 5 faces, parallelepiped 6 faces)
- `0f54bcc` prism-parallelepiped-face: step 7 — three-way view pair for prism
- `3943168` prism-parallelepiped-face: step 8 — tracker + journal — BOOKS XI & XII COMPLETE (463/465)

## Construction details

- **`PrismElement.ts`**: Extends `PolyhedronElement`. Base + top polygon (translated by D-C) + side quads. `update()` recomputes top vertices each frame. 41 lines, line-for-line port.
- **`ParallelepipedConstruction`**: Dispatch trick — `Layoff(B,A,C,A,C)` → parallelogram base → `PrismElement(base, A, D)`. Signature `[Point × 4]`.
- **`PrismConstruction`**: Signature `[PolygonElement, PointElement, PointElement]`.
- **`FacePolygonConstruction`**: Returns `polyhedron.P[n-1]`. Same pattern as `point;vertex`. Signature `[PolyhedronElement, Integer]`.

## Tests

48 → **50 passing**. Two new tests: prism (5 faces, top z=100), parallelepiped (6 faces).

## Verification

- [x] `npm run build` clean
- [x] `npm test` passes (50/50)
- [x] `npx webpack` rebuilds `dist/bundle.js`
- [x] Three-way harness for prism — **needs human verification**

## Newly renderable propositions

- **Book XI** (36 → **39/39 = 100%**): XI.35, XI.37, XI.39
- **Book XII** (9 → **18/18 = 100%**): XII.3–XII.9, XII.11, XII.12
- **Book XIII** (14 → 16): XIII.13, XIII.14
- **I–XIII total** (449 → **463**): +14

**Only 2 propositions remain**: XIII.15 and XIII.17. Both need `circle;intersection` (`IntersectionSS.java`, 41 lines). One more session to reach 465/465.
