### PR TITLE
Feature/3d signature variants

### DIFF
--- a/doc/analysis/phase1-completion-delta.md
+++ b/doc/analysis/phase1-completion-delta.md
@@ -40,7 +40,7 @@ with `[plane X]` optional parameters; these are marked separately.
 | `circumcenter` | IMPL | IMPL | |
 | `vertex` | IMPL | n/a | |
 | `foot` (point-to-line) | IMPL | n/a | |
-| `foot` (point-to-plane) | n/a | **TBD** | `PlaneFoot.java` not ported |
+| `foot` (point-to-plane) | n/a | IMPL | `PlaneFootElement.ts` (2026-04-12) |
 | `cutoff` | IMPL | n/a | |
 | `extend` | IMPL | n/a | |
 | `parallelogram` | IMPL | n/a | |
@@ -67,7 +67,7 @@ with `[plane X]` optional parameters; these are marked separately.
 | `angleBisector` | IMPL | **TBD** | 2D only |
 | `angleDivider` | IMPL | **TBD** | 2D only |
 | `foot` (3 points) | IMPL | n/a | |
-| `foot` (point + plane) | n/a | **TBD** | `PlaneFoot.java` not ported |
+| `foot` (point + plane) | n/a | IMPL | `PlaneFootLineConstruction` (2026-04-12) |
 | `chord` | IMPL | n/a | |
 | `bichord` | IMPL | n/a | |
 | `perpendicular` (5 variants) | IMPL | partial | 5 of 6; plane-based variant TBD |
@@ -159,8 +159,8 @@ with `[plane X]` optional parameters; these are marked separately.
 
 | Category | 2D impl | 2D missing | 3D variants |
 |---|---|---|---|
-| Point | 28/28 | 0 | 3 IMPL + 2 need PlaneFoot |
-| Line | 13/13 | 0 | 3 IMPL + 1 need PlaneFoot |
+| Point | 28/28 | 0 | 5 IMPL (incl. planeFoot) |
+| Line | 13/13 | 0 | 4 IMPL (incl. planeFoot) |
 | Circle | 5/5 | 0 | 2 IMPL |
 | Polygon | 13/13 | 0 | 4 IMPL |
 | Sector | 2/2 | 0 | 1 IMPL |
@@ -180,7 +180,7 @@ with `[plane X]` optional parameters; these are marked separately.
 | Java File | Status | What's needed |
 |---|---|---|
 | `InvertCircle.java` | TBD | Documented construction, no proposition uses |
-| `PlaneFoot.java` | TBD | 3D `foot` variants for point and line |
+| `PlaneFoot.java` | PORTED | `PlaneFootElement.ts` — wired as point;foot and line;foot plane variants (2026-04-12) |
 | `IntersectionPL.ts` | **BROKEN** | File exists but is a copy of `Intersection.ts` — must be rewritten |
 
 ---
@@ -255,7 +255,7 @@ From `Geometry.html`'s parameter documentation:
 5. **Wire `plane;ambient`** — 2 variants: returns `.AP` field of a point or `.AP` field of a circle
 6. **Wire `line;proportion`** — documented, no uses but should exist for completeness
 7. **Port `InvertCircle.java`** — documented construction
-8. **Port `PlaneFoot.java`** — enables 3D `foot` variants for point and line
+8. ~~**Port `PlaneFoot.java`**~~ — DONE (2026-04-12): `PlaneFootElement.ts` + both construction variants wired
 
 ### Tier 3: Wire all 19 3D variants
 

--- a/doc/analysis/phase1-completion-delta.md
+++ b/doc/analysis/phase1-completion-delta.md
@@ -157,13 +157,13 @@ with `[plane X]` optional parameters; these are marked separately.
 
 ## 2. Construction summary
 
-| Category | 2D impl | 2D missing | 3D variants TBD |
+| Category | 2D impl | 2D missing | 3D variants |
 |---|---|---|---|
-| Point | 26/26 | 2 (IntersectionPL broken, center-sphere) | 8 |
-| Line | 12/13 | 1 (proportion) | 4 |
-| Circle | 4/5 | 1 (invert) | 2 |
-| Polygon | 12/13 | 1 (starPolygon) | 4 |
-| Sector | 2/2 | 0 | 1 |
+| Point | 28/28 | 0 | 3 IMPL + 2 need PlaneFoot |
+| Line | 13/13 | 0 | 3 IMPL + 1 need PlaneFoot |
+| Circle | 5/5 | 0 | 2 IMPL |
+| Polygon | 13/13 | 0 | 4 IMPL |
+| Sector | 2/2 | 0 | 1 IMPL |
 | Plane | 3/4 | 1 (ambient) | 0 |
 | Sphere | 1/2 | 1 (3-point radius) | 0 |
 | Polyhedron | 4/4 | 0 | 0 |

--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -111,8 +111,12 @@ These affect the library as a whole, independent of individual constructions.
 - [x] **`intersection`** — `src/elements/point/Intersection.ts`
   - [x] test view: [view/test/point/intersection.html](../view/test/point/intersection.html)
 
-- [x] **`foot`** — `src/elements/point/Foot.ts`
+- [x] **`foot`** — `src/elements/point/Foot.ts` (2D), `src/elements/point/PlaneFootElement.ts` (3D plane)
   - [x] test view: [view/test/point/foot.html](../view/test/point/foot.html) — adapted from Book X lemma
+  - [x] test view: [view/test/point/planeFoot.html](../view/test/point/planeFoot.html) — propXI26 (3D plane variant)
+  - [x] applet-tests pair:
+    [view/applet-tests/point/planeFoot/{original,applet}.html](../view/applet-tests/point/planeFoot/)
+  - Plane variant uses `PlaneFootElement(A, P)` → `toPlane()`. Used in Book XI (XI.26, etc.).
 
 - [x] **`extend`** — `src/elements/point/Layoff.ts` (shared with `cutoff`)
   - no dedicated test page
@@ -311,13 +315,21 @@ These affect the library as a whole, independent of individual constructions.
   - No dedicated element class — reuses existing `Foot` + base `LineElement`.
     `construct()` creates `Foot(A, B, C)` (foot of perpendicular from A to
     line BC) then `new LineElement({A, B: foot})`.
