### PR TITLE
Feature/type counted dispatch

### DIFF
--- a/src/Slate.ts
+++ b/src/Slate.ts
@@ -1,7 +1,7 @@
 import {GeomElement} from "./elements/GeomElement";
 import {PlaneElement} from "./elements/plane/PlaneElement";
 import {FixedPoint} from "./elements/point/FixedPoint";
-import {AllConstructions, Construction, constructions, getConstructionName} from "./elements/Constructions";
+import {AllConstructions, Construction, SortedParams, constructions, getConstructionName} from "./elements/Constructions";
 import {PointElement} from "./elements/point/PointElement";
 import {Canvas} from "canvas";
 import {LineElement} from "./elements/line/LineElement";
@@ -158,36 +158,42 @@ export class Slate {
         return null;
     }
 
-    convertParams(params: any[]) : any[] {
-        let converted_params : any[] = [];
+    // Sort params into P[] (points), E[] (other elements), N[] (integers),
+    // matching Java's selectDataChoice (Slate.java lines 344-393).
+    // LineElements are expanded into their two endpoint PointElements.
+    convertParams(params: any[]) : SortedParams {
+        let P: PointElement[] = [];
+        let E: GeomElement[] = [];
+        let N: number[] = [];
         for(let param of params) {
             switch(typeof(param)) {
                 case "string":
                     let g : GeomElement = this.lookupElement(param);
                     if ( g == null )
                         throw new TypeError(`Element with name ${param} not found.`);
-                    if (g instanceof LineElement) {
-                        // We push the two point elements of the line on top
-                        converted_params.push(g.A);
-                        converted_params.push(g.B);
-
+                    if (g instanceof PointElement) {
+                        P.push(g);
+                    } else if (g instanceof LineElement) {
+                        // LineElement expands to two PointElements (matching Java)
+                        P.push(g.A);
+                        P.push(g.B);
                     } else {
-                        converted_params.push(g);
+                        E.push(g);
                     }
                     break;
                 case "number":
-                    converted_params.push(param);
+                    N.push(param);
                     break;
                 default:
                     throw new TypeError("Expecting only named elements (strings) or numbers.");
             }
         }
-        return converted_params;
+        return {P, E, N};
     }
 
-    findConstruction(cm : AllConstructions, params: any[]) : Construction {
+    findConstruction(cm : AllConstructions, sp: SortedParams) : Construction {
         for(let c of constructions) {
-            if(c.validateSignature(cm, params)) {
+            if(c.validateSignature(cm, sp)) {
                 return c;
             }
         }
@@ -195,16 +201,16 @@ export class Slate {
     }
 
     createElement(cm : AllConstructions, params: any[], name?: string) : GeomElement {
-        params = this.convertParams(params);
-        let c : Construction = this.findConstruction(cm, params);
+        let sp : SortedParams = this.convertParams(params);
+        let c : Construction = this.findConstruction(cm, sp);
         if(c == null) {
             let cName : String = getConstructionName(cm);
             if (name == null) {
                 name = "";
             }
-            throw new TypeError(`Construction not found for "${name}" ${cName} with params ${params}`);
+            throw new TypeError(`Construction not found for "${name}" ${cName} with params P=[${sp.P}] E=[${sp.E}] N=[${sp.N}]`);
         }
-        let [gs, g] = c.construct(this._screen, params);
+        let [gs, g] = c.construct(this._screen, sp.P, sp.E, sp.N);
         if(name != null)
             g.name = name;
         for (let elem of gs) {

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -15,12 +15,8 @@
 |                           https://www.nelsonbrown.net/                |
 +----------------------------------------------------------------------*/
 import {GeomElement} from "./GeomElement";
-import {CircleElement} from "./circle/CircleElement";
 import {PlaneElement} from "./plane/PlaneElement";
 import {PointElement} from "./point/PointElement";
-import {PolygonElement} from "./polygon/PolygonElement";
-import {PolyhedronElement} from "./polyhedron/PolyhedronElement";
-import {SphereElement} from "./sphere/SphereElement";
 
 export enum ConstructionTypes {
     Integer,
@@ -168,56 +164,45 @@ export type AllConstructions =
 
 export type GeomElementsForUpdate = GeomElement[];
 
+// Type-sorted parameter arrays, matching Java's P[]/E[]/N[] dispatch.
+// P = PointElements (including LineElement endpoint expansions)
+// E = all other elements (Circle, Plane, Sphere, Polygon, Polyhedron)
+// N = integers (numbers)
+export interface SortedParams {
+    P: PointElement[];
+    E: GeomElement[];
+    N: number[];
+}
+
+export interface ConstructionSignature {
+    points: number;
+    elements: number;
+    integers: number;
+    elementTypes?: Function[];
+}
+
 export abstract class Construction {
     public abstract constructionMethod : AllConstructions;
-    public abstract signature: ConstructionTypes[];
-    public abstract construct(screen: PlaneElement, params: any[]) : [GeomElementsForUpdate, GeomElement];
-    // Optional z coordinates are handled by separate 2D/3D construction classes
-    // with different signatures (e.g., LineSliderConstruction vs LineSlider2dConstruction).
-    public validateSignature(cm : AllConstructions, params: any[]) : boolean {
+    // Signature: type counts + element subtype list for E[] entries.
+    // e.g. { points: 2, elements: 1, integers: 0, elementTypes: [PlaneElement] }
+    public abstract signature: ConstructionSignature;
+
+    public abstract construct(screen: PlaneElement, P: PointElement[],
+                              E: GeomElement[], N: number[]) : [GeomElementsForUpdate, GeomElement];
+
+    // Match by counting types (matching Java's selectDataChoice).
+    // Position-independent: "E,Vplane,D,B" and "E,D,B,Vplane" both match
+    // { points: 3, elements: 1, elementTypes: [PlaneElement] }.
+    public validateSignature(cm: AllConstructions, sp: SortedParams) : boolean {
         if (cm != this.constructionMethod) return false;
-        const sigCopy : ConstructionTypes[] = [...this.signature].reverse();
-        if (sigCopy.length != params.length) return false;
-        for(let param of params) {
-            let sigItem = sigCopy.pop();
-            switch(sigItem) {
-                case ConstructionTypes.Integer:
-                    if (!(typeof(param) == "number")) {
-                        return false;
-                    }
-                    break;
-                case ConstructionTypes.CircleElement:
-                    if (!(param instanceof CircleElement)) {
-                        return false;
-                    }
-                    break;
-                case ConstructionTypes.PlaneElement:
-                    if (!(param instanceof PlaneElement)) {
-                        return false;
-                    }
-                    break;
-                case ConstructionTypes.PointElement:
-                    if (!(param instanceof PointElement)) {
-                        return false;
-                    }
-                    break;
-                case ConstructionTypes.SphereElement:
-                    if (!(param instanceof SphereElement)) {
-                        return false;
-                    }
-                    break;
-                case ConstructionTypes.PolygonElement:
-                    if (!(param instanceof PolygonElement)) {
-                        return false;
-                    }
-                    break;
-                case ConstructionTypes.PolyhedronElement:
-                    if (!(param instanceof PolyhedronElement)) {
-                        return false;
-                    }
-                    break;
-                default:
-                    return false;
+        let sig = this.signature;
+        if (sig.points !== sp.P.length) return false;
+        if (sig.elements !== sp.E.length) return false;
+        if (sig.integers !== sp.N.length) return false;
+        // Check element subtypes if specified
+        if (sig.elementTypes) {
+            for (let i = 0; i < sig.elementTypes.length; i++) {
+                if (!(sp.E[i] instanceof sig.elementTypes[i])) return false;
             }
         }
         return true;

--- a/src/elements/circle/CircleConstructions.ts
+++ b/src/elements/circle/CircleConstructions.ts
@@ -4,7 +4,7 @@
 |    because CircumcenterConstruction extends it directly.              |
 +----------------------------------------------------------------------*/
 
-import {Construction, ConstructionTypes, AllConstructions,
+import {Construction, AllConstructions,
         CircleConstructions as CircleConstructionsEnum,
         GeomElementsForUpdate} from "../Constructions";
 import {GeomElement} from "../GeomElement";
@@ -14,8 +14,6 @@ import {SphereIntersectionElement} from "./SphereIntersectionElement";
 import {PlaneElement} from "../plane/PlaneElement";
 import {PointElement} from "../point/PointElement";
 import {SphereElement} from "../sphere/SphereElement";
-
-let ct = ConstructionTypes;
 
 /************************
  * Element Class Circle *
@@ -28,11 +26,10 @@ let ct = ConstructionTypes;
 // (Java: Slate.java circle case 0, choice 0 — new CircleElement(A,B,screen))
 export class CircleRadiusCenterConstruction extends Construction {
     constructionMethod: AllConstructions = CircleConstructionsEnum.radius;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement];
+    signature = { points: 2, elements: 0, integers: 0 };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new CircleElement({C:ps[0], B:ps[1], AP:screen});
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new CircleElement({C:P[0], B:P[1], AP:screen});
         return [[g], g];
     }
 }
@@ -43,11 +40,10 @@ export class CircleRadiusCenterConstruction extends Construction {
 // (Java: Slate.java circle case 0, choice 2 — new CircleElement(A,B,C))
 export class CircleRadius3dConstruction extends Construction {
     constructionMethod: AllConstructions = CircleConstructionsEnum.radius;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PlaneElement];
+    signature = { points: 2, elements: 1, integers: 0, elementTypes: [PlaneElement] };
 
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new CircleElement({C: ps[0], B: ps[1], AP: params[2] as PlaneElement});
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new CircleElement({C: P[0], B: P[1], AP: E[0] as PlaneElement});
         return [[g], g];
     }
 }
@@ -57,11 +53,10 @@ export class CircleRadius3dConstruction extends Construction {
 // (Java: Slate.java circle case 0, choice 3 — new CircleElement(A,B,C,D))
 export class CircleRadius3Point3dConstruction extends Construction {
     constructionMethod: AllConstructions = CircleConstructionsEnum.radius;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement];
+    signature = { points: 3, elements: 1, integers: 0, elementTypes: [PlaneElement] };
 
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new CircleElement({C: ps[0], A: ps[1], B: ps[2], AP: params[3] as PlaneElement});
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new CircleElement({C: P[0], A: P[1], B: P[2], AP: E[0] as PlaneElement});
         return [[g], g];
     }
 }
@@ -74,11 +69,10 @@ export class CircleRadius3Point3dConstruction extends Construction {
 // (signature variant ordering rule: longer signature first)
 export class CircleRadius3PointConstruction extends Construction {
     constructionMethod: AllConstructions = CircleConstructionsEnum.radius;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
+    signature = { points: 3, elements: 0, integers: 0 };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new CircleElement({C: ps[0], A: ps[1], B: ps[2], AP: screen});
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new CircleElement({C: P[0], A: P[1], B: P[2], AP: screen});
         return [[g], g];
     }
 }
@@ -91,12 +85,10 @@ export class CircleRadius3PointConstruction extends Construction {
 // (Java: InvertCircle.java — TS: InvertCircleElement.ts)
 export class InvertCircleConstruction extends Construction {
     constructionMethod: AllConstructions = CircleConstructionsEnum.invert;
-    signature: ConstructionTypes[] = [ct.CircleElement, ct.CircleElement];
+    signature = { points: 0, elements: 2, integers: 0, elementTypes: [CircleElement, CircleElement] };
 
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const C = params[0] as CircleElement;
-        const D = params[1] as CircleElement;
-        const g = new InvertCircleElement(C, D);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new InvertCircleElement(E[0] as CircleElement, E[1] as CircleElement);
         return [[g], g];
     }
 }
@@ -108,12 +100,10 @@ export class InvertCircleConstruction extends Construction {
 // (Java: IntersectionSS.java — TS: SphereIntersectionElement.ts)
 export class SphereIntersectionConstruction extends Construction {
     constructionMethod: AllConstructions = CircleConstructionsEnum.intersection;
-    signature: ConstructionTypes[] = [ct.SphereElement, ct.SphereElement];
+    signature = { points: 0, elements: 2, integers: 0, elementTypes: [SphereElement, SphereElement] };
 
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const S = params[0] as SphereElement;
-        const T = params[1] as SphereElement;
-        const g = new SphereIntersectionElement(S, T);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new SphereIntersectionElement(E[0] as SphereElement, E[1] as SphereElement);
         return [[g], g];
     }
 }

--- a/src/elements/circle/CircleConstructions.ts
+++ b/src/elements/circle/CircleConstructions.ts
@@ -4,7 +4,7 @@
 |    because CircumcenterConstruction extends it directly.              |
 +----------------------------------------------------------------------*/
 
-import {Construction, AllConstructions,
+import {Construction, ConstructionSignature, SortedParams, AllConstructions,
         CircleConstructions as CircleConstructionsEnum,
         GeomElementsForUpdate} from "../Constructions";
 import {GeomElement} from "../GeomElement";
@@ -20,59 +20,44 @@ import {SphereElement} from "../sphere/SphereElement";
  ************************/
 
 // circle
-// radius
-// points A, B [plane C=screen]
+// radius — points A, B [, plane C = screen]
 // the circle with center A and radius AB in the plane C
-// (Java: Slate.java circle case 0, choice 0 — new CircleElement(A,B,screen))
+// 2D: 2 points, 0 elements — uses screen plane
+// 3D: 2 points, 1 PlaneElement — uses explicit plane
+// (Java: Slate.java circle case 0 — new CircleElement(A,B,plane))
 export class CircleRadiusCenterConstruction extends Construction {
     constructionMethod: AllConstructions = CircleConstructionsEnum.radius;
-    signature = { points: 2, elements: 0, integers: 0 };
-
-    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new CircleElement({C:P[0], B:P[1], AP:screen});
+    signature: ConstructionSignature = { points: 2, elements: 0, integers: 0 };
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 2 && sp.N.length === 0
+            && (sp.E.length === 0 || (sp.E.length === 1 && sp.E[0] instanceof PlaneElement));
+    }
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let plane = E.length > 0 ? E[0] as PlaneElement : screen;
+        let g = new CircleElement({C:P[0], B:P[1], AP:plane});
         return [[g], g];
     }
 }
 
-// circle — radius (3D, 2-point)
-// points A, B, plane C
-// the circle with center A and radius AB in the plane C
-// (Java: Slate.java circle case 0, choice 2 — new CircleElement(A,B,C))
-export class CircleRadius3dConstruction extends Construction {
-    constructionMethod: AllConstructions = CircleConstructionsEnum.radius;
-    signature = { points: 2, elements: 1, integers: 0, elementTypes: [PlaneElement] };
-
-    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new CircleElement({C: P[0], B: P[1], AP: E[0] as PlaneElement});
-        return [[g], g];
-    }
-}
-
-// circle — radius (3D, 3-point)
-// points A, B, C, plane D
-// (Java: Slate.java circle case 0, choice 3 — new CircleElement(A,B,C,D))
-export class CircleRadius3Point3dConstruction extends Construction {
-    constructionMethod: AllConstructions = CircleConstructionsEnum.radius;
-    signature = { points: 3, elements: 1, integers: 0, elementTypes: [PlaneElement] };
-
-    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new CircleElement({C: P[0], A: P[1], B: P[2], AP: E[0] as PlaneElement});
-        return [[g], g];
-    }
-}
-
-// circle — radius (2D, 3-point)
-// points A, B, C
-// the circle with center A and radius |BC| in the screen plane
-// (Java: CircleElement(A, B, C, screen) — A=center, radius=B.distance(C))
+// circle — radius (3-point) — points A, B, C [, plane D = screen]
+// the circle with center A and radius |BC| in the plane D
+// 2D: 3 points, 0 elements — uses screen plane
+// 3D: 3 points, 1 PlaneElement — uses explicit plane
 // MUST be registered BEFORE the 2-point variant in the constructions array
 // (signature variant ordering rule: longer signature first)
+// (Java: Slate.java circle case 0 — new CircleElement(A,B,C,plane))
 export class CircleRadius3PointConstruction extends Construction {
     constructionMethod: AllConstructions = CircleConstructionsEnum.radius;
-    signature = { points: 3, elements: 0, integers: 0 };
-
-    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new CircleElement({C: P[0], A: P[1], B: P[2], AP: screen});
+    signature: ConstructionSignature = { points: 3, elements: 0, integers: 0 };
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 3 && sp.N.length === 0
+            && (sp.E.length === 0 || (sp.E.length === 1 && sp.E[0] instanceof PlaneElement));
+    }
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let plane = E.length > 0 ? E[0] as PlaneElement : screen;
+        let g = new CircleElement({C: P[0], A: P[1], B: P[2], AP: plane});
         return [[g], g];
     }
 }
@@ -109,8 +94,6 @@ export class SphereIntersectionConstruction extends Construction {
 }
 
 export const circleConstructions: Construction[] = [
-    new CircleRadius3Point3dConstruction(),
-    new CircleRadius3dConstruction(),
     new CircleRadius3PointConstruction(),
     new CircleRadiusCenterConstruction(),
     new InvertCircleConstruction(),

--- a/src/elements/line/LineConstructions.ts
+++ b/src/elements/line/LineConstructions.ts
@@ -4,7 +4,7 @@
 |    a construct() method that creates the geometry element.             |
 +----------------------------------------------------------------------*/
 
-import {Construction, AllConstructions, LineConstructions as LineConstructionsEnum,
+import {Construction, ConstructionSignature, SortedParams, AllConstructions, LineConstructions as LineConstructionsEnum,
         GeomElementsForUpdate} from "../Constructions";
 import {PointPerpendicular1Construction, PointPerpendicular2Construction,
         PointPerpendicular3Construction, PointPerpendicular4Construction,
@@ -46,60 +46,44 @@ export class LineConnectConstruction extends Construction {
 }
 
 // line
-// angleBisector (2D variant)
-// points B, A, C
+// angleBisector — points B, A, C [, plane D = screen]
 // line from A to the bisector point of angle BAC on line BC
-// (Java: Slate.java line case 1 — AngleDivider(B,A,C,screen,2) + LineElement(A,result))
+// 2D: 3 points, 0 elements — uses screen plane
+// 3D: 3 points, 1 PlaneElement — uses explicit plane
+// (Java: Slate.java line case 1 — AngleDivider(B,A,C,plane,2) + LineElement(A,result))
 export class AngleBisectorLineConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.angleBisector;
-    signature = { points: 3, elements: 0, integers: 0 };
-
+    signature: ConstructionSignature = { points: 3, elements: 0, integers: 0 };
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 3 && sp.N.length === 0
+            && (sp.E.length === 0 || (sp.E.length === 1 && sp.E[0] instanceof PlaneElement));
+    }
     construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let ad = new AngleDividerElement(P[0], P[1], P[2], screen, 2);
+        let plane = E.length > 0 ? E[0] as PlaneElement : screen;
+        let ad = new AngleDividerElement(P[0], P[1], P[2], plane, 2);
         let g = new LineElement({A: P[1], B: ad});
         return [[ad, g], g];
     }
 }
 
 // line
-// angleDivider (2D variant)
-// points B, A, C, integer n
+// angleDivider — points B, A, C, integer n [, plane D = screen]
 // line from A to the n-th division point of angle BAC on line BC
-// (Java: Slate.java line case 2 — AngleDivider(B,A,C,screen,n) + LineElement(A,result))
+// 2D: 3 points, 0 elements, 1 integer — uses screen plane
+// 3D: 3 points, 1 PlaneElement, 1 integer — uses explicit plane
+// (Java: Slate.java line case 2 — AngleDivider(B,A,C,plane,n) + LineElement(A,result))
 export class AngleDividerLineConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.angleDivider;
-    signature = { points: 3, elements: 0, integers: 1 };
-
+    signature: ConstructionSignature = { points: 3, elements: 0, integers: 1 };
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 3 && sp.N.length === 1
+            && (sp.E.length === 0 || (sp.E.length === 1 && sp.E[0] instanceof PlaneElement));
+    }
     construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let ad = new AngleDividerElement(P[0], P[1], P[2], screen, N[0]);
-        let g = new LineElement({A: P[1], B: ad});
-        return [[ad, g], g];
-    }
-}
-
-// line — angleBisector (3D variant)
-// points B, A, C, plane D
-// (Java: Slate.java line case 1, choice 1 — AngleDivider(B,A,C,D,2) + LineElement(A,result))
-export class AngleBisectorLine3dConstruction extends Construction {
-    constructionMethod: AllConstructions = LineConstructionsEnum.angleBisector;
-    signature = { points: 3, elements: 1, integers: 0, elementTypes: [PlaneElement] };
-
-    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let ad = new AngleDividerElement(P[0], P[1], P[2], E[0] as PlaneElement, 2);
-        let g = new LineElement({A: P[1], B: ad});
-        return [[ad, g], g];
-    }
-}
-
-// line — angleDivider (3D variant)
-// points B, A, C, plane D, integer n
-// (Java: Slate.java line case 2, choice 1 — AngleDivider(B,A,C,D,n) + LineElement(A,result))
-export class AngleDividerLine3dConstruction extends Construction {
-    constructionMethod: AllConstructions = LineConstructionsEnum.angleDivider;
-    signature = { points: 3, elements: 1, integers: 1, elementTypes: [PlaneElement] };
-
-    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let ad = new AngleDividerElement(P[0], P[1], P[2], E[0] as PlaneElement, N[0]);
+        let plane = E.length > 0 ? E[0] as PlaneElement : screen;
+        let ad = new AngleDividerElement(P[0], P[1], P[2], plane, N[0]);
         let g = new LineElement({A: P[1], B: ad});
         return [[ad, g], g];
     }
@@ -266,30 +250,23 @@ export class LineParallelConstruction extends Construction {
 }
 
 // line
-// similar (2D variant)
-// points A, B, D, E, F
-// the line AH so that triangle ABH is similar to triangle DEF (screen plane)
-// (Java: Slate.java line case 10 — Similar(A,B,screen,D,E,F,screen) + LineElement(A,H))
+// similar — points A, B, D, E, F [, planes C, G = screen]
+// the line AH so that triangle ABH is similar to triangle DEF
+// 2D: 5 points, 0 elements — uses screen plane for both
+// 3D: 5 points, 2 PlaneElements — uses explicit planes
+// (Java: Slate.java line case 10 — Similar(A,B,C,D,E,F,G) + LineElement(A,H))
 export class SimilarLineConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.similar;
-    signature = { points: 5, elements: 0, integers: 0 };
-
-    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let sim = new SimilarElement(P[0], P[1], screen, P[2], P[3], P[4], screen);
-        let g = new LineElement({A: P[0], B: sim});
-        return [[sim, g], g];
+    signature: ConstructionSignature = { points: 5, elements: 0, integers: 0 };
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 5 && sp.N.length === 0
+            && (sp.E.length === 0 || sp.E.length === 2);
     }
-}
-
-// line — similar (3D variant)
-// points A, B, plane C, points D, E, F, plane G
-// (Java: Slate.java line case 10, choice 1 — Similar(A,B,C,D,E,F,G) + LineElement(A,H))
-export class SimilarLine3dConstruction extends Construction {
-    constructionMethod: AllConstructions = LineConstructionsEnum.similar;
-    signature = { points: 5, elements: 2, integers: 0, elementTypes: [PlaneElement, PlaneElement] };
-
-    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let sim = new SimilarElement(P[0], P[1], E[0] as PlaneElement, P[2], P[3], P[4], E[1] as PlaneElement);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let c = E.length > 0 ? E[0] as PlaneElement : screen;
+        let g2 = E.length > 1 ? E[1] as PlaneElement : screen;
+        let sim = new SimilarElement(P[0], P[1], c, P[2], P[3], P[4], g2);
         let g = new LineElement({A: P[0], B: sim});
         return [[sim, g], g];
     }
@@ -341,12 +318,9 @@ export const lineConstructions: Construction[] = [
     new LineCutoffConstruction(),
     new PlaneFootLineConstruction(),
     new LineFootConstruction(),
-    new SimilarLine3dConstruction(),
     new SimilarLineConstruction(),
     new ProportionLineConstruction(),
-    new AngleBisectorLine3dConstruction(),
     new AngleBisectorLineConstruction(),
-    new AngleDividerLine3dConstruction(),
     new AngleDividerLineConstruction(),
     new MeanProportionalLineConstruction(),
 ];

--- a/src/elements/line/LineConstructions.ts
+++ b/src/elements/line/LineConstructions.ts
@@ -4,7 +4,7 @@
 |    a construct() method that creates the geometry element.             |
 +----------------------------------------------------------------------*/
 
-import {Construction, ConstructionTypes, AllConstructions, LineConstructions as LineConstructionsEnum,
+import {Construction, AllConstructions, LineConstructions as LineConstructionsEnum,
         GeomElementsForUpdate} from "../Constructions";
 import {PointPerpendicular1Construction, PointPerpendicular2Construction,
         PointPerpendicular3Construction, PointPerpendicular4Construction,
@@ -26,8 +26,6 @@ import {ProportionElement} from "../point/ProportionElement";
 import {AngleDividerElement} from "../point/AngleDividerElement";
 import {MeanProportionalElement} from "../point/MeanProportionalElement";
 
-let ct = ConstructionTypes;
-
 /**********************
  * Element Class Line *
  **********************/
@@ -39,12 +37,9 @@ let ct = ConstructionTypes;
 // (Java: Slate.java line case 0 — new LineElement(A,B))
 export class LineConnectConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.connect;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement];
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let a : PointElement = params[0];
-        let b : PointElement = params[1];
-
-        let g = new LineElement({A:a, B: b});
+    signature = { points: 2, elements: 0, integers: 0 };
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new LineElement({A:P[0], B: P[1]});
 
         return [[g], g];
     }
@@ -57,12 +52,11 @@ export class LineConnectConstruction extends Construction {
 // (Java: Slate.java line case 1 — AngleDivider(B,A,C,screen,2) + LineElement(A,result))
 export class AngleBisectorLineConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.angleBisector;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
+    signature = { points: 3, elements: 0, integers: 0 };
 
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let ad = new AngleDividerElement(ps[0], ps[1], ps[2], screen, 2);
-        let g = new LineElement({A: ps[1], B: ad});
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let ad = new AngleDividerElement(P[0], P[1], P[2], screen, 2);
+        let g = new LineElement({A: P[1], B: ad});
         return [[ad, g], g];
     }
 }
@@ -74,13 +68,11 @@ export class AngleBisectorLineConstruction extends Construction {
 // (Java: Slate.java line case 2 — AngleDivider(B,A,C,screen,n) + LineElement(A,result))
 export class AngleDividerLineConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.angleDivider;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement, ct.Integer];
+    signature = { points: 3, elements: 0, integers: 1 };
 
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let n : number = params[3];
-        let ad = new AngleDividerElement(ps[0], ps[1], ps[2], screen, n);
-        let g = new LineElement({A: ps[1], B: ad});
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let ad = new AngleDividerElement(P[0], P[1], P[2], screen, N[0]);
+        let g = new LineElement({A: P[1], B: ad});
         return [[ad, g], g];
     }
 }
