### PR TITLE
feat: add diagram UI controls — reset, maximize, new window

### DIFF
--- a/src/Slate.ts
+++ b/src/Slate.ts
@@ -10,7 +10,6 @@ export type SlateCanvas = HTMLCanvasElement | Canvas;
 
 export class Slate {
 
-    protected _originalElements : GeomElement[];
     protected _elements : GeomElement[];
     protected _elementsForUpdate : GeomElement[];
     protected _screen : PlaneElement;
@@ -59,7 +58,6 @@ export class Slate {
             e.faceHighlightColor = null;
             this._elements.push(e);
         }
-        this._originalElements = [...this._elements];
         this._elementsForUpdate = [...this._elements];
 
         let slate = this;
@@ -221,7 +219,10 @@ export class Slate {
     }
 
     reset() : void {
-        this._elements = [...this._originalElements];
+        for (let element of this._elements) {
+            element.reset();
+        }
+        this.update();
     }
 
     update() : void {

--- a/src/SlateControls.ts
+++ b/src/SlateControls.ts
@@ -1,0 +1,435 @@
+/*----------------------------------------------------------------------+
+|    Title:  SlateControls.ts                                           |
+|    UI overlay for geometry diagrams: reset, maximize, new window.     |
+|    Buttons are canvas-drawn icons overlaid on each Slate canvas.      |
+|    Keyboard shortcuts match the original Java applet:                 |
+|      r / space  → reset                                               |
+|      u / return → new window                                          |
+|      m          → maximize/minimize                                   |
++----------------------------------------------------------------------*/
+
+import {Slate} from "./Slate";
+
+interface IInitConfig {
+    background: string;
+    title: string;
+    align?: number;
+    canvasid?: string;
+    pivot?: string;
+    elements: any[];
+}
+
+const BTN_SIZE = 20;
+const BTN_GAP = 4;
+const BTN_MARGIN = 8;
+
+export function createControls(slate: Slate, canvas: HTMLCanvasElement, config: IInitConfig): void {
+    // Skip in headless/test environments
+    if (!canvas.parentElement) return;
+
+    let controls = new SlateControls(slate, canvas, config);
+    controls.init();
+}
+
+class SlateControls {
+    private _slate: Slate;
+    private _canvas: HTMLCanvasElement;
+    private _config: IInitConfig;
+    private _wrapper: HTMLDivElement;
+    private _maximized: boolean = false;
+    private _savedStyles: {
+        wrapperPosition: string;
+        wrapperTop: string;
+        wrapperLeft: string;
+        wrapperWidth: string;
+        wrapperHeight: string;
+        wrapperZIndex: string;
+        wrapperBackground: string;
+        canvasWidth: string;
+        canvasHeight: string;
+    } = null;
+
+    constructor(slate: Slate, canvas: HTMLCanvasElement, config: IInitConfig) {
+        this._slate = slate;
+        this._canvas = canvas;
+        this._config = config;
+    }
+
+    init(): void {
+        this._wrapper = this.createWrapper();
+        this.createButtons();
+        this.addKeyboardShortcuts();
+    }
+
+    private createWrapper(): HTMLDivElement {
+        let wrapper = document.createElement("div");
+        wrapper.style.position = "relative";
+        wrapper.style.display = "inline-block";
+
+        // Insert wrapper before canvas, then move canvas into it
+        this._canvas.parentElement.insertBefore(wrapper, this._canvas);
+        wrapper.appendChild(this._canvas);
+
+        // Make canvas focusable for keyboard shortcuts
+        this._canvas.setAttribute("tabindex", "0");
+        this._canvas.style.outline = "none"; // default no outline
+        this._canvas.addEventListener("focus", () => {
+            this._canvas.style.outline = "2px solid rgba(66,133,244,0.5)";
+        });
+        this._canvas.addEventListener("blur", () => {
+            this._canvas.style.outline = "none";
+        });
+
+        return wrapper;
+    }
+
+    private createButtons(): void {
+        let buttons = [
+            { draw: drawResetIcon, action: () => this.onReset(), title: "Reset (r)" },
+            { draw: drawMaximizeIcon, action: () => this.onMaximize(), title: "Maximize (m)" },
+            { draw: drawNewWindowIcon, action: () => this.onNewWindow(), title: "New Window (u)" },
+        ];
+
+        for (let i = 0; i < buttons.length; i++) {
+            let btn = document.createElement("button");
+            btn.style.position = "absolute";
+            btn.style.top = BTN_MARGIN + "px";
+            btn.style.right = (BTN_MARGIN + i * (BTN_SIZE + BTN_GAP)) + "px";
+            btn.style.width = BTN_SIZE + "px";
+            btn.style.height = BTN_SIZE + "px";
+            btn.style.padding = "0";
+            btn.style.border = "none";
+            btn.style.cursor = "pointer";
+            btn.style.background = "rgba(0,0,0,0.12)";
+            btn.style.borderRadius = "3px";
+            btn.title = buttons[i].title;
+
+            btn.addEventListener("mouseenter", () => {
+                btn.style.background = "rgba(0,0,0,0.3)";
+            });
+            btn.addEventListener("mouseleave", () => {
+                btn.style.background = "rgba(0,0,0,0.12)";
+            });
+
+            // Draw icon on a small canvas inside the button
+            let iconCanvas = document.createElement("canvas");
+            iconCanvas.width = BTN_SIZE;
+            iconCanvas.height = BTN_SIZE;
+            iconCanvas.style.display = "block";
+            let ctx = iconCanvas.getContext("2d");
+            buttons[i].draw(ctx, BTN_SIZE);
+            btn.appendChild(iconCanvas);
+
+            btn.addEventListener("click", (e) => {
+                e.stopPropagation();
+                buttons[i].action();
+                // Return focus to the main canvas after button click
+                this._canvas.focus();
+            });
+
+            // Store reference for maximize icon swap
+            if (i === 1) {
+                (this as any)._maxBtn = btn;
+                (this as any)._maxIconCanvas = iconCanvas;
+            }
+
+            this._wrapper.appendChild(btn);
+        }
+    }
+
+    private addKeyboardShortcuts(): void {
+        this._canvas.addEventListener("keydown", (e: KeyboardEvent) => {
+            switch (e.key) {
+                case "r":
+                case "R":
+                case " ":
+                    e.preventDefault();
+                    this.onReset();
+                    break;
+                case "u":
+                case "U":
+                case "Enter":
+                    e.preventDefault();
+                    this.onNewWindow();
+                    break;
+                case "m":
+                case "M":
+                    e.preventDefault();
+                    this.onMaximize();
+                    break;
+            }
+        });
+    }
+
+    private onReset(): void {
+        this._slate.reset();
+    }
+
+    private onMaximize(): void {
+        if (this._maximized) {
+            this.minimize();
+        } else {
+            this.maximize();
+        }
+    }
+
+    private maximize(): void {
+        // Save current styles
+        this._savedStyles = {
+            wrapperPosition: this._wrapper.style.position,
+            wrapperTop: this._wrapper.style.top,
+            wrapperLeft: this._wrapper.style.left,
+            wrapperWidth: this._wrapper.style.width,
+            wrapperHeight: this._wrapper.style.height,
+            wrapperZIndex: this._wrapper.style.zIndex,
+            wrapperBackground: this._wrapper.style.background,
+            canvasWidth: this._canvas.style.width,
+            canvasHeight: this._canvas.style.height,
+        };
+
+        // Maximize wrapper to fill viewport
+        this._wrapper.style.position = "fixed";
+        this._wrapper.style.top = "0";
+        this._wrapper.style.left = "0";
+        this._wrapper.style.width = "100vw";
+        this._wrapper.style.height = "100vh";
+        this._wrapper.style.zIndex = "9999";
+        this._wrapper.style.background = "white";
+
+        // Expand canvas to fill wrapper
+        this._canvas.style.width = "100%";
+        this._canvas.style.height = "100%";
+
+        this.resizeAndRedraw();
+        this._maximized = true;
+        this.updateMaximizeIcon();
+    }
+
+    private minimize(): void {
+        if (!this._savedStyles) return;
+
+        // Restore saved styles
+        this._wrapper.style.position = this._savedStyles.wrapperPosition;
+        this._wrapper.style.top = this._savedStyles.wrapperTop;
+        this._wrapper.style.left = this._savedStyles.wrapperLeft;
+        this._wrapper.style.width = this._savedStyles.wrapperWidth;
+        this._wrapper.style.height = this._savedStyles.wrapperHeight;
+        this._wrapper.style.zIndex = this._savedStyles.wrapperZIndex;
+        this._wrapper.style.background = this._savedStyles.wrapperBackground;
+
+        this._canvas.style.width = this._savedStyles.canvasWidth;
+        this._canvas.style.height = this._savedStyles.canvasHeight;
+
+        this.resizeAndRedraw();
+        this._maximized = false;
+        this._savedStyles = null;
+        this.updateMaximizeIcon();
+    }
+
+    private resizeAndRedraw(): void {
+        // Sync canvas internal resolution to CSS size
+        let w = this._canvas.clientWidth;
+        let h = this._canvas.clientHeight;
+        if (this._canvas.width !== w || this._canvas.height !== h) {
+            this._canvas.width = w;
+            this._canvas.height = h;
+        }
+        this._slate.update();
+    }
+
+    private updateMaximizeIcon(): void {
+        let iconCanvas = (this as any)._maxIconCanvas as HTMLCanvasElement;
+        let btn = (this as any)._maxBtn as HTMLButtonElement;
+        if (!iconCanvas) return;
+        let ctx = iconCanvas.getContext("2d");
+        ctx.clearRect(0, 0, BTN_SIZE, BTN_SIZE);
+        if (this._maximized) {
+            drawMinimizeIcon(ctx, BTN_SIZE);
+            btn.title = "Minimize (m)";
+        } else {
+            drawMaximizeIcon(ctx, BTN_SIZE);
+            btn.title = "Maximize (m)";
+        }
+    }
+
+    private onNewWindow(): void {
+        // Find the bundle.js script path from the current page
+        let scripts = document.querySelectorAll("script[src]");
+        let bundleSrc = "bundle.js";
+        for (let i = 0; i < scripts.length; i++) {
+            let src = (scripts[i] as HTMLScriptElement).src;
+            if (src.indexOf("bundle.js") >= 0) {
+                bundleSrc = src;
+                break;
+            }
+        }
+
+        let configJSON = JSON.stringify(this._config);
+        let title = this._config.title || "Geometry";
+
+        // Open maximized: use full screen dimensions, canvas fills viewport
+        let html = `<!DOCTYPE html>
+<html><head><title>${title}</title></head>
+<body style="margin:0;padding:0;overflow:hidden;">
+<canvas id="canvasId" style="width:100vw;height:100vh;"></canvas>
+<script src="${bundleSrc}"><\/script>
+<script>geomlib.init(${configJSON});<\/script>
+</body></html>`;
+
+        let newWin = window.open("", "_blank");
+        if (newWin) {
+            newWin.document.write(html);
+            newWin.document.close();
+        }
+    }
+}
+
+// --- Icon drawing functions ---
+// All draw on a size×size canvas with 3px padding
+
+function drawResetIcon(ctx: CanvasRenderingContext2D, size: number): void {
+    let cx = size / 2;
+    let cy = size / 2;
+    let r = size * 0.32;
+    let pad = 2;
+
+    ctx.strokeStyle = "rgba(0,0,0,0.7)";
+    ctx.fillStyle = "rgba(0,0,0,0.7)";
+    ctx.lineWidth = 1.5;
+
+    // Circular arc (270 degrees)
+    ctx.beginPath();
+    ctx.arc(cx, cy, r, -Math.PI * 0.5, Math.PI * 0.75);
+    ctx.stroke();
+
+    // Arrowhead at the end of the arc
+    let endAngle = Math.PI * 0.75;
+    let ax = cx + r * Math.cos(endAngle);
+    let ay = cy + r * Math.sin(endAngle);
+    let headLen = 4;
+    let a1 = endAngle + Math.PI * 0.3;
+    let a2 = endAngle + Math.PI * 0.9;
+    ctx.beginPath();
+    ctx.moveTo(ax, ay);
+    ctx.lineTo(ax + headLen * Math.cos(a1), ay + headLen * Math.sin(a1));
+    ctx.lineTo(ax + headLen * Math.cos(a2), ay + headLen * Math.sin(a2));
+    ctx.closePath();
+    ctx.fill();
+}
+
+function drawMaximizeIcon(ctx: CanvasRenderingContext2D, size: number): void {
+    let pad = 4;
+    let s = size - pad * 2;
+
+    ctx.strokeStyle = "rgba(0,0,0,0.7)";
+    ctx.fillStyle = "rgba(0,0,0,0.7)";
+    ctx.lineWidth = 1.5;
+
+    // Top-right outward arrow
+    let ax = pad + s * 0.55;
+    let ay = pad + s * 0.45;
+    let bx = pad + s;
+    let by = pad;
+    ctx.beginPath();
+    ctx.moveTo(ax, ay);
+    ctx.lineTo(bx, by);
+    ctx.stroke();
+    // Arrowhead
+    ctx.beginPath();
+    ctx.moveTo(bx, by);
+    ctx.lineTo(bx - 5, by);
+    ctx.lineTo(bx, by + 5);
+    ctx.closePath();
+    ctx.fill();
+
+    // Bottom-left outward arrow
+    ax = pad + s * 0.45;
+    ay = pad + s * 0.55;
+    bx = pad;
+    by = pad + s;
+    ctx.beginPath();
+    ctx.moveTo(ax, ay);
+    ctx.lineTo(bx, by);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(bx, by);
+    ctx.lineTo(bx + 5, by);
+    ctx.lineTo(bx, by - 5);
+    ctx.closePath();
+    ctx.fill();
+}
+
+function drawMinimizeIcon(ctx: CanvasRenderingContext2D, size: number): void {
+    let pad = 4;
+    let s = size - pad * 2;
+
+    ctx.strokeStyle = "rgba(0,0,0,0.7)";
+    ctx.fillStyle = "rgba(0,0,0,0.7)";
+    ctx.lineWidth = 1.5;
+
+    // Top-right inward arrow
+    let ax = pad + s;
+    let ay = pad;
+    let bx = pad + s * 0.55;
+    let by = pad + s * 0.45;
+    ctx.beginPath();
+    ctx.moveTo(ax, ay);
+    ctx.lineTo(bx, by);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(bx, by);
+    ctx.lineTo(bx + 5, by);
+    ctx.lineTo(bx, by - 5);
+    ctx.closePath();
+    ctx.fill();
+
+    // Bottom-left inward arrow
+    ax = pad;
+    ay = pad + s;
+    bx = pad + s * 0.45;
+    by = pad + s * 0.55;
+    ctx.beginPath();
+    ctx.moveTo(ax, ay);
+    ctx.lineTo(bx, by);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(bx, by);
+    ctx.lineTo(bx - 5, by);
+    ctx.lineTo(bx, by + 5);
+    ctx.closePath();
+    ctx.fill();
+}
+
+function drawNewWindowIcon(ctx: CanvasRenderingContext2D, size: number): void {
+    let pad = 4;
+    let s = size - pad * 2;
+
+    ctx.strokeStyle = "rgba(0,0,0,0.7)";
+    ctx.fillStyle = "rgba(0,0,0,0.7)";
+    ctx.lineWidth = 1.5;
+
+    // Small rectangle (the window)
+    let rx = pad;
+    let ry = pad + s * 0.3;
+    let rw = s * 0.65;
+    let rh = s * 0.7;
+    ctx.strokeRect(rx, ry, rw, rh);
+
+    // Arrow pointing up-right out of the rectangle
+    let arrowStartX = pad + s * 0.4;
+    let arrowStartY = pad + s * 0.6;
+    let arrowEndX = pad + s;
+    let arrowEndY = pad;
+    ctx.beginPath();
+    ctx.moveTo(arrowStartX, arrowStartY);
+    ctx.lineTo(arrowEndX, arrowEndY);
+    ctx.stroke();
+
+    // Arrowhead
+    ctx.beginPath();
+    ctx.moveTo(arrowEndX, arrowEndY);
+    ctx.lineTo(arrowEndX - 5, arrowEndY);
+    ctx.lineTo(arrowEndX, arrowEndY + 5);
+    ctx.closePath();
+    ctx.fill();
+}

--- a/src/elements/point/PlaneSlider.ts
+++ b/src/elements/point/PlaneSlider.ts
@@ -41,6 +41,13 @@ export class PlaneSlider extends PointElement {
         this.toPlane(this._AP);
     }
 
+    public reset() : void {
+        this._x = this._initx;
+        this._y = this._inity;
+        this._z = this._initz;
+        this.toPlane(this._AP);
+    }
+
     public drag(tox : number, toy : number) : boolean {
         this._x = tox;
         this._y = toy;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {PointElement} from "./elements/point/PointElement";
 import {Slate} from "./Slate";
 import {PlaneSlider} from "./elements/point/PlaneSlider";
 import {colors, randomColor, lighten, darken, parseColor} from "./Colors";
+import {createControls} from "./SlateControls";
 
 export type IndexAllConstructions = AllConstructions;
 export {align  as Align};
@@ -21,7 +22,7 @@ export interface IConstructionInfo {
     faceColor?: string | number;
 }
 
-interface IInitialization {
+export interface IInitialization {
     background : string;
     title : string;
     align? : align;
@@ -82,5 +83,9 @@ export function init(i : IInitialization) {
     slate.update();
     slate.updateCoordinates(0);
 
+    // Add UI controls (reset, maximize, new window) if running in browser
+    if (canvas && canvas.parentElement) {
+        createControls(slate, canvas, i);
+    }
 }
 


### PR DESCRIPTION
## Summary

- Three small canvas-drawn icon buttons at the top-right of each diagram, injected automatically by `init()` — no HTML changes needed
- **Reset** (circular arrow): restores all dragged points to initial positions. Fixes broken `Slate.reset()` which previously destroyed the element array. Adds missing `PlaneSlider.reset()` method.
- **Maximize** (expand arrows): toggles canvas to fill viewport via CSS fixed positioning (not Fullscreen API). Click again to minimize back.
- **New Window** (box-with-arrow): opens diagram in a new tab at full viewport size with serialized config
- **Keyboard shortcuts** when canvas is focused (matching Java applet):
  - `r` / `space` → reset
  - `u` / `return` → new window
  - `m` → maximize/minimize toggle
- Canvas gets `tabindex="0"` for keyboard focus with a subtle blue focus ring
- Buttons use semi-transparent backgrounds that darken on hover
- Icons drawn with Canvas 2D paths — no external dependencies

**New file:** `src/SlateControls.ts` — all UI control logic  
**Modified:** `src/Slate.ts` (fix reset), `src/elements/point/PlaneSlider.ts` (add reset), `src/index.ts` (wire controls)

## Test plan

- [x] `npm run build` — no type errors
- [x] `npm test` — 98/98 passing
- [x] `npx webpack` — bundles successfully
- [x] Open any test page, verify 3 buttons appear at top-right of canvas
- [x] Drag points, click reset button — positions should snap back
- [x] Click maximize — canvas fills viewport; click again to minimize
- [x] Click new window — diagram opens in new tab at full size
- [x] Click canvas to focus, verify keyboard shortcuts: `r`, `space`, `m`, `u`, `return`
- [x] Verify shortcuts only fire when canvas is focused (not during other typing)
- [x] Test with a multi-canvas page to verify independent controls