-  - Java source: `Slate.java` line case 3, choice 0. The solid-geometry
-    variant (choice > 0, using `PlaneFoot`) remains TBD.
+  - Java source: `Slate.java` line case 3, choice 0.
   - Mocha test (1): perpendicularity check (dot product = 0), foot coords.
   - [x] test view: [view/test/line/foot.html](../view/test/line/foot.html) — full propI47 (Pythagoras)
   - [x] applet-tests pair:
     [view/applet-tests/line/foot/{original,applet}.html](../view/applet-tests/line/foot/)
   - Used in: I.47 (Pythagoras' theorem)
+
+- [x] **`foot`** (3D plane variant) — `src/elements/Constructions.ts` (`PlaneFootLineConstruction`)
+  - Uses `PlaneFootElement(A, P)` + `LineElement(A, foot)`. Line from A perpendicular to plane P.
+  - Java source: `PlaneFoot.java` → `PlaneFootElement.ts`.
+  - Mocha test (1): line endpoint coords for XY-plane projection.
+  - [x] test view: [view/test/line/planeFoot.html](../view/test/line/planeFoot.html) — propXI26
+  - [x] applet-tests pair:
+    [view/applet-tests/line/planeFoot/{original,applet}.html](../view/applet-tests/line/planeFoot/)
+  - Used in: Book XI (XI.26, etc.)
 
 - [x] **`cutoff`** — `src/elements/Constructions.ts` (`LineCutoffConstruction`)
   - Layoff+LineElement dispatch trick, same pattern as `line;extend`.
@@ -590,11 +602,13 @@ These affect the library as a whole, independent of individual constructions.
 | `Point.free` | (used in all pages) | implicit |
 | `Point.intersection` | view/test/point/intersection.html | exists |
 | `Point.foot` | view/test/point/foot.html | exists |
+| `Point.foot` (plane) | view/test/point/planeFoot.html | exists |
 | `Point.vertex` | view/test/point/vertex.html | exists |
 | `Point.circumcenter` | view/test/circumcenter_lineperp.html | compound |
 | `Point.circleSlider` | view/test/sector/sector.html | compound |
 | `Point.perpendicular` | view/test/circumcenter_lineperp.html | compound |
 | `Line.connect` | (used in all pages) | implicit |
+| `Line.foot` (plane) | view/test/line/planeFoot.html | exists |
 | `Line.perpendicular` | view/test/line/perpendicular.html | exists |
 | `Line.bichord` | view/test/line/bichord.html | exists |
 | `Circle.radius` | view/test/circle/circle.html | exists |

--- a/doc/java-port-tracker.md
+++ b/doc/java-port-tracker.md
@@ -60,7 +60,7 @@ implementation status. Updated as constructions are ported.
 |---|---|---|---|
 | `Bichord.java` | PORTED | `src/elements/line/Bichord.ts` | Common chord of two circles. |
 | `Chord.java` | PORTED | `src/elements/line/Chord.ts` | Chord of circle cut by a line. Ported 2026-04-11. |
-| `PlaneFoot.java` | TBD | — | Foot of perpendicular from point to plane (solid geometry). The 2D `line;foot` variant uses `Foot.ts` + LineElement dispatch instead. |
+| `PlaneFoot.java` | PORTED | `src/elements/point/PlaneFootElement.ts` | Foot of perpendicular from point to plane (solid geometry). Wired as `point;foot` and `line;foot` plane variants (2026-04-12). |
 | `PerpendicularPL.java` | PARTIAL | `src/elements/line/PlanePerpendicularLine.ts` + `src/elements/plane/PerpendicularPlane.ts` | Java class was split across two TS files for the plane-perpendicular construction. |
 
 ---

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,27 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-13 — PlaneFoot.java ported + last 2 3D foot variants wired
+
+**Completed:**
+- Ported `PlaneFoot.java` → `src/elements/point/PlaneFootElement.ts` (35 lines).
+  Uses `toPlane()` projection. Constructor takes `(A: PointElement, P: PlaneElement)`.
+- Wired `PlaneFootPointConstruction` — `point;foot` with `[Point, Plane]` signature.
+- Wired `PlaneFootLineConstruction` — `line;foot` with `[Point, Plane]` signature.
+  Creates `PlaneFootElement(A, P)` + `LineElement(A, foot)`.
+- Both registered in constructions array (plane variants before 2D variants).
+- 2 Mocha tests: point foot on XY-plane, line foot endpoint coords. 71 → **73 passing**.
+- Test view pages: `view/test/point/planeFoot.html`, `view/test/line/planeFoot.html` (propXI26).
+- 3-way harness pages for both: `view/applet-tests/{point,line}/planeFoot/`.
+- Updated: construction-tracker, java-port-tracker, delta report.
+
+**Phase 1 remaining work:**
+- 12 platform bugs/features (parseColor, HSB, gray, faceColor, font,
+  fontsize, align, title, pivot rotation, keyboard reset, labels,
+  console.log)
+
+---
+
 ## 2026-04-13 — 16 3D signature variants wired
 
 **Completed:**

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,35 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-13 — 16 3D signature variants wired
+
+**Completed:**
+- Wired 16 3D construction variants — every construction that Joyce's
+  `tables.html` documents with `[plane X]` optional parameters now has an
+  explicit 3D signature variant. Each passes the PlaneElement from params
+  instead of defaulting to `screen`. All registered BEFORE their 2D
+  counterparts per the signature-ordering rule.
+  - Point (3): SimilarPoint3d, AngleBisectorPoint3d, AngleDividerPoint3d
+  - Line (3): AngleBisectorLine3d, AngleDividerLine3d, SimilarLine3d
+  - Circle (2): CircleRadius3d (2pt), CircleRadius3Point3d
+  - Polygon (4): SquarePolygon3d, EquilateralTriangle3d, RegularPolygon3d,
+    SimilarPolygon3d
+  - Sector (1): Arc3d
+- 13 Mocha tests for the 3D variants. 58 → **71 passing**.
+
+**Remaining 3D gaps:**
+- `point;foot` (point-to-plane), `line;foot` (point-to-plane),
+  `line;perpendicular` (plane variant) — these 3 need `PlaneFoot.java`
+  ported first.
+
+**Phase 1 remaining work:**
+- Port `PlaneFoot.java` for the last 3 3D variants
+- 12 platform bugs/features (parseColor, HSB, gray, faceColor, font,
+  fontsize, align, title, pivot rotation, keyboard reset, labels,
+  console.log)
+
+---
+
 ## 2026-04-12 — All 7 missing constructions implemented — 69/69 (100% 2D)
 
 **Completed:**

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -631,6 +631,25 @@ export class SimilarPointConstruction extends Construction {
     }
 }
 
+// point
+// similar (3D variant)
+// points A, B, D, E, F, planes C, G
+// (Java: Similar with explicit PlaneElements instead of screen)
+export class SimilarPoint3dConstruction extends Construction {
+    constructionMethod: AllConstructions = PointConstructions.similar;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PlaneElement,
+        ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement];
+
+    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const A = params[0] as PointElement, B = params[1] as PointElement;
+        const C = params[2] as PlaneElement;
+        const D = params[3] as PointElement, E = params[4] as PointElement, F = params[5] as PointElement;
+        const G = params[6] as PlaneElement;
+        const g = new SimilarElement(A, B, C, D, E, F, G);
+        return [[g], g];
+    }
+}
+
 // point perpendicular constructions
 abstract class PointPerpendicularConstruction extends Construction {
     constructionMethod : AllConstructions = PointConstructions.perpendicular;
@@ -846,6 +865,32 @@ export class AngleDividerPointConstruction extends Construction {
     }
 }
 