@@ -90,12 +82,11 @@ export class AngleDividerLineConstruction extends Construction {
 // (Java: Slate.java line case 1, choice 1 — AngleDivider(B,A,C,D,2) + LineElement(A,result))
 export class AngleBisectorLine3dConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.angleBisector;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement];
+    signature = { points: 3, elements: 1, integers: 0, elementTypes: [PlaneElement] };
 
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let ad = new AngleDividerElement(ps[0], ps[1], ps[2], params[3] as PlaneElement, 2);
-        let g = new LineElement({A: ps[1], B: ad});
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let ad = new AngleDividerElement(P[0], P[1], P[2], E[0] as PlaneElement, 2);
+        let g = new LineElement({A: P[1], B: ad});
         return [[ad, g], g];
     }
 }
@@ -105,12 +96,11 @@ export class AngleBisectorLine3dConstruction extends Construction {
 // (Java: Slate.java line case 2, choice 1 — AngleDivider(B,A,C,D,n) + LineElement(A,result))
 export class AngleDividerLine3dConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.angleDivider;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement, ct.Integer];
+    signature = { points: 3, elements: 1, integers: 1, elementTypes: [PlaneElement] };
 
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let ad = new AngleDividerElement(ps[0], ps[1], ps[2], params[3] as PlaneElement, params[4] as number);
-        let g = new LineElement({A: ps[1], B: ad});
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let ad = new AngleDividerElement(P[0], P[1], P[2], E[0] as PlaneElement, N[0]);
+        let g = new LineElement({A: P[1], B: ad});
         return [[ad, g], g];
     }
 }
@@ -123,12 +113,11 @@ export class AngleDividerLine3dConstruction extends Construction {
 // Foot class already IMPL at src/elements/point/Foot.ts.)
 export class LineFootConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.foot;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
+    signature = { points: 3, elements: 0, integers: 0 };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let fo = new Foot(ps[0], ps[1], ps[2]);
-        let g = new LineElement({A: ps[0], B: fo});
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let fo = new Foot(P[0], P[1], P[2]);
+        let g = new LineElement({A: P[0], B: fo});
         return [[fo, g], g];
     }
 }
@@ -141,13 +130,11 @@ export class LineFootConstruction extends Construction {
 // (Java: PlaneFoot.java — TS: PlaneFootElement.ts, renamed for clarity)
 export class PlaneFootLineConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.foot;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PlaneElement];
+    signature = { points: 1, elements: 1, integers: 0, elementTypes: [PlaneElement] };
 
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const A = params[0] as PointElement;
-        const P = params[1] as PlaneElement;
-        const fo = new PlaneFootElement(A, P);
-        const g = new LineElement({A: A, B: fo});
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const fo = new PlaneFootElement(P[0], E[0] as PlaneElement);
+        const g = new LineElement({A: P[0], B: fo});
         return [[fo, g], g];
     }
 }
@@ -160,13 +147,10 @@ export class PlaneFootLineConstruction extends Construction {
 // (Java: Slate.java line case 4 — new Chord(A,B,C). Java: Chord.java)
 export class ChordConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.chord;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.CircleElement];
+    signature = { points: 2, elements: 1, integers: 0, elementTypes: [CircleElement] };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const D = params[0] as PointElement;
-        const E = params[1] as PointElement;
-        const C = params[2] as CircleElement;
-        const g = new Chord({D, E, C});
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new Chord({D: P[0], E: P[1], C: E[0] as CircleElement});
         return [[g], g];
     }
 }
@@ -178,11 +162,10 @@ export class ChordConstruction extends Construction {
 // (Java: Slate.java line case 5 — new Bichord(A,B). Java: Bichord.java)
 export class BichordConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.bichord;
-    signature: ConstructionTypes[] = [ct.CircleElement, ct.CircleElement];
+    signature = { points: 0, elements: 2, integers: 0, elementTypes: [CircleElement, CircleElement] };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : CircleElement[] = params;
-        let g = new Bichord({C:ps[0], D:ps[1]});
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new Bichord({C: E[0] as CircleElement, D: E[1] as CircleElement});
         return [[g], g];
     }
 }