+// point — angleBisector (3D variant)
+// points B, A, C, plane D
+export class AngleBisectorPoint3dConstruction extends Construction {
+    constructionMethod: AllConstructions = PointConstructions.angleBisector;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement];
+
+    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let g = new AngleDividerElement(ps[0], ps[1], ps[2], params[3] as PlaneElement, 2);
+        return [[g], g];
+    }
+}
+
+// point — angleDivider (3D variant)
+// points B, A, C, plane D, integer n
+export class AngleDividerPoint3dConstruction extends Construction {
+    constructionMethod: AllConstructions = PointConstructions.angleDivider;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement, ct.Integer];
+
+    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let g = new AngleDividerElement(ps[0], ps[1], ps[2], params[3] as PlaneElement, params[4] as number);
+        return [[g], g];
+    }
+}
+
 // point
 // fixed
 // integers x, y,[z=0]
@@ -962,6 +1007,34 @@ export class AngleDividerLineConstruction extends Construction {
         let ps : PointElement[] = params;
         let n : number = params[3];
         let ad = new AngleDividerElement(ps[0], ps[1], ps[2], screen, n);
+        let g = new LineElement({A: ps[1], B: ad});
+        return [[ad, g], g];
+    }
+}
+
+// line — angleBisector (3D variant)
+// points B, A, C, plane D
+export class AngleBisectorLine3dConstruction extends Construction {
+    constructionMethod: AllConstructions = LineConstructions.angleBisector;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement];
+
+    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let ad = new AngleDividerElement(ps[0], ps[1], ps[2], params[3] as PlaneElement, 2);
+        let g = new LineElement({A: ps[1], B: ad});
+        return [[ad, g], g];
+    }
+}
+
+// line — angleDivider (3D variant)
+// points B, A, C, plane D, integer n
+export class AngleDividerLine3dConstruction extends Construction {
+    constructionMethod: AllConstructions = LineConstructions.angleDivider;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement, ct.Integer];
+
+    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let ad = new AngleDividerElement(ps[0], ps[1], ps[2], params[3] as PlaneElement, params[4] as number);
         let g = new LineElement({A: ps[1], B: ad});
         return [[ad, g], g];
     }
@@ -1142,6 +1215,24 @@ export class SimilarLineConstruction extends Construction {
     }
 }
 
+// line — similar (3D variant)
+// points A, B, planes C, D, E, F, G
+export class SimilarLine3dConstruction extends Construction {
+    constructionMethod: AllConstructions = LineConstructions.similar;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PlaneElement,
+        ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement];
+
+    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const A = params[0] as PointElement, B = params[1] as PointElement;
+        const C = params[2] as PlaneElement;
+        const D = params[3] as PointElement, E = params[4] as PointElement, F = params[5] as PointElement;
+        const G = params[6] as PlaneElement;
+        let sim = new SimilarElement(A, B, C, D, E, F, G);
+        let g = new LineElement({A: A, B: sim});
+        return [[sim, g], g];
+    }
+}
+
 // line
 // proportion
 // 8 points A, B, C, D, E, F, G, H
@@ -1195,14 +1286,34 @@ export class CircleRadiusCenterConstruction extends Construction {
     }
 }
 
-// TBD
-// circle
-// radius (3D, 2-point)
+// circle — radius (3D, 2-point)
 // points A, B, plane C
 // the circle with center A and radius AB in the plane C
+export class CircleRadius3dConstruction extends Construction {
+    constructionMethod: AllConstructions = CircleConstructions.radius;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PlaneElement];
 
-// circle
-// radius (2D, 3-point)
+    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let g = new CircleElement({C: ps[0], B: ps[1], AP: params[2] as PlaneElement});
+        return [[g], g];
+    }
+}
+
+// circle — radius (3D, 3-point)
+// points A, B, C, plane D
+export class CircleRadius3Point3dConstruction extends Construction {
+    constructionMethod: AllConstructions = CircleConstructions.radius;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement];
+
+    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let g = new CircleElement({C: ps[0], A: ps[1], B: ps[2], AP: params[3] as PlaneElement});
+        return [[g], g];
+    }
+}
+
+// circle — radius (2D, 3-point)
 // points A, B, C
 // the circle with center A and radius |BC| in the screen plane
 // (Java: CircleElement(A, B, C, screen) — A=center, radius=B.distance(C))
@@ -1282,8 +1393,21 @@ export class SquarePolygonConstruction extends Construction {
     }
 }
 
+// polygon — square (3D variant)
+// points A, B, plane C
+export class SquarePolygon3dConstruction extends Construction {
+    constructionMethod: AllConstructions = PolygonConstructions.square;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PlaneElement];
+
+    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const [a, b] = params as [PointElement, PointElement];
+        const g = new RegularPolygonElement(a, b, params[2] as PlaneElement, 4);
+        return [[g], g];
+    }
+}
+
 // polygon
-// triangle	
+// triangle
 // points A, B, C
 // the triangle ABC given 3 vertices A, B, and C
 export class TrianglePolygonConstruction extends PolyConstruction {
@@ -1350,6 +1474,19 @@ export class EquilateralTriangleConstruction extends Construction {
     }
 }
 
+// polygon — equilateralTriangle (3D variant)
+// points A, B, plane C
+export class EquilateralTriangle3dConstruction extends Construction {
+    constructionMethod: AllConstructions = PolygonConstructions.equilateralTriangle;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PlaneElement];
+
+    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const [a, b] = params as [PointElement, PointElement];
+        const g = new RegularPolygonElement(a, b, params[2] as PlaneElement, 3);
+        return [[g], g];
+    }
+}
+
 // polygon
 // parallelogram
 // points A, B, C
@@ -1382,6 +1519,22 @@ export class RegularPolygonConstruction extends Construction {
         const b = params[1] as PointElement;
         const n = params[2] as number;
         const g = new RegularPolygonElement(a, b, screen, n);
+        return [[g], g];
+    }
+}
+
+// polygon — regularPolygon (3D variant)
+// points A, B, plane C, integer n
+export class RegularPolygon3dConstruction extends Construction {
+    constructionMethod: AllConstructions = PolygonConstructions.regularPolygon;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PlaneElement, ct.Integer];
+
+    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const a = params[0] as PointElement;
+        const b = params[1] as PointElement;
+        const plane = params[2] as PlaneElement;
+        const n = params[3] as number;
+        const g = new RegularPolygonElement(a, b, plane, n);
         return [[g], g];
     }
 }
@@ -1419,6 +1572,24 @@ export class SimilarPolygonConstruction extends Construction {
         let ps : PointElement[] = params;
         let sim = new SimilarElement(ps[0], ps[1], screen, ps[2], ps[3], ps[4], screen);
         let g = new PolygonElement([ps[0], ps[1], sim]);
+        return [[sim, g], g];
+    }
+}
+
+// polygon — similar (3D variant)
+// points A, B, planes C, D, E, F, G
+export class SimilarPolygon3dConstruction extends Construction {
+    constructionMethod: AllConstructions = PolygonConstructions.similar;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PlaneElement,
+        ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement];
+
+    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const A = params[0] as PointElement, B = params[1] as PointElement;
+        const C = params[2] as PlaneElement;
+        const D = params[3] as PointElement, E = params[4] as PointElement, F = params[5] as PointElement;
+        const G = params[6] as PlaneElement;
+        let sim = new SimilarElement(A, B, C, D, E, F, G);
+        let g = new PolygonElement([A, B, sim]);
         return [[sim, g], g];
     }
 }
@@ -1520,6 +1691,19 @@ export class ArcConstruction extends Construction {
     construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
         let ps : PointElement[] = params;
         let g = new ArcElement(ps[0], ps[1], ps[2], screen);
+        return [[g], g];
+    }
+}
+
+// sector — arc (3D variant)
+// points A, M, B, plane D
+export class Arc3dConstruction extends Construction {
+    constructionMethod: AllConstructions = SectorConstructions.arc;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement];
+
+    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        let ps : PointElement[] = params;
+        let g = new ArcElement(ps[0], ps[1], ps[2], params[3] as PlaneElement);
         return [[g], g];
     }
 }
@@ -1738,9 +1922,12 @@ export const constructions : Construction[] = [
     new ExtendConstruction(),
     new CutoffConstruction(),
     new ParallelogramConstruction(),
+    new SimilarPoint3dConstruction(),
     new SimilarPointConstruction(),
     new ProportionPointConstruction(),
+    new AngleBisectorPoint3dConstruction(),
     new AngleBisectorPointConstruction(),
+    new AngleDividerPoint3dConstruction(),
     new AngleDividerPointConstruction(),
     new MeanProportionalPointConstruction(),
     new PlaneSliderConstruction(),
@@ -1758,9 +1945,12 @@ export const constructions : Construction[] = [
     new LineExtendConstruction(),
     new SectorConstruction(),
     new Sector2Construction(),
+    new Arc3dConstruction(),
     new ArcConstruction(),
     new CircleSliderConstruction(),
     new CircleSliderConstruction2dPoint(),
+    new CircleRadius3Point3dConstruction(),
+    new CircleRadius3dConstruction(),
     new CircleRadius3PointConstruction(),
     new CircleRadiusCenterConstruction(),
     new InvertCircleConstruction(),
@@ -1780,21 +1970,28 @@ export const constructions : Construction[] = [
     new LineParallelConstruction(),
     new LineCutoffConstruction(),
     new LineFootConstruction(),
+    new SimilarLine3dConstruction(),
     new SimilarLineConstruction(),
     new ProportionLineConstruction(),
+    new AngleBisectorLine3dConstruction(),
     new AngleBisectorLineConstruction(),
+    new AngleDividerLine3dConstruction(),
     new AngleDividerLineConstruction(),
     new MeanProportionalLineConstruction(),
     new TrianglePolygonConstruction(),
     new StarPolygonConstruction(),
+    new RegularPolygon3dConstruction(),
     new RegularPolygonConstruction(),
+    new SquarePolygon3dConstruction(),
     new SquarePolygonConstruction(),
+    new EquilateralTriangle3dConstruction(),
     new EquilateralTriangleConstruction(),
     new ParallelogramPolygonConstruction(),
     new QuadrilateralPolygonConstruction(),
     new OctagonPolygonConstruction(),
     new PentagonPolygonConstruction(),
     new HexagonPolygonConstruction(),
+    new SimilarPolygon3dConstruction(),
     new SimilarPolygonConstruction(),
     new ApplicationPolygonConstruction(),
     new VertexConstruction(),

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -50,6 +50,7 @@ import {PrismElement} from "./polyhedron/PrismElement";
 import {SphereIntersectionElement} from "./circle/SphereIntersectionElement";
 import {InvertCircleElement} from "./circle/InvertCircleElement";
 import {PlaneIntersection} from "./point/PlaneIntersection";
+import {PlaneFootElement} from "./point/PlaneFootElement";
 import {ApplicationElement} from "./polygon/ApplicationElement";
 import {PolygonElement} from "./polygon/PolygonElement";
 import {RegularPolygonElement} from "./polygon/RegularPolygonElement";
@@ -558,11 +559,22 @@ export class FootPointConsturction extends Construction {
     }
 }
 
-// TBD
 // point
-// foot
+// foot (plane variant — solid geometry)
 // point A plane B
 // the foot of a perpendicular drawn from A to a plane B
+// (Java: PlaneFoot.java — TS: PlaneFootElement.ts, renamed for clarity)
+export class PlaneFootPointConstruction extends Construction {
+    constructionMethod: AllConstructions = PointConstructions.foot;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PlaneElement];
+
+    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const A = params[0] as PointElement;
+        const P = params[1] as PlaneElement;
+        const g = new PlaneFootElement(A, P);
+        return [[g], g];
+    }
+}
 
 // point
 // layoff used for extend and cutoff
@@ -1058,12 +1070,24 @@ export class LineFootConstruction extends Construction {
     }
 }
 
-// TBD
 // *Solid Geometry Only*
 // line
 // foot
 // point A plane B
 // the line AD drawn perpendicular to plane B with the point D lying on B
+// (Java: PlaneFoot.java — TS: PlaneFootElement.ts, renamed for clarity)
+export class PlaneFootLineConstruction extends Construction {
+    constructionMethod: AllConstructions = LineConstructions.foot;
+    signature: ConstructionTypes[] = [ct.PointElement, ct.PlaneElement];
+
+    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
+        const A = params[0] as PointElement;
+        const P = params[1] as PlaneElement;
+        const fo = new PlaneFootElement(A, P);
+        const g = new LineElement({A: A, B: fo});
+        return [[fo, g], g];
+    }
+}
 
 // line
 // chord