@@ -201,35 +184,35 @@ function wrapPointAsLine(es: [GeomElementsForUpdate, GeomElement]): [GeomElement
 // (Java: Slate.java line case 6, choice 0 — Perpendicular(A,B,screen,A,B))
 export class LinePerpendicular1Construction extends PointPerpendicular1Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.perpendicular;
-    construct(screen: PlaneElement, params: any[]) { return wrapPointAsLine(super.construct(screen, params)); }
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]) { return wrapPointAsLine(super.construct(screen, P, E, N)); }
 }
 
 // line — perpendicular variant 2: points A, B, plane C
 // (Java: Slate.java line case 6, choice 1 — Perpendicular(A,B,C,A,B))
 export class LinePerpendicular2Construction extends PointPerpendicular2Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.perpendicular;
-    construct(screen: PlaneElement, params: any[]) { return wrapPointAsLine(super.construct(screen, params)); }
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]) { return wrapPointAsLine(super.construct(screen, P, E, N)); }
 }
 
 // line — perpendicular variant 3: points A, B, D, E [plane C (screen)]
 // (Java: Slate.java line case 6, choice 2 — Perpendicular(A,B,screen,D,E))
 export class LinePerpendicular3Construction extends PointPerpendicular3Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.perpendicular;
-    construct(screen: PlaneElement, params: any[]) { return wrapPointAsLine(super.construct(screen, params)); }
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]) { return wrapPointAsLine(super.construct(screen, P, E, N)); }
 }
 
 // line — perpendicular variant 4: points A, B, plane C, points D, E
 // (Java: Slate.java line case 6, choice 3 — Perpendicular(A,B,C,D,E))
 export class LinePerpendicular4Construction extends PointPerpendicular4Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.perpendicular;
-    construct(screen: PlaneElement, params: any[]) { return wrapPointAsLine(super.construct(screen, params)); }
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]) { return wrapPointAsLine(super.construct(screen, P, E, N)); }
 }
 
 // line — perpendicular variant 5: point A, plane B, points C, D
 // (Java: Slate.java line case 6, choice 4 — PlanePerpendicularLine(A,B,C,D))
 export class LinePerpendicular5Construction extends PointPerpendicular5Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.perpendicular;
-    construct(screen: PlaneElement, params: any[]) { return wrapPointAsLine(super.construct(screen, params)); }
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]) { return wrapPointAsLine(super.construct(screen, P, E, N)); }
 }
 
 // line
@@ -239,12 +222,11 @@ export class LinePerpendicular5Construction extends PointPerpendicular5Construct
 // (Java: Slate.java line case 7 — Layoff(A,A,B,C,D) + LineElement(A,layoff))
 export class LineCutoffConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.cutoff;
-    signature: ConstructionTypes[] = (new Array(4)).fill(ct.PointElement);
+    signature = { points: 4, elements: 0, integers: 0 };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let lo = new Layoff(ps[0], ps[0], ps[1], ps[2], ps[3]);
-        let g = new LineElement({A: ps[0], B: lo});
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let lo = new Layoff(P[0], P[0], P[1], P[2], P[3]);
+        let g = new LineElement({A: P[0], B: lo});
         return [[lo, g], g];
     }
 }
@@ -256,12 +238,11 @@ export class LineCutoffConstruction extends Construction {
 // (Java: Slate.java line case 8 — Layoff(B,A,B,C,D) + LineElement(B,layoff))
 export class LineExtendConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.extend;
-    signature: ConstructionTypes[] = (new Array(4)).fill(ct.PointElement);
+    signature = { points: 4, elements: 0, integers: 0 };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let lo = new Layoff(ps[1], ps[0], ps[1], ps[2], ps[3]);
-        let g = new LineElement({A: ps[1], B: lo});
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let lo = new Layoff(P[1], P[0], P[1], P[2], P[3]);
+        let g = new LineElement({A: P[1], B: lo});
         return [[lo, g], g];
     }
 }
@@ -275,12 +256,11 @@ export class LineExtendConstruction extends Construction {
 // LineElement(A, D). Same pattern as LineExtendConstruction above.)
 export class LineParallelConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.parallel;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
+    signature = { points: 3, elements: 0, integers: 0 };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let lo = new Layoff(ps[0], ps[1], ps[2], ps[1], ps[2]);
-        let g = new LineElement({A: ps[0], B: lo});
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let lo = new Layoff(P[0], P[1], P[2], P[1], P[2]);
+        let g = new LineElement({A: P[0], B: lo});
         return [[lo, g], g];
     }
 }
@@ -292,12 +272,11 @@ export class LineParallelConstruction extends Construction {
 // (Java: Slate.java line case 10 — Similar(A,B,screen,D,E,F,screen) + LineElement(A,H))
 export class SimilarLineConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.similar;
-    signature: ConstructionTypes[] = (new Array(5)).fill(ct.PointElement);
+    signature = { points: 5, elements: 0, integers: 0 };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let sim = new SimilarElement(ps[0], ps[1], screen, ps[2], ps[3], ps[4], screen);
-        let g = new LineElement({A: ps[0], B: sim});
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let sim = new SimilarElement(P[0], P[1], screen, P[2], P[3], P[4], screen);
+        let g = new LineElement({A: P[0], B: sim});
         return [[sim, g], g];
     }
 }
@@ -307,16 +286,11 @@ export class SimilarLineConstruction extends Construction {
 // (Java: Slate.java line case 10, choice 1 — Similar(A,B,C,D,E,F,G) + LineElement(A,H))
 export class SimilarLine3dConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.similar;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PlaneElement,
-        ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement];
+    signature = { points: 5, elements: 2, integers: 0, elementTypes: [PlaneElement, PlaneElement] };
 
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const A = params[0] as PointElement, B = params[1] as PointElement;
-        const C = params[2] as PlaneElement;
-        const D = params[3] as PointElement, E = params[4] as PointElement, F = params[5] as PointElement;
-        const G = params[6] as PlaneElement;
-        let sim = new SimilarElement(A, B, C, D, E, F, G);
-        let g = new LineElement({A: A, B: sim});
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let sim = new SimilarElement(P[0], P[1], E[0] as PlaneElement, P[2], P[3], P[4], E[1] as PlaneElement);
+        let g = new LineElement({A: P[0], B: sim});
         return [[sim, g], g];
     }
 }
@@ -328,12 +302,11 @@ export class SimilarLine3dConstruction extends Construction {
 // (Java: Slate.java line case 11 — Proportion + LineElement(G, result))
 export class ProportionLineConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.proportion;
-    signature: ConstructionTypes[] = (new Array(8)).fill(ct.PointElement);
+    signature = { points: 8, elements: 0, integers: 0 };
 
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let prop = new ProportionElement(ps[0], ps[1], ps[2], ps[3], ps[4], ps[5], ps[6], ps[7]);
-        let g = new LineElement({A: ps[6], B: prop});
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let prop = new ProportionElement(P[0], P[1], P[2], P[3], P[4], P[5], P[6], P[7]);
+        let g = new LineElement({A: P[6], B: prop});
         return [[prop, g], g];
     }
 }
@@ -345,12 +318,11 @@ export class ProportionLineConstruction extends Construction {
 // (Java: Slate.java line case 12 — MeanProportional + LineElement(U0, result))
 export class MeanProportionalLineConstruction extends Construction {
     constructionMethod: AllConstructions = LineConstructionsEnum.meanProportional;
-    signature: ConstructionTypes[] = (new Array(6)).fill(ct.PointElement);
+    signature = { points: 6, elements: 0, integers: 0 };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let mp = new MeanProportionalElement(ps[0], ps[1], ps[2], ps[3], ps[4], ps[5]);
-        let g = new LineElement({A: ps[4], B: mp});
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let mp = new MeanProportionalElement(P[0], P[1], P[2], P[3], P[4], P[5]);
+        let g = new LineElement({A: P[4], B: mp});
         return [[mp, g], g];
     }
 }

--- a/src/elements/plane/PlaneConstructions.ts
+++ b/src/elements/plane/PlaneConstructions.ts
@@ -1,10 +1,8 @@
 /*----------------------------------------------------------------------+
 |    Plane construction classes — extracted from Constructions.ts        |
-|    Each class maps a (type, constructionName, signature) triple to    |
-|    a construct() method that creates the geometry element.             |
 +----------------------------------------------------------------------*/
 
-import {Construction, ConstructionTypes, AllConstructions,
+import {Construction, AllConstructions,
         PlaneConstructions as PlaneConstructionsEnum,
         GeomElementsForUpdate} from "../Constructions";
 import {GeomElement} from "../GeomElement";
@@ -14,89 +12,56 @@ import {PlaneElement} from "./PlaneElement";
 import {PerpendicularPlane} from "./PerpendicularPlane";
 import {ParallelPlane} from "./ParallelPlane";
 
-let ct = ConstructionTypes;
-
-/***********************
- * Element Class Plane *
- ***********************/
-
-// plane
-// 3points
-// points A, B, C
-// the plane passing through points A, B, and C
-// (Java: Slate.java plane case 0 — new PlaneElement(A, B, C).
-// PlaneElement.ts already has the full constructor + update() that computes S, T, U.)
+// plane — 3points — points A, B, C
+// (Java: Slate.java plane case 0 — new PlaneElement(A, B, C))
 export class Plane3PointsConstruction extends Construction {
     constructionMethod: AllConstructions = PlaneConstructionsEnum.threePoints;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
-
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new PlaneElement({A: ps[0], B: ps[1], C: ps[2]});
+    signature = { points: 3, elements: 0, integers: 0 };
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new PlaneElement({A: P[0], B: P[1], C: P[2]});
         return [[g], g];
     }
 }
 
-// plane
-// perpendicular
-// points A, B
-// the plane passing through point A and perpendicular to line AB
-// (Java: Slate.java plane case 1 — new PerpendicularPL(A,B). Java: PerpendicularPL.java)
+// plane — perpendicular — points A, B
+// (Java: Slate.java plane case 1 — new PerpendicularPL(A,B))
 export class PerpendicularPlaneConstruction extends Construction {
     constructionMethod: AllConstructions = PlaneConstructionsEnum.perpendicular;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement]
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new PerpendicularPlane({A: ps[0], E: ps[1]});
+    signature = { points: 2, elements: 0, integers: 0 };
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new PerpendicularPlane({A: P[0], E: P[1]});
         return [[g], g];
     }
 }
 
-
-
-// plane
-// parallel
-// plane P, point A
-// the plane passing through point A and parallel to plane P
+// plane — parallel — plane P, point A
 // (Java: ParallelP.java — 26 lines, line-for-line port)
 export class PlaneParallelConstruction extends Construction {
     constructionMethod: AllConstructions = PlaneConstructionsEnum.parallel;
-    signature: ConstructionTypes[] = [ct.PlaneElement, ct.PointElement];
-
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const P = params[0] as PlaneElement;
-        const A = params[1] as PointElement;
-        const g = new ParallelPlane(P, A);
+    signature = { points: 1, elements: 1, integers: 0, elementTypes: [PlaneElement] };
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new ParallelPlane(E[0] as PlaneElement, P[0]);
         return [[g], g];
     }
 }
 
-// plane
-// ambient (point variant)
-// point A
-// the ambient plane of point A
+// plane — ambient (point variant) — point A
 // (Java: Slate.java plane case 3, choice 0 — returns P[0].AP)
 export class AmbientPlanePointConstruction extends Construction {
     constructionMethod: AllConstructions = PlaneConstructionsEnum.ambient;
-    signature: ConstructionTypes[] = [ct.PointElement];
-
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const p = params[0] as PointElement;
-        return [[p._AP], p._AP];
+    signature = { points: 1, elements: 0, integers: 0 };
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        return [[P[0]._AP], P[0]._AP];
     }
 }
 
-// plane
-// ambient (circle variant)
-// circle A
-// the ambient plane of circle A
+// plane — ambient (circle variant) — circle A
 // (Java: Slate.java plane case 3, choice 1 — returns ((CircleElement)E[0]).AP)
 export class AmbientPlaneCircleConstruction extends Construction {
     constructionMethod: AllConstructions = PlaneConstructionsEnum.ambient;
-    signature: ConstructionTypes[] = [ct.CircleElement];
-
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const c = params[0] as CircleElement;
+    signature = { points: 0, elements: 1, integers: 0, elementTypes: [CircleElement] };
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const c = E[0] as CircleElement;
         return [[c.AP], c.AP];
     }
 }

--- a/src/elements/point/PointConstructions.ts
+++ b/src/elements/point/PointConstructions.ts
@@ -4,7 +4,7 @@
 |    a construct() method that creates the geometry element.             |
 +----------------------------------------------------------------------*/
 
-import {Construction, ConstructionSignature, AllConstructions, PointConstructions,
+import {Construction, ConstructionSignature, SortedParams, AllConstructions, PointConstructions,
         CircleConstructions, GeomElementsForUpdate} from "../Constructions";
 import {GeomElement} from "../GeomElement";
 import {CircleElement} from "../circle/CircleElement";
@@ -71,24 +71,21 @@ export class MidPointConstruction extends Construction {
 
 // point
 // intersection
-// points A, B, C, D, plane E
+// points A, B, C, D [, plane E = screen]
 // the intersection of two lines AB and CD in the plane E
-// (Java: Slate.java point case 2, choice 1 — new Intersection(A,B,C,D,E))
+// (Java: Slate.java point case 2 — new Intersection(A,B,C,D,E))
 export class IntersectionConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.intersection;
-    signature: ConstructionSignature = { points: 4, elements: 1, integers: 0, elementTypes: [PlaneElement] };
-    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new Intersection(P[0], P[1], P[2], P[3], E[0] as PlaneElement);
-
-        return [[g], g];
-    }
-}
-
-// (Java: Slate.java point case 2, choice 0 — new Intersection(A,B,C,D,screen))
-export class IntersectionConstructionScreen extends IntersectionConstruction {
     signature: ConstructionSignature = { points: 4, elements: 0, integers: 0 };
-    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        return super.construct(screen, P, [screen], N);
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 4 && sp.N.length === 0
+            && (sp.E.length === 0 || (sp.E.length === 1 && sp.E[0] instanceof PlaneElement));
+    }
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let plane = E.length > 0 ? E[0] as PlaneElement : screen;
+        let g = new Intersection(P[0], P[1], P[2], P[3], plane);
+        return [[g], g];
     }
 }
 
@@ -162,15 +159,18 @@ export class SphereCenterConstruction extends Construction {
 
 // point
 // lineSlider
-// points A, B integers x, y,[z]
+// points A, B, integers x, y, [z=0]
 // a point that slides along a line AB with initial coordinates (x,y,z)
 // (Java: Slate.java point case 6 — new LineSlider(A,B,x,y,z,false))
 export class LineSliderConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.lineSlider;
-    signature: ConstructionSignature = { points: 2, elements: 0, integers: 3 };
-    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = this.createSlider(P[0], P[1], N[0], N[1], N[2]);
-
+    signature: ConstructionSignature = { points: 2, elements: 0, integers: 2 };
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 2 && sp.E.length === 0 && (sp.N.length === 2 || sp.N.length === 3);
+    }
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = this.createSlider(P[0], P[1], N[0], N[1], N.length > 2 ? N[2] : 0);
         return [[g], g];
     }
     protected createSlider(a: PointElement, b: PointElement, x: number, y: number, z: number) {
@@ -178,92 +178,55 @@ export class LineSliderConstruction extends Construction {
     }
 }
 
-// point — lineSlider (2D variant, z defaults to 0)
-// (Java: Slate.java point case 6, choice 0 — z set to 0)
-export class LineSlider2dConstruction extends LineSliderConstruction {
-    signature: ConstructionSignature = { points: 2, elements: 0, integers: 2 };
-    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = this.createSlider(P[0], P[1], N[0], N[1], 0);
-
-        return [[g], g];
-    }
-}
-
 // point
 // circleSlider
-// circle A, integers x, y, [z]
+// circle A, integers x, y, [z=0]
 // a point that slides along a circle A with given initial coordinates (x,y,z)
 // (Java: Slate.java point case 7 — new CircleSlider(E[0], x, y, z))
 export class CircleSliderConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.circleSlider;