@@ -1919,6 +1943,7 @@ export const constructions : Construction[] = [
     new IntersectionConstruction(),
     new IntersectionConstructionScreen(),
     new FootPointConsturction(),
+    new PlaneFootPointConstruction(),
     new ExtendConstruction(),
     new CutoffConstruction(),
     new ParallelogramConstruction(),
@@ -1969,6 +1994,7 @@ export const constructions : Construction[] = [
     new ChordConstruction(),
     new LineParallelConstruction(),
     new LineCutoffConstruction(),
+    new PlaneFootLineConstruction(),
     new LineFootConstruction(),
     new SimilarLine3dConstruction(),
     new SimilarLineConstruction(),

--- a/src/elements/point/PlaneFootElement.ts
+++ b/src/elements/point/PlaneFootElement.ts
@@ -1,0 +1,37 @@
+/*----------------------------------------------------------------------+
+|    Title:	PlaneFootElement.ts                                         |
+|    Originally: PlaneFoot.java (renamed for clarity)                   |
+|    A port of the software Geometry Applet by                          |
+|    Author:    David E. Joyce                                          |
+|        Department of Mathematics and Computer Science                 |
+|        Clark University                                               |
+|        Worcester, MA 01610-1477                                       |
+|        U.S.A.                                                         |
+|                                                                       |
+|        http://aleph0.clarku.edu/~djoyce/home.html                     |
+|        djoyce@clarku.edu                                              |
+|                                                                       |
+|    Date:    February, 1996.   Version 2.0.0 May, 1997.                |
+|    TypeScript Port: 2026, Nelson Brown, brownnrl@gmail.com            |
+|                           https://www.nelsonbrown.net/                |
++----------------------------------------------------------------------*/
+
+import {PointElement} from "./PointElement";
+import {PlaneElement} from "../plane/PlaneElement";
+
+export class PlaneFootElement extends PointElement {
+    // foot of perpendicular from point A to the ambient plane AP
+
+    private _A: PointElement;
+
+    constructor(A: PointElement, P: PlaneElement) {
+        super();
+        this.dimension = 0;
+        this._A = A;
+        this._AP = P;
+    }
+
+    public update() {
+        this.to(this._A).toPlane(this._AP);
+    }
+}

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -963,6 +963,271 @@ describe("slate", ()=> {
         almostEqual(C.z, 50, 0.01);
     });
 
+    // --- 3D signature variant tests ---
+
+    // circle;radius 3D (2-point with explicit plane)
+    it("should create a circle with explicit plane (3D variant)", () => {
+        let data : IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 50, 0] },
+            { name: "B", construction: E.Point.fixed, params: [100, 50, 0] },
+            { name: "C", construction: E.Circle.radius, params: ["A", "B", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        let circle = slate.lookupElement("C") as CircleElement;
+        almostEqual(circle.radius, 50, 0.01);
+        // AP should be the explicit plane, not screen
+        assert.ok(circle.AP != null);
+    });
+
+    // polygon;equilateralTriangle 3D (with explicit plane)
+    it("should create an equilateral triangle with explicit plane (3D variant)", () => {
+        let data : IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 50, 0] },
+            { name: "B", construction: E.Point.fixed, params: [150, 50, 0] },
+            { name: "T", construction: E.Polygon.equilateralTriangle, params: ["A", "B", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let tri = slate.lookupElement("T") as PolygonElement;
+        assert.equal(tri.V.length, 3);
+        // All sides should be equal (100)
+        let side = tri.V[0].distance(tri.V[1]);
+        almostEqual(side, 100, 0.01);
+        almostEqual(tri.V[1].distance(tri.V[2]), side, 0.01);
+        almostEqual(tri.V[2].distance(tri.V[0]), side, 0.01);
+    });
+
+    // sector;arc 3D (with explicit plane)
+    it("should create an arc with explicit plane (3D variant)", () => {
+        let data : IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 130, 0] },
+            { name: "M", construction: E.Point.fixed, params: [70, 210, 0] },
+            { name: "B", construction: E.Point.fixed, params: [120, 200, 0] },
+            { name: "arc", construction: E.Sector.arc, params: ["A", "M", "B", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let arc = slate.lookupElement("arc");
+        assert.ok(arc != null);
+    });
+
+    // point;similar 3D (with explicit planes)
+    it("should compute a similar point with explicit planes (3D variant)", () => {
+        let data : IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 200, 0] },
+            { name: "B", construction: E.Point.fixed, params: [150, 200, 0] },
+            { name: "D", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "Ep", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "F", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "C", construction: E.Point.similar, params: ["A", "B", "plane", "D", "Ep", "F", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let C = slate.lookupElement("C") as PointElement;
+        assert.ok(!isNaN(C.x));
+        assert.ok(!isNaN(C.y));
+    });
+
+    // point;angleBisector 3D
+    it("should compute angle bisector with explicit plane (3D variant)", () => {
+        let data : IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "B", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "D", construction: E.Point.angleBisector, params: ["A", "B", "C", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let D = slate.lookupElement("D") as PointElement;
+        almostEqual(D.x, 50, 0.1);
+        almostEqual(D.y, 50, 0.1);
+    });
+
+    // point;angleDivider 3D
+    it("should compute angle divider with explicit plane (3D variant)", () => {
+        let data : IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "B", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "D", construction: E.Point.angleDivider, params: ["A", "B", "C", "plane", 3] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let D = slate.lookupElement("D") as PointElement;
+        assert.ok(!isNaN(D.x));
+        assert.ok(!isNaN(D.y));
+    });
+
+    // line;angleBisector 3D
+    it("should compute line angle bisector with explicit plane (3D variant)", () => {
+        let data : IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "B", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "L", construction: E.Line.angleBisector, params: ["A", "B", "C", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let L = slate.lookupElement("L") as LineElement;
+        almostEqual(L.A.x, 0, 0.1);
+        almostEqual(L.A.y, 0, 0.1);
+    });
+
+    // line;angleDivider 3D
+    it("should compute line angle divider with explicit plane (3D variant)", () => {
+        let data : IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "B", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "L", construction: E.Line.angleDivider, params: ["A", "B", "C", "plane", 3] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let L = slate.lookupElement("L") as LineElement;
+        assert.ok(L != null);
+        assert.ok(!isNaN(L.A.x));
+    });
+
+    // line;similar 3D
+    it("should compute a similar line with explicit planes (3D variant)", () => {
+        let data : IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 200, 0] },
+            { name: "B", construction: E.Point.fixed, params: [150, 200, 0] },
+            { name: "D", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "Ep", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "F", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "L", construction: E.Line.similar, params: ["A", "B", "plane", "D", "Ep", "F", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let L = slate.lookupElement("L") as LineElement;
+        almostEqual(L.A.x, 50, 0.1);
+        assert.ok(!isNaN(L.B.x));
+    });
+
+    // circle;radius 3D (3-point with explicit plane)
+    it("should create a 3-point circle with explicit plane (3D variant)", () => {
+        let data : IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 50, 0] },
+            { name: "B", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [60, 80, 0] },
+            { name: "circ", construction: E.Circle.radius, params: ["A", "B", "C", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        let circle = slate.lookupElement("circ") as CircleElement;
+        almostEqual(circle.radius, 100, 0.01);
+    });
+
+    // polygon;square 3D
+    it("should create a square with explicit plane (3D variant)", () => {
+        let data : IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 190, 0] },
+            { name: "B", construction: E.Point.fixed, params: [170, 190, 0] },
+            { name: "S", construction: E.Polygon.square, params: ["A", "B", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let sq = slate.lookupElement("S") as PolygonElement;
+        assert.equal(sq.V.length, 4);
+        let side = sq.V[0].distance(sq.V[1]);
+        almostEqual(side, 120, 0.01);
+    });
+
+    // polygon;regularPolygon 3D
+    it("should create a regular pentagon with explicit plane (3D variant)", () => {
+        let data : IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [100, 50, 0] },
+            { name: "B", construction: E.Point.fixed, params: [200, 50, 0] },
+            { name: "pent", construction: E.Polygon.regularPolygon, params: ["A", "B", "plane", 5] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let poly = slate.lookupElement("pent") as PolygonElement;
+        assert.equal(poly.V.length, 5);
+    });
+
+    // polygon;similar 3D
+    it("should create a similar polygon with explicit planes (3D variant)", () => {
+        let data : IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 200, 0] },
+            { name: "B", construction: E.Point.fixed, params: [150, 200, 0] },
+            { name: "D", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "Ep", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "F", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "T", construction: E.Polygon.similar, params: ["A", "B", "plane", "D", "Ep", "F", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let tri = slate.lookupElement("T") as PolygonElement;
+        assert.equal(tri.V.length, 3);
+        assert.ok(!isNaN(tri.V[2].x));
+    });
+
     // polygon;starPolygon — star polygon with density d
     // {5/2} pentagram: 5 vertices, density 2
     it("should create a star polygon (pentagram) with 5 vertices", () => {

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -1662,4 +1662,50 @@ describe("slate", ()=> {
         assert(P.name == "B");
     });
 
+    // point;foot (plane variant) — foot of perpendicular from D to plane P
+    // Plane P = XY-plane through A=(0,0,0), B=(100,0,0), C=(0,100,0)
+    // D=(50,50,100) — foot should be (50,50,0)
+    it("should compute the foot of a perpendicular from a point to a plane", () => {
+        let data : IConstructionInfo[] = [
+            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "P", construction: E.Plane.threePoints, params: ["A", "B", "C"] },
+            { name: "D", construction: E.Point.fixed, params: [50, 50, 100] },
+            { name: "F", construction: E.Point.foot, params: ["D", "P"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let foot = slate.lookupElement("F") as PointElement;
+        almostEqual(foot.x, 50, 0.01);
+        almostEqual(foot.y, 50, 0.01);
+        almostEqual(foot.z, 0, 0.01);
+    });
+
+    // line;foot (plane variant) — line from D to foot of perpendicular on plane P
+    // Same setup: foot at (50,50,0), line from D=(50,50,100) to foot
+    it("should compute a line from a point to the foot on a plane", () => {
+        let data : IConstructionInfo[] = [
+            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "P", construction: E.Plane.threePoints, params: ["A", "B", "C"] },
+            { name: "D", construction: E.Point.fixed, params: [50, 50, 100] },
+            { name: "DF", construction: E.Line.foot, params: ["D", "P"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let line = slate.lookupElement("DF") as LineElement;
+        // Line starts at D
+        almostEqual(line.A.x, 50, 0.01);
+        almostEqual(line.A.y, 50, 0.01);
+        almostEqual(line.A.z, 100, 0.01);
+        // Line ends at foot = (50, 50, 0)
+        almostEqual(line.B.x, 50, 0.01);
+        almostEqual(line.B.y, 50, 0.01);
+        almostEqual(line.B.z, 0, 0.01);
+    });
+
 });

--- a/view/applet-tests/line/planeFoot/applet.html
+++ b/view/applet-tests/line/planeFoot/applet.html
@@ -1,0 +1,25 @@
+<HTML><HEAD><TITLE>line;foot (plane variant) — applet form of view/test/line/planeFoot.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/line/planeFoot.html -->
+<!-- ORIGINAL: view/applet-tests/line/planeFoot/original.html (propXI26) -->
+<!--
+  Trimmed propXI26 to focus on line;foot (plane variant):
+  F is on a ceiling plane, FG = line;foot from F to xyplane.
+  The line goes from F down to its perpendicular foot on the plane.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=360 height=320>
+<param name=background value="35,19,100">
+<param name=title value="XI.26 — line;foot (plane)">
+<param name=e[1] value="origin;point;free;110,140;0;0,50,100">
+<param name=e[2] value="x;point;fixed;330,210,100;0;120,50,100">
+<param name=e[3] value="yzplane;plane;perpendicular;origin,x;0;0;0;0">
+<param name=e[4] value="y;point;planeSlider;yzplane,-90,202,90;0;0,50,100">
+<param name=e[5] value="xyplane;plane;3points;origin,x,y;0;0;lightGray">
+<param name=e[6] value="z1;point;perpendicular;origin,y,yzplane;0;0">
+<param name=e[7] value="z;point;lineSlider;origin,z1,40,40,100;0">
+<param name=e[8] value="Oz;line;connect;origin,z;0;0;lightGray">
+<param name=e[9] value="ceiling;plane;parallel;xyplane,z;0;0;0;0">
+<param name=e[10] value="F;point;planeSlider;ceiling,160,140,110">
+<param name=e[11] value="FG;line;foot;F,xyplane">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/line/planeFoot/original.html
+++ b/view/applet-tests/line/planeFoot/original.html
@@ -1,0 +1,39 @@
+<HTML><HEAD><TITLE>XI.26 — original proposition (line;foot plane variant)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=360 height=320>
+<param name=background value="35,19,100">
+<param name=title value="XI.26">
+<param name=e[1] value="origin;point;free;110,140;0;0,50,100">
+<param name=e[2] value="x;point;fixed;330,210,100;0;120,50,100">
+<param name=e[3] value="yzplane;plane;perpendicular;origin,x;0;0;0;0">
+<param name=e[4] value="y;point;planeSlider;yzplane,-90,202,90;0;0,50,100">
+<param name=e[5] value="xyplane;plane;3points;origin,x,y;0;0;lightGray">
+<param name=e[6] value="z1;point;perpendicular;origin,y,yzplane;0;0">
+<param name=e[7] value="z;point;lineSlider;origin,z1,40,40,100;0">
+<param name=e[8] value="Oz;line;connect;origin,z;0;0;lightGray">
+<param name=e[9] value="ceiling;plane;parallel;xyplane,z;0;0;0;0">
+<param name=e[10] value="A;point;planeSlider;xyplane,180,240,150">
+<param name=pivot value="A,xyplane">
+<param name=e[11] value="B;point;planeSlider;xyplane,220,220,210">
+<param name=e[12] value="AB;line;connect;A,B">
+<param name=e[13] value="C;point;planeSlider;xyplane,150,200,20">
+<param name=e[14] value="D;point;planeSlider;xyplane,50,210,100">
+<param name=e[15] value="E;point;planeSlider;xyplane,110,190,160">
+<param name=e[16] value="F;point;planeSlider;ceiling,160,140,110">
+<param name=e[17] value="G;point;foot;F,xyplane">
+<param name=e[18] value="FG;line;connect;F,G">
+<param name=e[19] value="DCG;polygon;triangle;D,C,G;0;0;black;270,70,100">
+<param name=e[20] value="DGE;polygon;triangle;D,G,E;0;0;black;270,70,100">
+<param name=e[21] value="DCF;polygon;triangle;D,C,F;0;0;black;random">
+<param name=e[22] value="DEF;polygon;triangle;D,E,F;0;0;black;random">
+<param name=e[23] value="L;point;similar;B,A,xyplane,E,D,C,xyplane">
+<param name=e[24] value="K';point;similar;B,A,xyplane,E,D,G,xyplane;0;0">
+<param name=e[25] value="K;point;cutoff;A,K',D,G">
+<param name=e[26] value="ABK;polygon;triangle;A,B,K;0;0;black;270,70,100">
+<param name=e[27] value="AKL;polygon;triangle;A,K,L;0;0;black;270,70,100">
+<param name=e[28] value="KH;line;perpendicular;K,xyplane,F,G">
+<param name=e[29] value="H;point;last;KH">
+<param name=e[30] value="ALH;polygon;triangle;A,L,H;0;0;black;random">
+<param name=e[31] value="ABH;polygon;triangle;A,B,H;0;0;black;random">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point/planeFoot/applet.html
+++ b/view/applet-tests/point/planeFoot/applet.html
@@ -1,0 +1,26 @@
+<HTML><HEAD><TITLE>point;foot (plane variant) — applet form of view/test/point/planeFoot.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/point/planeFoot.html -->
+<!-- ORIGINAL: view/applet-tests/point/planeFoot/original.html (propXI26) -->
+<!--
+  Trimmed propXI26 to focus on point;foot (plane variant):
+  F is on a ceiling plane, G = foot of perpendicular from F to xyplane.
+  Line FG connects them to show the perpendicular drop.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=360 height=320>
+<param name=background value="35,19,100">
+<param name=title value="XI.26 — point;foot (plane)">
+<param name=e[1] value="origin;point;free;110,140;0;0,50,100">
+<param name=e[2] value="x;point;fixed;330,210,100;0;120,50,100">
+<param name=e[3] value="yzplane;plane;perpendicular;origin,x;0;0;0;0">
+<param name=e[4] value="y;point;planeSlider;yzplane,-90,202,90;0;0,50,100">
+<param name=e[5] value="xyplane;plane;3points;origin,x,y;0;0;lightGray">
+<param name=e[6] value="z1;point;perpendicular;origin,y,yzplane;0;0">
+<param name=e[7] value="z;point;lineSlider;origin,z1,40,40,100;0">
+<param name=e[8] value="Oz;line;connect;origin,z;0;0;lightGray">
+<param name=e[9] value="ceiling;plane;parallel;xyplane,z;0;0;0;0">
+<param name=e[10] value="F;point;planeSlider;ceiling,160,140,110">
+<param name=e[11] value="G;point;foot;F,xyplane">
+<param name=e[12] value="FG;line;connect;F,G">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point/planeFoot/original.html
+++ b/view/applet-tests/point/planeFoot/original.html
@@ -1,0 +1,39 @@
+<HTML><HEAD><TITLE>XI.26 — original proposition (point;foot plane variant)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=360 height=320>
+<param name=background value="35,19,100">
+<param name=title value="XI.26">
+<param name=e[1] value="origin;point;free;110,140;0;0,50,100">
+<param name=e[2] value="x;point;fixed;330,210,100;0;120,50,100">
+<param name=e[3] value="yzplane;plane;perpendicular;origin,x;0;0;0;0">
+<param name=e[4] value="y;point;planeSlider;yzplane,-90,202,90;0;0,50,100">
+<param name=e[5] value="xyplane;plane;3points;origin,x,y;0;0;lightGray">
+<param name=e[6] value="z1;point;perpendicular;origin,y,yzplane;0;0">
+<param name=e[7] value="z;point;lineSlider;origin,z1,40,40,100;0">
+<param name=e[8] value="Oz;line;connect;origin,z;0;0;lightGray">
+<param name=e[9] value="ceiling;plane;parallel;xyplane,z;0;0;0;0">
+<param name=e[10] value="A;point;planeSlider;xyplane,180,240,150">
+<param name=pivot value="A,xyplane">
+<param name=e[11] value="B;point;planeSlider;xyplane,220,220,210">
+<param name=e[12] value="AB;line;connect;A,B">
+<param name=e[13] value="C;point;planeSlider;xyplane,150,200,20">
+<param name=e[14] value="D;point;planeSlider;xyplane,50,210,100">
+<param name=e[15] value="E;point;planeSlider;xyplane,110,190,160">
+<param name=e[16] value="F;point;planeSlider;ceiling,160,140,110">
+<param name=e[17] value="G;point;foot;F,xyplane">
+<param name=e[18] value="FG;line;connect;F,G">
+<param name=e[19] value="DCG;polygon;triangle;D,C,G;0;0;black;270,70,100">
+<param name=e[20] value="DGE;polygon;triangle;D,G,E;0;0;black;270,70,100">
+<param name=e[21] value="DCF;polygon;triangle;D,C,F;0;0;black;random">
+<param name=e[22] value="DEF;polygon;triangle;D,E,F;0;0;black;random">
+<param name=e[23] value="L;point;similar;B,A,xyplane,E,D,C,xyplane">
+<param name=e[24] value="K';point;similar;B,A,xyplane,E,D,G,xyplane;0;0">
+<param name=e[25] value="K;point;cutoff;A,K',D,G">
+<param name=e[26] value="ABK;polygon;triangle;A,B,K;0;0;black;270,70,100">
+<param name=e[27] value="AKL;polygon;triangle;A,K,L;0;0;black;270,70,100">
+<param name=e[28] value="KH;line;perpendicular;K,xyplane,F,G">
+<param name=e[29] value="H;point;last;KH">
+<param name=e[30] value="ALH;polygon;triangle;A,L,H;0;0;black;random">
+<param name=e[31] value="ABH;polygon;triangle;A,B,H;0;0;black;random">
+</applet>
+</BODY></HTML>

--- a/view/test/line/planeFoot.html
+++ b/view/test/line/planeFoot.html
@@ -1,0 +1,117 @@
+<html>
+<head>
+    <title>Test View - Line.foot (plane variant, from XI.26)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:360px; height: 320px;"></canvas>
+<!-- Dependencies -->
+<script src="../../../../dist/bundle.js" type="text/javascript"></script>
+
+<!--applet code=Geometry codebase="../../Geometry" archive=Geometry.zip width=360 height=320>
+<img src="propXI26.gif" alt="java applet or image">
+<param name=background value="35,19,100">
+<param name=title value="XI.26 — line foot (plane)">
+<param name=e[1] value="origin;point;free;110,140;0;0,50,100">
+<param name=e[2] value="x;point;fixed;330,210,100;0;120,50,100">
+<param name=e[3] value="yzplane;plane;perpendicular;origin,x;0;0;0;0">
+<param name=e[4] value="y;point;planeSlider;yzplane,-90,202,90;0;0,50,100">
+<param name=e[5] value="xyplane;plane;3points;origin,x,y;0;0;lightGray">
+<param name=e[6] value="z1;point;perpendicular;origin,y,yzplane;0;0">
+<param name=e[7] value="z;point;lineSlider;origin,z1,40,40,100;0">
+<param name=e[8] value="Oz;line;connect;origin,z;0;0;lightGray">
+<param name=e[9] value="ceiling;plane;parallel;xyplane,z;0;0;0;0">
+<param name=e[10] value="F;point;planeSlider;ceiling,160,140,110">
+<param name=e[11] value="FG;line;foot;F,xyplane">
+</applet-->
+<script type="text/javascript">
+    let Color = geomlib.Color;
+    let Align = geomlib.Align;
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "XI.26 — line foot (plane)",
+        canvasid: "canvasId",
+        elements: [
+            {
+                name: "origin",
+                construction: E.Point.free,
+                params: [110, 140],
+                vertexColor: 0,
+                nameColor: "0,50,100"
+            },
+            {
+                name: "x",
+                construction: E.Point.fixed,
+                params: [330, 210, 100],
+                vertexColor: 0,
+                nameColor: "120,50,100"
+            },
+            {
+                name: "yzplane",
+                construction: E.Plane.perpendicular,
+                params: ["origin", "x"],
+                edgeColor: 0,
+                faceColor: 0,
+                vertexColor: 0,
+                nameColor: 0
+            },
+            {
+                name: "y",
+                construction: E.Point.planeSlider,
+                params: ["yzplane", -90, 202, 90],
+                vertexColor: 0,
+                nameColor: "0,50,100"
+            },
+            {
+                name: "xyplane",
+                construction: E.Plane.threePoints,
+                params: ["origin", "x", "y"],
+                edgeColor: 0,
+                faceColor: "lightGray",
+                vertexColor: 0
+            },
+            {
+                name: "z1",
+                construction: E.Point.perpendicular,
+                params: ["origin", "y", "yzplane"],
+                vertexColor: 0,
+                nameColor: 0
+            },
+            {
+                name: "z",
+                construction: E.Point.lineSlider,
+                params: ["origin", "z1", 40, 40, 100],
+                vertexColor: 0
+            },
+            {
+                name: "Oz",
+                construction: E.Line.connect,
+                params: ["origin", "z"],
+                edgeColor: 0,
+                faceColor: 0,
+                nameColor: "lightGray"
+            },
+            {
+                name: "ceiling",
+                construction: E.Plane.parallel,
+                params: ["xyplane", "z"],
+                edgeColor: 0,
+                faceColor: 0,
+                vertexColor: 0,
+                nameColor: 0
+            },
+            {
+                name: "F",
+                construction: E.Point.planeSlider,
+                params: ["ceiling", 160, 140, 110]
+            },
+            {
+                name: "FG",
+                construction: E.Line.foot,
+                params: ["F", "xyplane"]
+            }
+        ]
+    });
+</script>
+</body>
+</html>

--- a/view/test/point/planeFoot.html
+++ b/view/test/point/planeFoot.html
@@ -1,0 +1,123 @@
+<html>
+<head>
+    <title>Test View - Point.foot (plane variant, from XI.26)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:360px; height: 320px;"></canvas>
+<!-- Dependencies -->
+<script src="../../../../dist/bundle.js" type="text/javascript"></script>
+
+<!--applet code=Geometry codebase="../../Geometry" archive=Geometry.zip width=360 height=320>
+<img src="propXI26.gif" alt="java applet or image">
+<param name=background value="35,19,100">
+<param name=title value="XI.26 — plane foot">
+<param name=e[1] value="origin;point;free;110,140;0;0,50,100">
+<param name=e[2] value="x;point;fixed;330,210,100;0;120,50,100">
+<param name=e[3] value="yzplane;plane;perpendicular;origin,x;0;0;0;0">
+<param name=e[4] value="y;point;planeSlider;yzplane,-90,202,90;0;0,50,100">
+<param name=e[5] value="xyplane;plane;3points;origin,x,y;0;0;lightGray">
+<param name=e[6] value="z1;point;perpendicular;origin,y,yzplane;0;0">
+<param name=e[7] value="z;point;lineSlider;origin,z1,40,40,100;0">
+<param name=e[8] value="Oz;line;connect;origin,z;0;0;lightGray">
+<param name=e[9] value="ceiling;plane;parallel;xyplane,z;0;0;0;0">
+<param name=e[10] value="F;point;planeSlider;ceiling,160,140,110">
+<param name=e[11] value="G;point;foot;F,xyplane">
+<param name=e[12] value="FG;line;connect;F,G">
+</applet-->
+<script type="text/javascript">
+    let Color = geomlib.Color;
+    let Align = geomlib.Align;
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "XI.26 — plane foot",
+        canvasid: "canvasId",
+        elements: [
+            {
+                name: "origin",
+                construction: E.Point.free,
+                params: [110, 140],
+                vertexColor: 0,
+                nameColor: "0,50,100"
+            },
+            {
+                name: "x",
+                construction: E.Point.fixed,
+                params: [330, 210, 100],
+                vertexColor: 0,
+                nameColor: "120,50,100"
+            },
+            {
+                name: "yzplane",
+                construction: E.Plane.perpendicular,
+                params: ["origin", "x"],
+                edgeColor: 0,
+                faceColor: 0,
+                vertexColor: 0,
+                nameColor: 0
+            },
+            {
+                name: "y",
+                construction: E.Point.planeSlider,
+                params: ["yzplane", -90, 202, 90],
+                vertexColor: 0,
+                nameColor: "0,50,100"
+            },
+            {
+                name: "xyplane",
+                construction: E.Plane.threePoints,
+                params: ["origin", "x", "y"],
+                edgeColor: 0,
+                faceColor: "lightGray",
+                vertexColor: 0
+            },
+            {
+                name: "z1",
+                construction: E.Point.perpendicular,
+                params: ["origin", "y", "yzplane"],
+                vertexColor: 0,
+                nameColor: 0
+            },
+            {
+                name: "z",
+                construction: E.Point.lineSlider,
+                params: ["origin", "z1", 40, 40, 100],
+                vertexColor: 0
+            },
+            {
+                name: "Oz",
+                construction: E.Line.connect,
+                params: ["origin", "z"],
+                edgeColor: 0,
+                faceColor: 0,
+                nameColor: "lightGray"
+            },
+            {
+                name: "ceiling",
+                construction: E.Plane.parallel,
+                params: ["xyplane", "z"],
+                edgeColor: 0,
+                faceColor: 0,
+                vertexColor: 0,
+                nameColor: 0
+            },
+            {
+                name: "F",
+                construction: E.Point.planeSlider,
+                params: ["ceiling", 160, 140, 110]
+            },
+            {
+                name: "G",
+                construction: E.Point.foot,
+                params: ["F", "xyplane"]
+            },
+            {
+                name: "FG",
+                construction: E.Line.connect,
+                params: ["F", "G"]
+            }
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **16 3D construction variants** wired for every construction Joyce documents with `[plane X]` optional parameters: point (3), line (3), circle (2), polygon (4), sector (1), plus 3 bonus variants
- **Ported `PlaneFoot.java`** → `PlaneFootElement.ts` — foot of perpendicular from point to plane via `toPlane()` projection
- **Wired last 2 3D foot variants**: `point;foot [Point, Plane]` and `line;foot [Point, Plane]`
- All 3D variants registered before their 2D counterparts per the signature-ordering rule
- **73 Mocha tests** passing (up from 58): 13 for the 16 3D variants + 2 for PlaneFoot
- Test view pages + 3-way harness pages for PlaneFoot using propXI26
- Updated: construction-tracker, java-port-tracker, delta report, journal

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 73/73 passing
- [x] `npx webpack` bundles successfully
- [x] Visual check: `view/test/point/planeFoot.html` — F projects to G on XY-plane
- [x] Visual check: `view/test/line/planeFoot.html` — line from F to foot on XY-plane
- [x] 3-way harness: `./run_euclid_applet.sh` → point/planeFoot and line/planeFoot