-    signature: ConstructionSignature = { points: 0, elements: 1, integers: 3, elementTypes: [CircleElement] };
-
-    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new CircleSlider(E[0] as CircleElement, N[0], N[1], N[2]);
-        return [[g], g];
-    }
-}
-
-// point — circleSlider (2D variant, z defaults to 0)
-// (Java: Slate.java point case 7, choice 0 — z set to 0)
-export class CircleSliderConstruction2dPoint extends CircleSliderConstruction {
     signature: ConstructionSignature = { points: 0, elements: 1, integers: 2, elementTypes: [CircleElement] };
-
-    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        return super.construct(screen, P, E, [...N, 0]);
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 0 && sp.E.length === 1 && (sp.N.length === 2 || sp.N.length === 3)
+            && sp.E[0] instanceof CircleElement;
+    }
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new CircleSlider(E[0] as CircleElement, N[0], N[1], N.length > 2 ? N[2] : 0);
+        return [[g], g];
     }
 }
 
 // circle
-// circumcircle
-// points A, B, C, plane D
+// circumcircle — points A, B, C [, plane D = screen]
 // the circle passing through 3 points A, B, and C in the plane D
-// (Java: Slate.java circle case 1, choice 1 — new Circumcircle(A,B,C,D))
-// NOTE: Lives here (not in circle/constructions.ts) because CircumcenterConstruction
-// extends it, and both are tightly coupled.
+// (Java: Slate.java circle case 1 — new Circumcircle(A,B,C,D))
 export class CircumcircleConstruction extends Construction {
     constructionMethod: AllConstructions = CircleConstructions.circumcircle;
-    signature: ConstructionSignature = { points: 3, elements: 1, integers: 0, elementTypes: [PlaneElement] };
-
-    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new CircumcircleElement(P[0], P[1], P[2], E[0] as PlaneElement);
+    signature: ConstructionSignature = { points: 3, elements: 0, integers: 0 };
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 3 && sp.N.length === 0
+            && (sp.E.length === 0 || (sp.E.length === 1 && sp.E[0] instanceof PlaneElement));
+    }
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let plane = E.length > 0 ? E[0] as PlaneElement : screen;
+        let g = new CircumcircleElement(P[0], P[1], P[2], plane);
         return [[g], g];
     }
 }
 
-// circle — circumcircle (2D variant, plane defaults to screen)
-// (Java: Slate.java circle case 1, choice 0 — E[0] = screen)
-export class CircumcircleConstruction2d extends CircumcircleConstruction {
-    signature: ConstructionSignature = { points: 3, elements: 0, integers: 0 };
-
-    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        return super.construct(screen, P, [screen], N);
-    }
-}
-
 // point
-// circumcenter
-// points A, B, C, plane D
+// circumcenter — points A, B, C [, plane D = screen]
 // the center of a circle ABC passing through 3 points A, B, and C in the plane D
 // (Java: Slate.java point case 8 — new Circumcircle(A,B,C,D), returns circ.Center)
 export class CircumcenterConstruction extends CircumcircleConstruction {
     constructionMethod: AllConstructions = PointConstructions.circumcenter;
-
-    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
         let es = super.construct(screen, P, E, N);
         let g : CircleElement = es[1] as CircleElement;
         es[0].push(g.Center);
         return [es[0], g.Center];
-    }
-}
-
-// point — circumcenter (2D variant, plane defaults to screen)
-// (Java: Slate.java point case 8, choice 0 — E[0] = screen)
-export class CircumcenterConstruction2d extends CircumcenterConstruction {
-    signature: ConstructionSignature = { points: 3, elements: 0, integers: 0 };
-
-    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        return super.construct(screen, P, [screen], N);
     }
 }
 
@@ -351,30 +314,21 @@ export class ParallelogramConstruction extends Construction {
 }
 
 // point
-// similar	points A, B, D, E, F [planes C, G]
+// similar — points A, B, D, E, F [, planes C, G = screen]
 // the point H so that triangle ABH in plane C is similar to triangle DEF in plane G
-// 2D variant: 5 PointElements, both planes default to screen
-// (Java: Similar.java — extends PointElement, calls this.toSimilar(...) in update())
+// (Java: Slate.java point case 14 — Similar.java)
 export class SimilarPointConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.similar;
     signature: ConstructionSignature = { points: 5, elements: 0, integers: 0 };
-
-    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new SimilarElement(P[0], P[1], screen, P[2], P[3], P[4], screen);
-        return [[g], g];
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 5 && sp.N.length === 0
+            && (sp.E.length === 0 || sp.E.length === 2);
     }
-}
-
-// point
-// similar (3D variant)
-// points A, B, D, E, F, planes C, G
-// (Java: Similar with explicit PlaneElements instead of screen)
-export class SimilarPoint3dConstruction extends Construction {
-    constructionMethod: AllConstructions = PointConstructions.similar;
-    signature: ConstructionSignature = { points: 5, elements: 2, integers: 0, elementTypes: [PlaneElement, PlaneElement] };
-
     construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        const g = new SimilarElement(P[0], P[1], E[0] as PlaneElement, P[2], P[3], P[4], E[1] as PlaneElement);
+        let c = E.length > 0 ? E[0] as PlaneElement : screen;
+        let g2 = E.length > 1 ? E[1] as PlaneElement : screen;
+        let g = new SimilarElement(P[0], P[1], c, P[2], P[3], P[4], g2);
         return [[g], g];
     }
 }
@@ -538,87 +492,57 @@ export class SphereSliderConstruction extends Construction {
 }
 
 // point
-// angleBisector (2D variant)
-// points B, A, C
+// angleBisector — points B, A, C [, plane D = screen]
 // bisect angle BAC — the point on BC where the bisector from A meets BC
 // (Java: AngleDivider.java with n=2, Slate.java point case 21)
 export class AngleBisectorPointConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.angleBisector;
     signature: ConstructionSignature = { points: 3, elements: 0, integers: 0 };
-
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 3 && sp.N.length === 0
+            && (sp.E.length === 0 || (sp.E.length === 1 && sp.E[0] instanceof PlaneElement));
+    }
     construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new AngleDividerElement(P[0], P[1], P[2], screen, 2);
+        let plane = E.length > 0 ? E[0] as PlaneElement : screen;
+        let g = new AngleDividerElement(P[0], P[1], P[2], plane, 2);
         return [[g], g];
     }
 }
 
 // point
-// angleDivider (2D variant)
-// points B, A, C, integer n
+// angleDivider — points B, A, C, integer n [, plane D = screen]
 // n-sect angle BAC — the point on BC where the 1/n ray from A meets BC
 // (Java: AngleDivider.java with variable n, Slate.java point case 22)
 export class AngleDividerPointConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.angleDivider;
     signature: ConstructionSignature = { points: 3, elements: 0, integers: 1 };
-
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 3 && sp.N.length === 1
+            && (sp.E.length === 0 || (sp.E.length === 1 && sp.E[0] instanceof PlaneElement));
+    }
     construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new AngleDividerElement(P[0], P[1], P[2], screen, N[0]);
-        return [[g], g];
-    }
-}
-
-// point — angleBisector (3D variant)
-// points B, A, C, plane D
-// (Java: Slate.java point case 21, choice 1 — new AngleDivider(B,A,C,D,2))
-export class AngleBisectorPoint3dConstruction extends Construction {
-    constructionMethod: AllConstructions = PointConstructions.angleBisector;
-    signature: ConstructionSignature = { points: 3, elements: 1, integers: 0, elementTypes: [PlaneElement] };
-
-    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new AngleDividerElement(P[0], P[1], P[2], E[0] as PlaneElement, 2);
-        return [[g], g];
-    }
-}
-
-// point — angleDivider (3D variant)
-// points B, A, C, plane D, integer n
-// (Java: Slate.java point case 22, choice 1 — new AngleDivider(B,A,C,D,n))
-export class AngleDividerPoint3dConstruction extends Construction {
-    constructionMethod: AllConstructions = PointConstructions.angleDivider;
-    signature: ConstructionSignature = { points: 3, elements: 1, integers: 1, elementTypes: [PlaneElement] };
-
-    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new AngleDividerElement(P[0], P[1], P[2], E[0] as PlaneElement, N[0]);
+        let plane = E.length > 0 ? E[0] as PlaneElement : screen;
+        let g = new AngleDividerElement(P[0], P[1], P[2], plane, N[0]);
         return [[g], g];
     }
 }
 
 // point
 // fixed
-// integers x, y [z=0]
-// the fixed point with coordinates (x, y, 0)
-// (Java: Slate.java point case 23, choice 0 — new FixedPoint(x,y,0))
-export class FixedPoint2dConstruction extends Construction {
+// integers x, y [, z=0]
+// the fixed point with coordinates (x, y, z). z defaults to 0 if not provided.
+// (Java: Slate.java point case 23 — new FixedPoint(x,y,z))
+export class FixedPointConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.fixed;
     signature: ConstructionSignature = { points: 0, elements: 0, integers: 2 };
-    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new FixedPoint({x:N[0], y:N[1],z:0});
-
-        return [[g], g];
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 0 && sp.E.length === 0 && (sp.N.length === 2 || sp.N.length === 3);
     }
-}
-
-// point
-// fixed
-// integers x, y, z
-// the fixed point with coordinates (x, y, z)
-// (Java: Slate.java point case 23 — new FixedPoint(x,y,z))
-export class FixedPoint3dConstruction extends Construction {
-    constructionMethod: AllConstructions = PointConstructions.fixed;
-    signature: ConstructionSignature = { points: 0, elements: 0, integers: 3 };
     construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new FixedPoint({x:N[0], y:N[1], z:N[2]});
-
+        let g = new FixedPoint({x:N[0], y:N[1], z: N.length > 2 ? N[2] : 0});
         return [[g], g];
     }
 }
@@ -670,27 +594,21 @@ export class VertexConstruction extends Construction {
 
 export const pointConstructions: Construction[] = [
     new FreePointConstruction(),
-    new FixedPoint2dConstruction(),
-    new FixedPoint3dConstruction(),
+    new FixedPointConstruction(),
     new FirstPointConstruction(),
     new LastPointConstruction(),
     new CircleCenterConstruction(),
     new CircumcenterConstruction(),
-    new CircumcenterConstruction2d(),
     new MidPointConstruction(),
     new IntersectionConstruction(),
-    new IntersectionConstructionScreen(),
     new FootPointConstruction(),
     new PlaneFootPointConstruction(),
     new ExtendConstruction(),
     new CutoffConstruction(),
     new ParallelogramConstruction(),
-    new SimilarPoint3dConstruction(),
     new SimilarPointConstruction(),
     new ProportionPointConstruction(),
-    new AngleBisectorPoint3dConstruction(),
     new AngleBisectorPointConstruction(),
-    new AngleDividerPoint3dConstruction(),
     new AngleDividerPointConstruction(),
     new MeanProportionalPointConstruction(),
     new PlaneSliderConstruction(),
@@ -700,12 +618,9 @@ export const pointConstructions: Construction[] = [
     new PlaneIntersectionConstruction(),
     new SphereCenterConstruction(),
     new CircumcircleConstruction(),
-    new CircumcircleConstruction2d(),
     new LineSliderConstruction(),
-    new LineSlider2dConstruction(),
     new LineSliderSegmentConstruction(),
     new CircleSliderConstruction(),
-    new CircleSliderConstruction2dPoint(),
     new PointPerpendicular1Construction(),
     new PointPerpendicular2Construction(),
     new PointPerpendicular3Construction(),

--- a/src/elements/point/PointConstructions.ts
+++ b/src/elements/point/PointConstructions.ts
@@ -4,7 +4,7 @@
 |    a construct() method that creates the geometry element.             |
 +----------------------------------------------------------------------*/
 
-import {Construction, ConstructionTypes, AllConstructions, PointConstructions,
+import {Construction, ConstructionSignature, AllConstructions, PointConstructions,
         CircleConstructions, GeomElementsForUpdate} from "../Constructions";
 import {GeomElement} from "../GeomElement";
 import {CircleElement} from "../circle/CircleElement";
@@ -33,8 +33,6 @@ import {PlanePerpendicularLine} from "../line/PlanePerpendicularLine";
 import {SphereElement} from "../sphere/SphereElement";
 import {PolygonElement} from "../polygon/PolygonElement";
 
-let ct = ConstructionTypes;
-
 /***********************
  * Element Class Point *
  ***********************/
@@ -47,12 +45,9 @@ let ct = ConstructionTypes;
  */
 export class FreePointConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.free;
-    signature: ConstructionTypes[] = [ct.Integer, ct.Integer];
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let x : number = params[0];
-        let y : number = params[1];
-
-        let g = new PlaneSlider(screen, x, y, 0);
+    signature: ConstructionSignature = { points: 0, elements: 0, integers: 2 };
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new PlaneSlider(screen, N[0], N[1], 0);
 
         return [[g], g];
     }
@@ -66,12 +61,9 @@ export class FreePointConstruction extends Construction {
 // (Java: Slate.java point case 1 — new Midpoint(A, B))
 export class MidPointConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.midpoint;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement];
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let a : PointElement = params[0];
-        let b : PointElement = params[1];
-
-        let g = new Midpoint(a, b);
+    signature: ConstructionSignature = { points: 2, elements: 0, integers: 0 };
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new Midpoint(P[0], P[1]);
 
         return [[g], g];
     }
@@ -84,20 +76,9 @@ export class MidPointConstruction extends Construction {
 // (Java: Slate.java point case 2, choice 1 — new Intersection(A,B,C,D,E))
 export class IntersectionConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.intersection;
-    signature: ConstructionTypes[] = [ct.PointElement,
-                                      ct.PointElement,
-                                      ct.PointElement,
-                                      ct.PointElement,
-                                      ct.PlaneElement
-                                     ];
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let a : PointElement = params[0];
-        let b : PointElement = params[1];
-        let c : PointElement = params[2];
-        let d : PointElement = params[3];
-        let ap : PlaneElement = params[4];
-
-        let g = new Intersection(a,b,c,d,ap);
+    signature: ConstructionSignature = { points: 4, elements: 1, integers: 0, elementTypes: [PlaneElement] };
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new Intersection(P[0], P[1], P[2], P[3], E[0] as PlaneElement);
 
         return [[g], g];
     }
@@ -105,14 +86,9 @@ export class IntersectionConstruction extends Construction {
 
 // (Java: Slate.java point case 2, choice 0 — new Intersection(A,B,C,D,screen))
 export class IntersectionConstructionScreen extends IntersectionConstruction {
-    signature: ConstructionTypes[] = [ct.PointElement,
-                                      ct.PointElement,
-                                      ct.PointElement,
-                                      ct.PointElement,
-                                     ];
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        params.push(screen);
-        return super.construct(screen, params);
+    signature: ConstructionSignature = { points: 4, elements: 0, integers: 0 };
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        return super.construct(screen, P, [screen], N);
     }
 }
 
@@ -123,13 +99,10 @@ export class IntersectionConstructionScreen extends IntersectionConstruction {
 // (Java: IntersectionPL.java — TS: PlaneIntersection.ts, renamed for clarity)
 export class PlaneIntersectionConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.intersection;
-    signature: ConstructionTypes[] = [ct.PlaneElement, ct.PointElement, ct.PointElement];
+    signature: ConstructionSignature = { points: 2, elements: 1, integers: 0, elementTypes: [PlaneElement] };
 
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const P = params[0] as PlaneElement;
-        const A = params[1] as PointElement;
-        const B = params[2] as PointElement;
-        const g = new PlaneIntersection(P, A, B);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new PlaneIntersection(E[0] as PlaneElement, P[0], P[1]);
         return [[g], g];
     }
 }
@@ -141,9 +114,9 @@ export class PlaneIntersectionConstruction extends Construction {
 // (Java: Slate.java point case 3 — returns P[0], preexists=true)
 export class FirstPointConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.first;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement];
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        return [[], params[0] as PointElement];
+    signature: ConstructionSignature = { points: 2, elements: 0, integers: 0 };
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        return [[], P[0]];
     }
 
 }
@@ -155,9 +128,9 @@ export class FirstPointConstruction extends Construction {
 // (Java: Slate.java point case 4 — returns P[1], preexists=true)
 export class LastPointConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.last;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement];
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        return [[], params[1] as PointElement];
+    signature: ConstructionSignature = { points: 2, elements: 0, integers: 0 };
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        return [[], P[1]];
     }
 }
 
@@ -168,9 +141,9 @@ export class LastPointConstruction extends Construction {
 // (Java: Slate.java point case 5, choice 0 — returns ((CircleElement)E[0]).Center)
 export class CircleCenterConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.center;
-    signature: ConstructionTypes[] = [ct.CircleElement];
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        return [[], (params[0] as CircleElement).Center as PointElement];
+    signature: ConstructionSignature = { points: 0, elements: 1, integers: 0, elementTypes: [CircleElement] };
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        return [[], (E[0] as CircleElement).Center as PointElement];
     }
 }
 
@@ -181,9 +154,9 @@ export class CircleCenterConstruction extends Construction {
 // (Java: Slate.java point case 5, choice 1 — returns ((SphereElement)E[0]).Center)
 export class SphereCenterConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.center;
-    signature: ConstructionTypes[] = [ct.SphereElement];
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        return [[], (params[0] as SphereElement).Center as PointElement];
+    signature: ConstructionSignature = { points: 0, elements: 1, integers: 0, elementTypes: [SphereElement] };
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        return [[], (E[0] as SphereElement).Center as PointElement];
     }
 }
 
@@ -194,15 +167,9 @@ export class SphereCenterConstruction extends Construction {
 // (Java: Slate.java point case 6 — new LineSlider(A,B,x,y,z,false))
 export class LineSliderConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.lineSlider;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.Integer, ct.Integer, ct.Integer];
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let a : PointElement = params[0];
-        let b : PointElement = params[1];
-        let x : number = params[2];
-        let y : number = params[3];
-        let z : number = params[4];
-
-        let g = this.createSlider(a,b,x,y,z);
+    signature: ConstructionSignature = { points: 2, elements: 0, integers: 3 };
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = this.createSlider(P[0], P[1], N[0], N[1], N[2]);
 
         return [[g], g];
     }
@@ -214,14 +181,9 @@ export class LineSliderConstruction extends Construction {
 // point — lineSlider (2D variant, z defaults to 0)
 // (Java: Slate.java point case 6, choice 0 — z set to 0)
 export class LineSlider2dConstruction extends LineSliderConstruction {
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.Integer, ct.Integer];
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let a : PointElement = params[0];
-        let b : PointElement = params[1];
-        let x : number = params[2];
-        let y : number = params[3];
-
-        let g = this.createSlider(a,b,x,y,0);
+    signature: ConstructionSignature = { points: 2, elements: 0, integers: 2 };
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = this.createSlider(P[0], P[1], N[0], N[1], 0);
 
         return [[g], g];
     }
@@ -234,12 +196,10 @@ export class LineSlider2dConstruction extends LineSliderConstruction {
 // (Java: Slate.java point case 7 — new CircleSlider(E[0], x, y, z))
 export class CircleSliderConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.circleSlider;
-    signature: ConstructionTypes[] = [ct.CircleElement, ct.Integer, ct.Integer, ct.Integer];
+    signature: ConstructionSignature = { points: 0, elements: 1, integers: 3, elementTypes: [CircleElement] };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let c : CircleElement = params[0];
-        let ns : number[] = params.slice(1,4);
-        let g = new CircleSlider(c, ns[0], ns[1], ns[2]);
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new CircleSlider(E[0] as CircleElement, N[0], N[1], N[2]);
         return [[g], g];
     }
 }
@@ -247,11 +207,10 @@ export class CircleSliderConstruction extends Construction {
 // point — circleSlider (2D variant, z defaults to 0)
 // (Java: Slate.java point case 7, choice 0 — z set to 0)
 export class CircleSliderConstruction2dPoint extends CircleSliderConstruction {
-    signature: ConstructionTypes[] = [ct.CircleElement, ct.Integer, ct.Integer];
+    signature: ConstructionSignature = { points: 0, elements: 1, integers: 2, elementTypes: [CircleElement] };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        params.push(0);
-        return super.construct(screen, params);
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        return super.construct(screen, P, E, [...N, 0]);
     }
 }
 
@@ -264,14 +223,10 @@ export class CircleSliderConstruction2dPoint extends CircleSliderConstruction {
 // extends it, and both are tightly coupled.
 export class CircumcircleConstruction extends Construction {
     constructionMethod: AllConstructions = CircleConstructions.circumcircle;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement];
+    signature: ConstructionSignature = { points: 3, elements: 1, integers: 0, elementTypes: [PlaneElement] };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let A : PointElement = params[0];
-        let B : PointElement = params[1];
-        let C : PointElement = params[2];
-        let AP : PlaneElement = params[3];
-        let g = new CircumcircleElement(A,B,C,AP);
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new CircumcircleElement(P[0], P[1], P[2], E[0] as PlaneElement);
         return [[g], g];
     }
 }
@@ -279,11 +234,10 @@ export class CircumcircleConstruction extends Construction {
 // circle — circumcircle (2D variant, plane defaults to screen)
 // (Java: Slate.java circle case 1, choice 0 — E[0] = screen)
 export class CircumcircleConstruction2d extends CircumcircleConstruction {
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
+    signature: ConstructionSignature = { points: 3, elements: 0, integers: 0 };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        params.push(screen);
-        return super.construct(screen, params);
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        return super.construct(screen, P, [screen], N);
     }
 }
 
@@ -295,8 +249,8 @@ export class CircumcircleConstruction2d extends CircumcircleConstruction {
 export class CircumcenterConstruction extends CircumcircleConstruction {
     constructionMethod: AllConstructions = PointConstructions.circumcenter;
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let es = super.construct(screen, params);
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let es = super.construct(screen, P, E, N);
         let g : CircleElement = es[1] as CircleElement;
         es[0].push(g.Center);
         return [es[0], g.Center];
@@ -306,11 +260,10 @@ export class CircumcenterConstruction extends CircumcircleConstruction {
 // point — circumcenter (2D variant, plane defaults to screen)
 // (Java: Slate.java point case 8, choice 0 — E[0] = screen)
 export class CircumcenterConstruction2d extends CircumcenterConstruction {
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
+    signature: ConstructionSignature = { points: 3, elements: 0, integers: 0 };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        params.push(screen);
-        return super.construct(screen, params);
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        return super.construct(screen, P, [screen], N);
     }
 }
 
@@ -322,12 +275,9 @@ export class CircumcenterConstruction2d extends CircumcenterConstruction {
 // (Java: Slate.java point case 10, choice 0 — new Foot(A,B,C))
 export class FootPointConstruction extends Construction {
     constructionMethod : AllConstructions = PointConstructions.foot;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
-    construct(screen: PlaneElement, params: any[]) : [GeomElementsForUpdate, GeomElement] {
-        let a : PointElement = params[0];
-        let b : PointElement = params[1];
-        let c : PointElement = params[2];
-        let g = new Foot(a, b, c);
+    signature: ConstructionSignature = { points: 3, elements: 0, integers: 0 };
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]) : [GeomElementsForUpdate, GeomElement] {
+        let g = new Foot(P[0], P[1], P[2]);
 
         return [[g], g];
     }
@@ -340,12 +290,10 @@ export class FootPointConstruction extends Construction {
 // (Java: PlaneFoot.java — TS: PlaneFootElement.ts, renamed for clarity)
 export class PlaneFootPointConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.foot;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PlaneElement];
+    signature: ConstructionSignature = { points: 1, elements: 1, integers: 0, elementTypes: [PlaneElement] };
 
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const A = params[0] as PointElement;
-        const P = params[1] as PlaneElement;
-        const g = new PlaneFootElement(A, P);
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new PlaneFootElement(P[0], E[0] as PlaneElement);
         return [[g], g];
     }
 }
@@ -353,10 +301,9 @@ export class PlaneFootPointConstruction extends Construction {
 // point
 // layoff used for extend and cutoff
 export abstract class LayoffConstruction extends Construction {
-    signature: ConstructionTypes[] = (new Array(4)).fill(ct.PointElement);
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = this._createLayoff(ps);
+    signature: ConstructionSignature = { points: 4, elements: 0, integers: 0 };
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = this._createLayoff(P);
         return [[g], g];
     }
 
@@ -395,11 +342,10 @@ export class ExtendConstruction extends LayoffConstruction {
 // (Java: Slate.java point case 13 — new Layoff(C,A,B,A,B))
 export class ParallelogramConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.parallelogram;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
+    signature: ConstructionSignature = { points: 3, elements: 0, integers: 0 };
 
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const [c, a, b] = params as [PointElement, PointElement, PointElement];
-        const g = new Layoff(c, a, b, a, b);
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new Layoff(P[0], P[1], P[2], P[1], P[2]);
         return [[g], g];
     }
 }
@@ -411,11 +357,10 @@ export class ParallelogramConstruction extends Construction {
 // (Java: Similar.java — extends PointElement, calls this.toSimilar(...) in update())
 export class SimilarPointConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.similar;
-    signature: ConstructionTypes[] = (new Array(5)).fill(ct.PointElement);
+    signature: ConstructionSignature = { points: 5, elements: 0, integers: 0 };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new SimilarElement(ps[0], ps[1], screen, ps[2], ps[3], ps[4], screen);
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new SimilarElement(P[0], P[1], screen, P[2], P[3], P[4], screen);
         return [[g], g];
     }
 }
@@ -426,15 +371,10 @@ export class SimilarPointConstruction extends Construction {
 // (Java: Similar with explicit PlaneElements instead of screen)
 export class SimilarPoint3dConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.similar;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PlaneElement,
-        ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement];
+    signature: ConstructionSignature = { points: 5, elements: 2, integers: 0, elementTypes: [PlaneElement, PlaneElement] };
 
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const A = params[0] as PointElement, B = params[1] as PointElement;
-        const C = params[2] as PlaneElement;
-        const D = params[3] as PointElement, E = params[4] as PointElement, F = params[5] as PointElement;
-        const G = params[6] as PlaneElement;
-        const g = new SimilarElement(A, B, C, D, E, F, G);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new SimilarElement(P[0], P[1], E[0] as PlaneElement, P[2], P[3], P[4], E[1] as PlaneElement);
         return [[g], g];
     }
 }
@@ -444,6 +384,7 @@ export abstract class PointPerpendicularConstruction extends Construction {
     constructionMethod : AllConstructions = PointConstructions.perpendicular;
 }
 
+
 /* point
  * perpendicular
  * points A, B, [plane C (screen)]
@@ -451,11 +392,9 @@ export abstract class PointPerpendicularConstruction extends Construction {
  * (Java: Slate.java point case 15, choice 0 — new Perpendicular(A,B,screen,A,B))
  */
 export class PointPerpendicular1Construction extends PointPerpendicularConstruction {
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement];
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let a : PointElement = params[0];
-        let b : PointElement = params[1];
-        let g = new Perpendicular({C:a, D:b,P:screen, E:a, F:b});
+    signature: ConstructionSignature = { points: 2, elements: 0, integers: 0 };
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new Perpendicular({C:P[0], D:P[1],P:screen, E:P[0], F:P[1]});
         return [[g], g.B];
     }
 }
@@ -468,12 +407,9 @@ export class PointPerpendicular1Construction extends PointPerpendicularConstruct
  * (Java: Slate.java point case 15, choice 1 — new Perpendicular(A,B,C,A,B))
  */
 export class PointPerpendicular2Construction extends PointPerpendicularConstruction {
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PlaneElement];
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let a : PointElement = params[0];
-        let b : PointElement = params[1];
-        let c : PlaneElement = params[2];
-        let g = new Perpendicular({C:a, D:b,P:c, E:a, F:b});
+    signature: ConstructionSignature = { points: 2, elements: 1, integers: 0, elementTypes: [PlaneElement] };
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new Perpendicular({C:P[0], D:P[1],P:E[0] as PlaneElement, E:P[0], F:P[1]});
         return [[g], g.B];
     }
 }
@@ -486,13 +422,9 @@ export class PointPerpendicular2Construction extends PointPerpendicularConstruct
  * (Java: Slate.java point case 15, choice 2 — new Perpendicular(A,B,screen,D,E))
  */
 export class PointPerpendicular3Construction extends PointPerpendicularConstruction {
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement, ct.PointElement];
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let a : PointElement = params[0];
-        let b : PointElement = params[1];
-        let d : PointElement = params[2];
-        let e : PointElement = params[3];
-        let g = new Perpendicular({C:a, D:b,P:screen, E:d, F:e});
+    signature: ConstructionSignature = { points: 4, elements: 0, integers: 0 };
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new Perpendicular({C:P[0], D:P[1],P:screen, E:P[2], F:P[3]});
         return [[g], g.B];
     }
 }
@@ -505,14 +437,9 @@ export class PointPerpendicular3Construction extends PointPerpendicularConstruct
  * (Java: Slate.java point case 15, choice 3 — new Perpendicular(A,B,C,D,E))
  */
 export class PointPerpendicular4Construction extends PointPerpendicularConstruction {
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PlaneElement, ct.PointElement, ct.PointElement];
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let a : PointElement = params[0];
-        let b : PointElement = params[1];
-        let c : PlaneElement = params[2];
-        let d : PointElement = params[3];
-        let e : PointElement = params[4];
-        let g = new Perpendicular({C:a, D:b,P:c, E:d, F:e});
+    signature: ConstructionSignature = { points: 4, elements: 1, integers: 0, elementTypes: [PlaneElement] };
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new Perpendicular({C:P[0], D:P[1],P:E[0] as PlaneElement, E:P[2], F:P[3]});
         return [[g], g.B];
     }
 }
@@ -526,13 +453,9 @@ export class PointPerpendicular4Construction extends PointPerpendicularConstruct
  * (Java: Slate.java point case 15, choice 4 — new PlanePerpendicular(A,B,C,D))
  */
 export class PointPerpendicular5Construction extends PointPerpendicularConstruction {
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PlaneElement, ct.PointElement, ct.PointElement];
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let a : PointElement = params[0];
-        let b : PlaneElement = params[1];
-        let c : PointElement = params[2];
-        let d : PointElement = params[3];
-        let g = new PlanePerpendicularLine({C:a, P:b, D:c, E:d});
+    signature: ConstructionSignature = { points: 3, elements: 1, integers: 0, elementTypes: [PlaneElement] };
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new PlanePerpendicularLine({C:P[0], P:E[0] as PlaneElement, D:P[1], E:P[2]});
         return [[g], g.B];
     }
 }
@@ -545,11 +468,10 @@ export class PointPerpendicular5Construction extends PointPerpendicularConstruct
 // (Java: Proportion.java — 26 lines, line-for-line port)
 export class ProportionPointConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.proportion;
-    signature: ConstructionTypes[] = (new Array(8)).fill(ct.PointElement);
+    signature: ConstructionSignature = { points: 8, elements: 0, integers: 0 };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new ProportionElement(ps[0], ps[1], ps[2], ps[3], ps[4], ps[5], ps[6], ps[7]);
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new ProportionElement(P[0], P[1], P[2], P[3], P[4], P[5], P[6], P[7]);
         return [[g], g];
     }
 }
@@ -561,12 +483,10 @@ export class ProportionPointConstruction extends Construction {
 // (Java: InvertPoint.java — 16 lines, calls toInvertPoint(A, C))
 export class InvertPointConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.invert;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.CircleElement];
+    signature: ConstructionSignature = { points: 1, elements: 1, integers: 0, elementTypes: [CircleElement] };
 
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const A = params[0] as PointElement;
-        const C = params[1] as CircleElement;
-        const g = new InvertPointElement(A, C);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new InvertPointElement(P[0], E[0] as CircleElement);
         return [[g], g];
     }
 }
@@ -578,11 +498,10 @@ export class InvertPointConstruction extends Construction {
 // (Java: MeanProportional.java — 23 lines, line-for-line port)
 export class MeanProportionalPointConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.meanProportional;
-    signature: ConstructionTypes[] = (new Array(6)).fill(ct.PointElement);
+    signature: ConstructionSignature = { points: 6, elements: 0, integers: 0 };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new MeanProportionalElement(ps[0], ps[1], ps[2], ps[3], ps[4], ps[5]);
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new MeanProportionalElement(P[0], P[1], P[2], P[3], P[4], P[5]);
         return [[g], g];
     }
 }
@@ -595,14 +514,10 @@ export class MeanProportionalPointConstruction extends Construction {
 // PlaneSlider.ts already has the full constructor + update() + drag().)
 export class PlaneSliderConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.planeSlider;
-    signature: ConstructionTypes[] = [ct.PlaneElement, ct.Integer, ct.Integer, ct.Integer];
+    signature: ConstructionSignature = { points: 0, elements: 1, integers: 3, elementTypes: [PlaneElement] };
 
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const plane = params[0] as PlaneElement;
-        const x = params[1] as number;
-        const y = params[2] as number;
-        const z = params[3] as number;
-        const g = new PlaneSlider(plane, x, y, z);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new PlaneSlider(E[0] as PlaneElement, N[0], N[1], N[2]);
         return [[g], g];
     }
 }
@@ -614,14 +529,10 @@ export class PlaneSliderConstruction extends Construction {
 // (Java: SphereSlider.java — 43 lines, line-for-line port)
 export class SphereSliderConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.sphereSlider;
-    signature: ConstructionTypes[] = [ct.SphereElement, ct.Integer, ct.Integer, ct.Integer];
+    signature: ConstructionSignature = { points: 0, elements: 1, integers: 3, elementTypes: [SphereElement] };
 
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const S = params[0] as SphereElement;
-        const x = params[1] as number;
-        const y = params[2] as number;
-        const z = params[3] as number;
-        const g = new SphereSliderElement(S, x, y, z);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new SphereSliderElement(E[0] as SphereElement, N[0], N[1], N[2]);
         return [[g], g];
     }
 }
@@ -633,11 +544,10 @@ export class SphereSliderConstruction extends Construction {
 // (Java: AngleDivider.java with n=2, Slate.java point case 21)
 export class AngleBisectorPointConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.angleBisector;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
+    signature: ConstructionSignature = { points: 3, elements: 0, integers: 0 };
 
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new AngleDividerElement(ps[0], ps[1], ps[2], screen, 2);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new AngleDividerElement(P[0], P[1], P[2], screen, 2);
         return [[g], g];
     }
 }
@@ -649,12 +559,10 @@ export class AngleBisectorPointConstruction extends Construction {
 // (Java: AngleDivider.java with variable n, Slate.java point case 22)
 export class AngleDividerPointConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.angleDivider;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement, ct.Integer];
+    signature: ConstructionSignature = { points: 3, elements: 0, integers: 1 };
 
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let n : number = params[3];
-        let g = new AngleDividerElement(ps[0], ps[1], ps[2], screen, n);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new AngleDividerElement(P[0], P[1], P[2], screen, N[0]);
         return [[g], g];
     }
 }
@@ -664,11 +572,10 @@ export class AngleDividerPointConstruction extends Construction {
 // (Java: Slate.java point case 21, choice 1 — new AngleDivider(B,A,C,D,2))
 export class AngleBisectorPoint3dConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.angleBisector;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement];
+    signature: ConstructionSignature = { points: 3, elements: 1, integers: 0, elementTypes: [PlaneElement] };
 
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new AngleDividerElement(ps[0], ps[1], ps[2], params[3] as PlaneElement, 2);
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new AngleDividerElement(P[0], P[1], P[2], E[0] as PlaneElement, 2);
         return [[g], g];
     }
 }
@@ -678,11 +585,10 @@ export class AngleBisectorPoint3dConstruction extends Construction {
 // (Java: Slate.java point case 22, choice 1 — new AngleDivider(B,A,C,D,n))
 export class AngleDividerPoint3dConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.angleDivider;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement, ct.Integer];
+    signature: ConstructionSignature = { points: 3, elements: 1, integers: 1, elementTypes: [PlaneElement] };
 
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new AngleDividerElement(ps[0], ps[1], ps[2], params[3] as PlaneElement, params[4] as number);
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new AngleDividerElement(P[0], P[1], P[2], E[0] as PlaneElement, N[0]);
         return [[g], g];
     }
 }
@@ -694,12 +600,9 @@ export class AngleDividerPoint3dConstruction extends Construction {
 // (Java: Slate.java point case 23, choice 0 — new FixedPoint(x,y,0))
 export class FixedPoint2dConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.fixed;
-    signature: ConstructionTypes[] = [ct.Integer, ct.Integer];
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let x : number = params[0];
-        let y : number = params[1];
-
-        let g = new FixedPoint({x:x, y:y,z:0});
+    signature: ConstructionSignature = { points: 0, elements: 0, integers: 2 };
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new FixedPoint({x:N[0], y:N[1],z:0});
 
         return [[g], g];
     }
@@ -712,13 +615,9 @@ export class FixedPoint2dConstruction extends Construction {
 // (Java: Slate.java point case 23 — new FixedPoint(x,y,z))
 export class FixedPoint3dConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.fixed;
-    signature: ConstructionTypes[] = [ct.Integer, ct.Integer, ct.Integer];
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let x : number = params[0];
-        let y : number = params[1];
-        let z : number = params[2];
-
-        let g = new FixedPoint({x:x, y:y, z:z});
+    signature: ConstructionSignature = { points: 0, elements: 0, integers: 3 };
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new FixedPoint({x:N[0], y:N[1], z:N[2]});
 
         return [[g], g];
     }
@@ -745,11 +644,10 @@ export class LineSliderSegmentConstruction extends LineSliderConstruction {
 // Slate.java point case 25 — new Harmonic(P[0], P[1], P[2]))
 export class HarmonicPointConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.harmonic;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
+    signature: ConstructionSignature = { points: 3, elements: 0, integers: 0 };
 
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new HarmonicElement(ps[0], ps[1], ps[2]);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new HarmonicElement(P[0], P[1], P[2]);
         return [[g], g];
     }
 }
@@ -761,12 +659,11 @@ export class HarmonicPointConstruction extends Construction {
 // (Java: Slate.java point case 9 — returns ((PolygonElement)E[0]).V[n-1])
 export class VertexConstruction extends Construction {
     constructionMethod: AllConstructions = PointConstructions.vertex;
-    signature: ConstructionTypes[] = [ct.PolygonElement, ct.Integer];
+    signature: ConstructionSignature = { points: 0, elements: 1, integers: 1, elementTypes: [PolygonElement] };
 
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const poly = params[0] as PolygonElement;
-        const n    = params[1] as number;
-        const vertex = poly.V[n - 1];
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const poly = E[0] as PolygonElement;
+        const vertex = poly.V[N[0] - 1];
         return [[vertex], vertex];
     }
 }

--- a/src/elements/polygon/PolygonConstructions.ts
+++ b/src/elements/polygon/PolygonConstructions.ts
@@ -4,7 +4,7 @@
 |    a construct() method that creates the geometry element.             |
 +----------------------------------------------------------------------*/
 
-import {Construction, AllConstructions,
+import {Construction, ConstructionSignature, SortedParams, AllConstructions,
         PolygonConstructions as PolygonConstructionsEnum,
         GeomElementsForUpdate} from "../Constructions";
 import {GeomElement} from "../GeomElement";
@@ -29,29 +29,22 @@ export abstract class PolyConstruction extends Construction {
 }
 
 // polygon
-// square
-// points A, B [plane C]
-// the square on a side AB in plane C (2D variant: plane defaults to screen)
+// square — points A, B [, plane C = screen]
+// the square on a side AB in plane C
+// 2D: 2 points, 0 elements — uses screen plane
+// 3D: 2 points, 1 PlaneElement — uses explicit plane
 // (Java: RegularPolygon.java with n=4 — same class as equilateralTriangle)
 export class SquarePolygonConstruction extends Construction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.square;
-    signature = { points: 2, elements: 0, integers: 0 };
-
-    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        const g = new RegularPolygonElement(P[0], P[1], screen, 4);
-        return [[g], g];
+    signature: ConstructionSignature = { points: 2, elements: 0, integers: 0 };
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 2 && sp.N.length === 0
+            && (sp.E.length === 0 || (sp.E.length === 1 && sp.E[0] instanceof PlaneElement));
     }
-}
-
-// polygon — square (3D variant)
-// points A, B, plane C
-// (Java: Slate.java polygon case 0, choice 1 — new RegularPolygon(A,B,C,4))
-export class SquarePolygon3dConstruction extends Construction {
-    constructionMethod: AllConstructions = PolygonConstructionsEnum.square;
-    signature = { points: 2, elements: 1, integers: 0, elementTypes: [PlaneElement] };
-
-    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        const g = new RegularPolygonElement(P[0], P[1], E[0] as PlaneElement, 4);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const plane = E.length > 0 ? E[0] as PlaneElement : screen;
+        const g = new RegularPolygonElement(P[0], P[1], plane, 4);
         return [[g], g];
     }
 }
@@ -97,29 +90,22 @@ export class HexagonPolygonConstruction extends PolyConstruction {
 }
 
 // polygon
-// equilateralTriangle
-// points A, B [plane C = screen]
-// the equilateral triangle on side AB in the screen plane (2D variant)
-// (Java: Slate.java polygon case 5, choice 0 — new RegularPolygon(A,B,screen,3))
+// equilateralTriangle — points A, B [, plane C = screen]
+// the equilateral triangle on side AB in the plane C
+// 2D: 2 points, 0 elements — uses screen plane
+// 3D: 2 points, 1 PlaneElement — uses explicit plane
+// (Java: Slate.java polygon case 5 — new RegularPolygon(A,B,plane,3))
 export class EquilateralTriangleConstruction extends Construction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.equilateralTriangle;
-    signature = { points: 2, elements: 0, integers: 0 };
-
-    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        const g = new RegularPolygonElement(P[0], P[1], screen, 3);
-        return [[g], g];
+    signature: ConstructionSignature = { points: 2, elements: 0, integers: 0 };
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 2 && sp.N.length === 0
+            && (sp.E.length === 0 || (sp.E.length === 1 && sp.E[0] instanceof PlaneElement));
     }
-}
-
-// polygon — equilateralTriangle (3D variant)
-// points A, B, plane C
-// (Java: Slate.java polygon case 5, choice 1 — new RegularPolygon(A,B,C,3))
-export class EquilateralTriangle3dConstruction extends Construction {
-    constructionMethod: AllConstructions = PolygonConstructionsEnum.equilateralTriangle;
-    signature = { points: 2, elements: 1, integers: 0, elementTypes: [PlaneElement] };
-
-    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        const g = new RegularPolygonElement(P[0], P[1], E[0] as PlaneElement, 3);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const plane = E.length > 0 ? E[0] as PlaneElement : screen;
+        const g = new RegularPolygonElement(P[0], P[1], plane, 3);
         return [[g], g];
     }
 }
@@ -142,29 +128,22 @@ export class ParallelogramPolygonConstruction extends Construction {
 }
 
 // polygon
-// regularPolygon (2D variant)
-// points A, B, integer n
-// the regular n-gon on side AB in the screen plane
-// (Java: Slate.java polygon case 7 — RegularPolygon(A, B, screen, n))
+// regularPolygon — points A, B, integer n [, plane C = screen]
+// the regular n-gon on side AB in the plane C
+// 2D: 2 points, 0 elements, 1 integer — uses screen plane
+// 3D: 2 points, 1 PlaneElement, 1 integer — uses explicit plane
+// (Java: Slate.java polygon case 7 — RegularPolygon(A,B,plane,n))
 export class RegularPolygonConstruction extends Construction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.regularPolygon;
-    signature = { points: 2, elements: 0, integers: 1 };
-
-    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        const g = new RegularPolygonElement(P[0], P[1], screen, N[0]);
-        return [[g], g];
+    signature: ConstructionSignature = { points: 2, elements: 0, integers: 1 };
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 2 && sp.N.length === 1
+            && (sp.E.length === 0 || (sp.E.length === 1 && sp.E[0] instanceof PlaneElement));
     }
-}
-
-// polygon — regularPolygon (3D variant)
-// points A, B, plane C, integer n
-// (Java: Slate.java polygon case 7, choice 1 — new RegularPolygon(A,B,C,n))
-export class RegularPolygon3dConstruction extends Construction {
-    constructionMethod: AllConstructions = PolygonConstructionsEnum.regularPolygon;
-    signature = { points: 2, elements: 1, integers: 1, elementTypes: [PlaneElement] };
-
-    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        const g = new RegularPolygonElement(P[0], P[1], E[0] as PlaneElement, N[0]);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const plane = E.length > 0 ? E[0] as PlaneElement : screen;
+        const g = new RegularPolygonElement(P[0], P[1], plane, N[0]);
         return [[g], g];
     }
 }
@@ -186,30 +165,23 @@ export class StarPolygonConstruction extends Construction {
 
 
 // polygon
-// similar (2D variant)
-// points A, B, D, E, F
-// the triangle ABH where H is the similar point so △ABH ∼ △DEF (screen plane)
-// (Java: Slate.java polygon case 9 — Similar(A,B,screen,D,E,F,screen) + PolygonElement(A,B,H))
+// similar — points A, B, D, E, F [, planes C, G = screen]
+// the triangle ABH where H is the similar point so triangle ABH ~ triangle DEF
+// 2D: 5 points, 0 elements — uses screen plane for both
+// 3D: 5 points, 2 PlaneElements — uses explicit planes
+// (Java: Slate.java polygon case 9 — Similar(A,B,C,D,E,F,G) + PolygonElement(A,B,H))
 export class SimilarPolygonConstruction extends Construction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.similar;
-    signature = { points: 5, elements: 0, integers: 0 };
-
-    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let sim = new SimilarElement(P[0], P[1], screen, P[2], P[3], P[4], screen);
-        let g = new PolygonElement([P[0], P[1], sim]);
-        return [[sim, g], g];
+    signature: ConstructionSignature = { points: 5, elements: 0, integers: 0 };
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 5 && sp.N.length === 0
+            && (sp.E.length === 0 || sp.E.length === 2);
     }
-}
-
-// polygon — similar (3D variant)
-// points A, B, plane C, points D, E, F, plane G
-// (Java: Slate.java polygon case 9, choice 1 — Similar(A,B,C,D,E,F,G) + PolygonElement(A,B,H))
-export class SimilarPolygon3dConstruction extends Construction {
-    constructionMethod: AllConstructions = PolygonConstructionsEnum.similar;
-    signature = { points: 5, elements: 2, integers: 0, elementTypes: [PlaneElement, PlaneElement] };
-
-    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let sim = new SimilarElement(P[0], P[1], E[0] as PlaneElement, P[2], P[3], P[4], E[1] as PlaneElement);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let c = E.length > 0 ? E[0] as PlaneElement : screen;
+        let g2 = E.length > 1 ? E[1] as PlaneElement : screen;
+        let sim = new SimilarElement(P[0], P[1], c, P[2], P[3], P[4], g2);
         let g = new PolygonElement([P[0], P[1], sim]);
         return [[sim, g], g];
     }
@@ -260,18 +232,14 @@ export class FacePolygonConstruction extends Construction {
 export const polygonConstructions: Construction[] = [
     new TrianglePolygonConstruction(),
     new StarPolygonConstruction(),
-    new RegularPolygon3dConstruction(),
     new RegularPolygonConstruction(),
-    new SquarePolygon3dConstruction(),
     new SquarePolygonConstruction(),
-    new EquilateralTriangle3dConstruction(),
     new EquilateralTriangleConstruction(),
     new ParallelogramPolygonConstruction(),
     new QuadrilateralPolygonConstruction(),
     new OctagonPolygonConstruction(),
     new PentagonPolygonConstruction(),
     new HexagonPolygonConstruction(),
-    new SimilarPolygon3dConstruction(),
     new SimilarPolygonConstruction(),
     new ApplicationPolygonConstruction(),
     new FacePolygonConstruction(),

--- a/src/elements/polygon/PolygonConstructions.ts
+++ b/src/elements/polygon/PolygonConstructions.ts
@@ -4,7 +4,7 @@
 |    a construct() method that creates the geometry element.             |
 +----------------------------------------------------------------------*/
 
-import {Construction, ConstructionTypes, AllConstructions,
+import {Construction, AllConstructions,
         PolygonConstructions as PolygonConstructionsEnum,
         GeomElementsForUpdate} from "../Constructions";
 import {GeomElement} from "../GeomElement";
@@ -17,16 +17,13 @@ import {RegularPolygonElement} from "./RegularPolygonElement";
 import {ApplicationElement} from "./ApplicationElement";
 import {PolyhedronElement} from "../polyhedron/PolyhedronElement";
 
-let ct = ConstructionTypes;
-
 /*************************
  * Element Class Polygon *
  *************************/
 
 export abstract class PolyConstruction extends Construction {
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new PolygonElement(ps);
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new PolygonElement(P);
         return [[g],g];
     }
 }
@@ -38,11 +35,10 @@ export abstract class PolyConstruction extends Construction {
 // (Java: RegularPolygon.java with n=4 — same class as equilateralTriangle)
 export class SquarePolygonConstruction extends Construction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.square;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement];
+    signature = { points: 2, elements: 0, integers: 0 };
 
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const [a, b] = params as [PointElement, PointElement];
-        const g = new RegularPolygonElement(a, b, screen, 4);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new RegularPolygonElement(P[0], P[1], screen, 4);
         return [[g], g];
     }
 }
@@ -52,11 +48,10 @@ export class SquarePolygonConstruction extends Construction {
 // (Java: Slate.java polygon case 0, choice 1 — new RegularPolygon(A,B,C,4))
 export class SquarePolygon3dConstruction extends Construction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.square;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PlaneElement];
+    signature = { points: 2, elements: 1, integers: 0, elementTypes: [PlaneElement] };
 
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const [a, b] = params as [PointElement, PointElement];
-        const g = new RegularPolygonElement(a, b, params[2] as PlaneElement, 4);
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new RegularPolygonElement(P[0], P[1], E[0] as PlaneElement, 4);
         return [[g], g];
     }
 }
@@ -68,7 +63,7 @@ export class SquarePolygon3dConstruction extends Construction {
 // (Java: Slate.java polygon case 1 — new PolygonElement(A,B,C))
 export class TrianglePolygonConstruction extends PolyConstruction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.triangle;
-    signature: ConstructionTypes[] = (new Array(3)).fill(ct.PointElement);
+    signature = { points: 3, elements: 0, integers: 0 };
 }
 
 // polygon
@@ -78,7 +73,7 @@ export class TrianglePolygonConstruction extends PolyConstruction {
 // (Java: Slate.java polygon case 2 — new PolygonElement(A,B,C,D))
 export class QuadrilateralPolygonConstruction extends PolyConstruction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.quadrilateral;
-    signature: ConstructionTypes[] = (new Array(4)).fill(ct.PointElement);
+    signature = { points: 4, elements: 0, integers: 0 };
 }
 
 // polygon
@@ -88,7 +83,7 @@ export class QuadrilateralPolygonConstruction extends PolyConstruction {
 // (Java: Slate.java polygon case 3 — new PolygonElement(A,B,C,D,E))
 export class PentagonPolygonConstruction extends PolyConstruction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.pentagon;
-    signature: ConstructionTypes[] = (new Array(5)).fill(ct.PointElement);
+    signature = { points: 5, elements: 0, integers: 0 };
 }
 
 // polygon
@@ -98,7 +93,7 @@ export class PentagonPolygonConstruction extends PolyConstruction {
 // (Java: Slate.java polygon case 4 — new PolygonElement(A,B,C,D,E,F))
 export class HexagonPolygonConstruction extends PolyConstruction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.hexagon;
-    signature: ConstructionTypes[] = (new Array(6)).fill(ct.PointElement);
+    signature = { points: 6, elements: 0, integers: 0 };
 }
 
 // polygon
@@ -108,11 +103,10 @@ export class HexagonPolygonConstruction extends PolyConstruction {
 // (Java: Slate.java polygon case 5, choice 0 — new RegularPolygon(A,B,screen,3))
 export class EquilateralTriangleConstruction extends Construction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.equilateralTriangle;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement];
+    signature = { points: 2, elements: 0, integers: 0 };
 
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const [a, b] = params as [PointElement, PointElement];
-        const g = new RegularPolygonElement(a, b, screen, 3);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new RegularPolygonElement(P[0], P[1], screen, 3);
         return [[g], g];
     }
 }
@@ -122,11 +116,10 @@ export class EquilateralTriangleConstruction extends Construction {
 // (Java: Slate.java polygon case 5, choice 1 — new RegularPolygon(A,B,C,3))
 export class EquilateralTriangle3dConstruction extends Construction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.equilateralTriangle;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PlaneElement];
+    signature = { points: 2, elements: 1, integers: 0, elementTypes: [PlaneElement] };
 
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const [a, b] = params as [PointElement, PointElement];
-        const g = new RegularPolygonElement(a, b, params[2] as PlaneElement, 3);
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new RegularPolygonElement(P[0], P[1], E[0] as PlaneElement, 3);
         return [[g], g];
     }
 }
@@ -139,12 +132,11 @@ export class EquilateralTriangle3dConstruction extends Construction {
 // trick identical to the point;parallelogram and line;parallel patterns)
 export class ParallelogramPolygonConstruction extends Construction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.parallelogram;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
+    signature = { points: 3, elements: 0, integers: 0 };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let lo = new Layoff(ps[0], ps[1], ps[2], ps[1], ps[2]);
-        let g = new PolygonElement([ps[0], ps[1], ps[2], lo]);
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let lo = new Layoff(P[0], P[1], P[2], P[1], P[2]);
+        let g = new PolygonElement([P[0], P[1], P[2], lo]);
         return [[lo, g], g];
     }
 }
@@ -156,13 +148,10 @@ export class ParallelogramPolygonConstruction extends Construction {
 // (Java: Slate.java polygon case 7 — RegularPolygon(A, B, screen, n))
 export class RegularPolygonConstruction extends Construction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.regularPolygon;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.Integer];
+    signature = { points: 2, elements: 0, integers: 1 };
 
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const a = params[0] as PointElement;
-        const b = params[1] as PointElement;
-        const n = params[2] as number;
-        const g = new RegularPolygonElement(a, b, screen, n);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new RegularPolygonElement(P[0], P[1], screen, N[0]);
         return [[g], g];
     }
 }
@@ -172,14 +161,10 @@ export class RegularPolygonConstruction extends Construction {
 // (Java: Slate.java polygon case 7, choice 1 — new RegularPolygon(A,B,C,n))
 export class RegularPolygon3dConstruction extends Construction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.regularPolygon;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PlaneElement, ct.Integer];
+    signature = { points: 2, elements: 1, integers: 1, elementTypes: [PlaneElement] };
 
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const a = params[0] as PointElement;
-        const b = params[1] as PointElement;
-        const plane = params[2] as PlaneElement;
-        const n = params[3] as number;
-        const g = new RegularPolygonElement(a, b, plane, n);
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new RegularPolygonElement(P[0], P[1], E[0] as PlaneElement, N[0]);
         return [[g], g];
     }
 }
@@ -191,14 +176,10 @@ export class RegularPolygon3dConstruction extends Construction {
 // (Java: Slate.java polygon case 8 — new RegularPolygon(A,B,screen,n,d))
 export class StarPolygonConstruction extends Construction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.starPolygon;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.Integer, ct.Integer];
+    signature = { points: 2, elements: 0, integers: 2 };
 
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const a = params[0] as PointElement;
-        const b = params[1] as PointElement;
-        const n = params[2] as number;
-        const d = params[3] as number;
-        const g = new RegularPolygonElement(a, b, screen, n, d);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new RegularPolygonElement(P[0], P[1], screen, N[0], N[1]);
         return [[g], g];
     }
 }
@@ -211,12 +192,11 @@ export class StarPolygonConstruction extends Construction {
 // (Java: Slate.java polygon case 9 — Similar(A,B,screen,D,E,F,screen) + PolygonElement(A,B,H))
 export class SimilarPolygonConstruction extends Construction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.similar;
-    signature: ConstructionTypes[] = (new Array(5)).fill(ct.PointElement);
+    signature = { points: 5, elements: 0, integers: 0 };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let sim = new SimilarElement(ps[0], ps[1], screen, ps[2], ps[3], ps[4], screen);
-        let g = new PolygonElement([ps[0], ps[1], sim]);
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let sim = new SimilarElement(P[0], P[1], screen, P[2], P[3], P[4], screen);
+        let g = new PolygonElement([P[0], P[1], sim]);
         return [[sim, g], g];
     }
 }
@@ -226,16 +206,11 @@ export class SimilarPolygonConstruction extends Construction {
 // (Java: Slate.java polygon case 9, choice 1 — Similar(A,B,C,D,E,F,G) + PolygonElement(A,B,H))
 export class SimilarPolygon3dConstruction extends Construction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.similar;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PlaneElement,
-        ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement];
+    signature = { points: 5, elements: 2, integers: 0, elementTypes: [PlaneElement, PlaneElement] };
 
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const A = params[0] as PointElement, B = params[1] as PointElement;
-        const C = params[2] as PlaneElement;
-        const D = params[3] as PointElement, E = params[4] as PointElement, F = params[5] as PointElement;
-        const G = params[6] as PlaneElement;
-        let sim = new SimilarElement(A, B, C, D, E, F, G);
-        let g = new PolygonElement([A, B, sim]);
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let sim = new SimilarElement(P[0], P[1], E[0] as PlaneElement, P[2], P[3], P[4], E[1] as PlaneElement);
+        let g = new PolygonElement([P[0], P[1], sim]);
         return [[sim, g], g];
     }
 }
@@ -247,14 +222,10 @@ export class SimilarPolygon3dConstruction extends Construction {
 // (Java: Application.java — parallelogram with area = P.area(), side BC, angle DCB)
 export class ApplicationPolygonConstruction extends Construction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.application;
-    signature: ConstructionTypes[] = [ct.PolygonElement, ct.PointElement, ct.PointElement, ct.PointElement];
+    signature = { points: 3, elements: 1, integers: 0, elementTypes: [PolygonElement] };
 
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const P = params[0] as PolygonElement;
-        const A = params[1] as PointElement;
-        const B = params[2] as PointElement;
-        const C = params[3] as PointElement;
-        const g = new ApplicationElement(P, A, B, C);
+    construct(screen : PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new ApplicationElement(E[0] as PolygonElement, P[0], P[1], P[2]);
         return [[g], g];
     }
 }
@@ -266,7 +237,7 @@ export class ApplicationPolygonConstruction extends Construction {
 // (Java: Slate.java polygon case 11 — new PolygonElement(A,B,C,D,E,F,G,H))
 export class OctagonPolygonConstruction extends PolyConstruction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.octagon;
-    signature: ConstructionTypes[] = (new Array(8)).fill(ct.PointElement);
+    signature = { points: 8, elements: 0, integers: 0 };
 }
 
 // polygon
@@ -277,12 +248,11 @@ export class OctagonPolygonConstruction extends PolyConstruction {
 // Same pattern as point;vertex (returns polygon from polyhedron, not point from polygon)
 export class FacePolygonConstruction extends Construction {
     constructionMethod: AllConstructions = PolygonConstructionsEnum.face;
-    signature: ConstructionTypes[] = [ct.PolyhedronElement, ct.Integer];
+    signature = { points: 0, elements: 1, integers: 1, elementTypes: [PolyhedronElement] };
 
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const polyhedron = params[0] as PolyhedronElement;
-        const n = params[1] as number;
-        const face = polyhedron.P[n - 1];
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const polyhedron = E[0] as PolyhedronElement;
+        const face = polyhedron.P[N[0] - 1];
         return [[face], face];
     }
 }

--- a/src/elements/polyhedron/PolyhedronConstructions.ts
+++ b/src/elements/polyhedron/PolyhedronConstructions.ts
@@ -1,10 +1,8 @@
 /*----------------------------------------------------------------------+
 |    Polyhedron construction classes — extracted from Constructions.ts   |
-|    Each class maps a (type, constructionName, signature) triple to    |
-|    a construct() method that creates the geometry element.             |
 +----------------------------------------------------------------------*/
 
-import {Construction, ConstructionTypes, AllConstructions,
+import {Construction, AllConstructions,
         PolyhedraConstructions as PolyhedraConstructionsEnum,
         GeomElementsForUpdate} from "../Constructions";
 import {GeomElement} from "../GeomElement";
@@ -12,82 +10,52 @@ import {PlaneElement} from "../plane/PlaneElement";
 import {PointElement} from "../point/PointElement";
 import {Layoff} from "../point/Layoff";
 import {PolygonElement} from "../polygon/PolygonElement";
-import {PolyhedronElement} from "./PolyhedronElement";
 import {PyramidElement} from "./PyramidElement";
 import {PrismElement} from "./PrismElement";
 
-let ct = ConstructionTypes;
-
-/****************************
- * Element Class Polyhedron *
- ****************************/
-
-// polyhedron
-// tetrahedron
-// points A, B, C, D
-// the tetrahedron given four vertices (creates a triangle base + Pyramid)
+// polyhedron — tetrahedron — points A, B, C, D
 // (Java: Slate.java polyhedron case 0 — PolygonElement(A,B,C) + Pyramid(base,D))
 export class TetrahedronConstruction extends Construction {
     constructionMethod: AllConstructions = PolyhedraConstructionsEnum.tetrahedron;
-    signature: ConstructionTypes[] = (new Array(4)).fill(ct.PointElement);
-
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let base = new PolygonElement([ps[0], ps[1], ps[2]]);
-        let g = new PyramidElement(base, ps[3]);
+    signature = { points: 4, elements: 0, integers: 0 };
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let base = new PolygonElement([P[0], P[1], P[2]]);
+        let g = new PyramidElement(base, P[3]);
         return [[base, g], g];
     }
 }
 
-// polyhedron
-// parallelepiped
-// points A, B, C, D
-// the parallelepiped with three edges AB, AC, and AD
+// polyhedron — parallelepiped — points A, B, C, D
 // (Java: Slate.java polyhedron case 1 — Layoff(B,A,C,A,C) + PolygonElement(B,A,C,fourth) + Prism(base,A,D))
 export class ParallelepipedConstruction extends Construction {
     constructionMethod: AllConstructions = PolyhedraConstructionsEnum.parallelepiped;
-    signature: ConstructionTypes[] = (new Array(4)).fill(ct.PointElement);
-
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let fourth = new Layoff(ps[1], ps[0], ps[2], ps[0], ps[2]);
-        let base = new PolygonElement([ps[1], ps[0], ps[2], fourth]);
-        let g = new PrismElement(base, ps[0], ps[3]);
+    signature = { points: 4, elements: 0, integers: 0 };
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let fourth = new Layoff(P[1], P[0], P[2], P[0], P[2]);
+        let base = new PolygonElement([P[1], P[0], P[2], fourth]);
+        let g = new PrismElement(base, P[0], P[3]);
         return [[fourth, base, g], g];
     }
 }
 
-// polyhedron
-// prism
-// polygon A points B, C
-// the prism with base A and side edges parallel and equal to BC
+// polyhedron — prism — polygon A, points B, C
 // (Java: Prism.java — 41 lines, line-for-line port)
 export class PrismConstruction extends Construction {
     constructionMethod: AllConstructions = PolyhedraConstructionsEnum.prism;
-    signature: ConstructionTypes[] = [ct.PolygonElement, ct.PointElement, ct.PointElement];
-
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const base = params[0] as PolygonElement;
-        const C = params[1] as PointElement;
-        const D = params[2] as PointElement;
-        const g = new PrismElement(base, C, D);
+    signature = { points: 2, elements: 1, integers: 0, elementTypes: [PolygonElement] };
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new PrismElement(E[0] as PolygonElement, P[0], P[1]);
         return [[g], g];
     }
 }
 
-// polyhedron
-// pyramid
-// polygon A point B
-// the pyramid with base A and apex B
+// polyhedron — pyramid — polygon A, point B
 // (Java: Pyramid.java — 11 lines, line-for-line port)
 export class PyramidConstruction extends Construction {
     constructionMethod: AllConstructions = PolyhedraConstructionsEnum.pyramid;
-    signature: ConstructionTypes[] = [ct.PolygonElement, ct.PointElement];
-
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        const base = params[0] as PolygonElement;
-        const apex = params[1] as PointElement;
-        const g = new PyramidElement(base, apex);
+    signature = { points: 1, elements: 1, integers: 0, elementTypes: [PolygonElement] };
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        const g = new PyramidElement(E[0] as PolygonElement, P[0]);
         return [[g], g];
     }
 }

--- a/src/elements/sector/SectorConstructions.ts
+++ b/src/elements/sector/SectorConstructions.ts
@@ -2,7 +2,7 @@
 |    Sector construction classes — extracted from Constructions.ts       |
 +----------------------------------------------------------------------*/
 
-import {Construction, AllConstructions,
+import {Construction, ConstructionSignature, SortedParams, AllConstructions,
         SectorConstructions as SectorConstructionsEnum,
         GeomElementsForUpdate} from "../Constructions";
 import {GeomElement} from "../GeomElement";
@@ -11,53 +11,45 @@ import {PointElement} from "../point/PointElement";
 import {SectorElement} from "./SectorElement";
 import {ArcElement} from "./ArcElement";
 
-// sector — points A, B, C [plane D = screen]
-// (Java: Slate.java sector case 0, choice 0 — new SectorElement(A,B,C,screen))
+// sector — points A, B, C [, plane D = screen]
+// 2D: 3 points, 0 elements — uses screen plane
+// 3D: 3 points, 1 PlaneElement — uses explicit plane
+// (Java: Slate.java sector case 0 — new SectorElement(A,B,C,plane))
 export class SectorConstruction extends Construction {
     constructionMethod: AllConstructions = SectorConstructionsEnum.sector;
-    signature = { points: 3, elements: 0, integers: 0 };
+    signature: ConstructionSignature = { points: 3, elements: 0, integers: 0 };
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 3 && sp.N.length === 0
+            && (sp.E.length === 0 || (sp.E.length === 1 && sp.E[0] instanceof PlaneElement));
+    }
     construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new SectorElement({O:P[0], A:P[1], B:P[2], P: screen});
+        let plane = E.length > 0 ? E[0] as PlaneElement : screen;
+        let g = new SectorElement({O:P[0], A:P[1], B:P[2], P: plane});
         return [[g], g];
     }
 }
 
-// sector — sector (3D variant) — points A, B, C, plane D
-// (Java: Slate.java sector case 0, choice 1 — new SectorElement(A,B,C,D))
-export class Sector2Construction extends Construction {
-    constructionMethod: AllConstructions = SectorConstructionsEnum.sector;
-    signature = { points: 3, elements: 1, integers: 0, elementTypes: [PlaneElement] };
-    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new SectorElement({O:P[0], A:P[1], B:P[2], P: E[0] as PlaneElement});
-        return [[g], g];
-    }
-}
-
-// sector — arc — points A, M, B in screen plane
-// (Java: Slate.java sector case 1 — new ArcElement(A, M, B, screen))
+// sector — arc — points A, M, B [, plane D = screen]
+// 2D: 3 points, 0 elements — uses screen plane
+// 3D: 3 points, 1 PlaneElement — uses explicit plane
+// (Java: Slate.java sector case 1 — new ArcElement(A,M,B,plane))
 export class ArcConstruction extends Construction {
     constructionMethod: AllConstructions = SectorConstructionsEnum.arc;
-    signature = { points: 3, elements: 0, integers: 0 };
-    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new ArcElement(P[0], P[1], P[2], screen);
-        return [[g], g];
+    signature: ConstructionSignature = { points: 3, elements: 0, integers: 0 };
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 3 && sp.N.length === 0
+            && (sp.E.length === 0 || (sp.E.length === 1 && sp.E[0] instanceof PlaneElement));
     }
-}
-
-// sector — arc (3D variant) — points A, M, B, plane D
-// (Java: Slate.java sector case 1, choice 1 — new ArcElement(A,M,B,D))
-export class Arc3dConstruction extends Construction {
-    constructionMethod: AllConstructions = SectorConstructionsEnum.arc;
-    signature = { points: 3, elements: 1, integers: 0, elementTypes: [PlaneElement] };
-    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
-        let g = new ArcElement(P[0], P[1], P[2], E[0] as PlaneElement);
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let plane = E.length > 0 ? E[0] as PlaneElement : screen;
+        let g = new ArcElement(P[0], P[1], P[2], plane);
         return [[g], g];
     }
 }
 
 export const sectorConstructions: Construction[] = [
     new SectorConstruction(),
-    new Sector2Construction(),
-    new Arc3dConstruction(),
     new ArcConstruction(),
 ];

--- a/src/elements/sector/SectorConstructions.ts
+++ b/src/elements/sector/SectorConstructions.ts
@@ -1,10 +1,8 @@
 /*----------------------------------------------------------------------+
 |    Sector construction classes — extracted from Constructions.ts       |
-|    Each class maps a (type, constructionName, signature) triple to    |
-|    a construct() method that creates the geometry element.             |
 +----------------------------------------------------------------------*/
 
-import {Construction, ConstructionTypes, AllConstructions,
+import {Construction, AllConstructions,
         SectorConstructions as SectorConstructionsEnum,
         GeomElementsForUpdate} from "../Constructions";
 import {GeomElement} from "../GeomElement";
@@ -13,76 +11,46 @@ import {PointElement} from "../point/PointElement";
 import {SectorElement} from "./SectorElement";
 import {ArcElement} from "./ArcElement";
 
-let ct = ConstructionTypes;
-
-/************************
- * Element Class Sector *
- ************************/
-
-
-// sector
-// sector
-// points A, B, C [plane D = screen]
-// the sector of a circle in plane D given the center A and two points B and C on the circumference
+// sector — points A, B, C [plane D = screen]
 // (Java: Slate.java sector case 0, choice 0 — new SectorElement(A,B,C,screen))
 export class SectorConstruction extends Construction {
     constructionMethod: AllConstructions = SectorConstructionsEnum.sector;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
-
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new SectorElement({O:ps[0], A:ps[1], B:ps[2], P: screen});
+    signature = { points: 3, elements: 0, integers: 0 };
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new SectorElement({O:P[0], A:P[1], B:P[2], P: screen});
         return [[g], g];
     }
 }
 
-// sector — sector (3D variant)
-// points A, B, C, plane D
-// the sector of a circle in plane D given the center A and two points B and C on the circumference
+// sector — sector (3D variant) — points A, B, C, plane D
 // (Java: Slate.java sector case 0, choice 1 — new SectorElement(A,B,C,D))
 export class Sector2Construction extends Construction {
     constructionMethod: AllConstructions = SectorConstructionsEnum.sector;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement];
-
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let a : PointElement = params[0];
-        let b : PointElement = params[1];
-        let c : PointElement = params[2];
-        let d : PlaneElement = params[3];
-        let g = new SectorElement({O:a, A:b, B:c, P: d});
+    signature = { points: 3, elements: 1, integers: 0, elementTypes: [PlaneElement] };
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new SectorElement({O:P[0], A:P[1], B:P[2], P: E[0] as PlaneElement});
         return [[g], g];
     }
 }
 
-// sector
-// arc
-// points A, M, B
-// the arc of the circle through points A, M, B in the screen plane
-// (M is the "through" point between the two endpoints A and B)
-// 2D variant: arc passes through A, M, B in the screen plane.
-// M is the "through" point between endpoints A and B.
+// sector — arc — points A, M, B in screen plane
 // (Java: Slate.java sector case 1 — new ArcElement(A, M, B, screen))
 export class ArcConstruction extends Construction {
     constructionMethod: AllConstructions = SectorConstructionsEnum.arc;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
-
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new ArcElement(ps[0], ps[1], ps[2], screen);
+    signature = { points: 3, elements: 0, integers: 0 };
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new ArcElement(P[0], P[1], P[2], screen);
         return [[g], g];
     }
 }
 
-// sector — arc (3D variant)
-// points A, M, B, plane D
+// sector — arc (3D variant) — points A, M, B, plane D
 // (Java: Slate.java sector case 1, choice 1 — new ArcElement(A,M,B,D))
 export class Arc3dConstruction extends Construction {
     constructionMethod: AllConstructions = SectorConstructionsEnum.arc;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement, ct.PlaneElement];
-
-    construct(_screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new ArcElement(ps[0], ps[1], ps[2], params[3] as PlaneElement);
+    signature = { points: 3, elements: 1, integers: 0, elementTypes: [PlaneElement] };
+    construct(_screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new ArcElement(P[0], P[1], P[2], E[0] as PlaneElement);
         return [[g], g];
     }
 }

--- a/src/elements/sphere/SphereConstructions.ts
+++ b/src/elements/sphere/SphereConstructions.ts
@@ -1,10 +1,8 @@
 /*----------------------------------------------------------------------+
 |    Sphere construction classes — extracted from Constructions.ts       |
-|    Each class maps a (type, constructionName, signature) triple to    |
-|    a construct() method that creates the geometry element.             |
 +----------------------------------------------------------------------*/
 
-import {Construction, ConstructionTypes, AllConstructions,
+import {Construction, AllConstructions,
         SphereConstructions as SphereConstructionsEnum,
         GeomElementsForUpdate} from "../Constructions";
 import {GeomElement} from "../GeomElement";
@@ -12,41 +10,24 @@ import {PlaneElement} from "../plane/PlaneElement";
 import {PointElement} from "../point/PointElement";
 import {SphereElement} from "./SphereElement";
 
-let ct = ConstructionTypes;
-
-/************************
- * Element Class Sphere *
- ************************/
-
-// sphere
-// radius
-// points A, B
-// the sphere with center A and radius AB
+// sphere — radius — points A, B
 // (Java: Slate.java sphere case 0 — new SphereElement(A, A, B))
 export class SphereRadiusConstruction extends Construction {
     constructionMethod: AllConstructions = SphereConstructionsEnum.radius;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement]
-    construct(screen : PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new SphereElement({Center: ps[0], B: ps[1]});
+    signature = { points: 2, elements: 0, integers: 0 };
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new SphereElement({Center: P[0], B: P[1]});
         return [[g], g];
     }
 }
 
-
-
-// sphere
-// radius (3-point variant)
-// points A, B, C
-// the sphere with center A and radius |BC|
+// sphere — radius (3-point) — points A, B, C — center A, radius |BC|
 // (Java: Slate.java sphere case 0, choice 1 — new SphereElement(A,B,C))
 export class SphereRadius3PointConstruction extends Construction {
     constructionMethod: AllConstructions = SphereConstructionsEnum.radius;
-    signature: ConstructionTypes[] = [ct.PointElement, ct.PointElement, ct.PointElement];
-
-    construct(screen: PlaneElement, params: any[]): [GeomElementsForUpdate, GeomElement] {
-        let ps : PointElement[] = params;
-        let g = new SphereElement({Center: ps[0], A: ps[1], B: ps[2]});
+    signature = { points: 3, elements: 0, integers: 0 };
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new SphereElement({Center: P[0], A: P[1], B: P[2]});
         return [[g], g];
     }
 }

--- a/view/test/icosahedron.html
+++ b/view/test/icosahedron.html
@@ -12,7 +12,8 @@
   David Joyce's Geometry Applet documentation page. Constructs an
   icosahedron using spheres, planes, regular polygons, and 3D geometry.
 
-  Original applet params reproduced below using the parseParam() string API.
+  Uses parseParam() string format with ORIGINAL Java param order —
+  no manual reordering needed thanks to type-counted dispatch.
 -->
 
 <script type="text/javascript">
@@ -49,7 +50,7 @@
             "LEcirc;circle;radius;L,W,Z,Vplane;0;0;0;0",
             "FE;line;bichord;Vcirc,LEcirc;0;0;0",
             "E;point;last;FE;0;0",
-            "dec;polygon;regularPolygon;L,E,Vplane,10;0;0;0;0",
+            "dec;polygon;regularPolygon;L,E,10,Vplane;0;0;0;0",
             "P;point;vertex;dec,3",
             "K;point;vertex;dec,4;0;0",
             "O;point;vertex;dec,5",


### PR DESCRIPTION
## Summary

Replaces positional signature matching with Java's type-separated dispatch
(`Slate.java selectDataChoice`, lines 344-393). Param order in Java HTML
strings is now irrelevant — `"E,Vplane,D,B"` and `"E,D,B,Vplane"` both work.

### Core dispatch change
- `convertParams` now sorts resolved params into `SortedParams {P[], E[], N[]}` by type
  (Points, Elements, iNtegers) instead of preserving positional order
- `validateSignature` counts types `{points, elements, integers}` + checks `elementTypes[]`
  via `instanceof`, instead of zip-comparing positions
- `construct()` receives `(screen, P[], E[], N[])` instead of `(screen, params: any[])`
- Removes `ConstructionTypes` enum (no longer needed)

### 20 variant classes merged (102 → 82)
2D/3D pairs that differed only in whether a PlaneElement was provided collapse
into single classes with `E.length > 0 ? E[0] as PlaneElement : screen`:

- **Point** (9 merges): Intersection, Circumcircle, Circumcenter, Similar,
  AngleBisector, AngleDivider, FixedPoint, LineSlider, CircleSlider
- **Line** (3): AngleBisector, AngleDivider, Similar
- **Circle** (2): Radius 2-point, Radius 3-point
- **Polygon** (4): Square, EquilateralTriangle, RegularPolygon, Similar
- **Sector** (2): Sector, Arc

### Icosahedron showcase
62-element 3D construction from Joyce's `Geometry.html` using `parseParam()` with
**original Java param order** — no manual reordering. Validates that type-counted
dispatch handles `"dec;polygon;regularPolygon;L,E,10,Vplane"` (integer before plane)
and `"Q;point;perpendicular;E,Vplane,D,B"` (plane between points).

## Test plan

- [x] `npm run build` — no type errors
- [x] `npm test` — 116/116 passing
- [x] `npm run coverage` — verify no regression
- [x] Manual: icosahedron renders with raw Java param strings
- [x] Manual: all 40 harness selections still render correctly
- [x] `./run_euclid_applet.sh` loop mode (`a`) — full visual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
