### PR TITLE
fix: setPivot handles Java's "point,plane" two-part format

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -36,7 +36,9 @@ These affect the library as a whole, independent of individual constructions.
 - [ ] **`PerpendicularPlane` division by zero** — `// TODO` in normalization
   step (~line 56)
 - [ ] **`font` / `fontsize` params** — hardcoded, not configurable
-- [ ] **`pivot` rotation** — parsed but not fully implemented for 3D scenes
+- [x] **`pivot` rotation** — FIXED (2026-04-18): `setPivot` now handles
+  Java's `"point,plane"` two-part format. The rotation math was already
+  implemented in `Slate.rotateCoordinates` and `PointElement.rotate`
 - [x] **Background HSB in init()** — FIXED (2026-04-18): `slate.bgcolor` now
   parsed through `parseColor` before assignment, so HSB triples like
   `"35,19,100"` are converted to valid CSS `rgb()` strings

--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -36,6 +36,19 @@ These affect the library as a whole, independent of individual constructions.
 - [ ] **`PerpendicularPlane` division by zero** — `// TODO` in normalization
   step (~line 56)
 - [ ] **`font` / `fontsize` params** — hardcoded, not configurable
+- [ ] **`preexists` tracking missing** — Java's `Slate.java` has a
+  `preexists[]` boolean array that marks elements which are references
+  to existing elements (e.g., `point;first` returns `P[0]`,
+  `point;vertex` returns a polygon vertex, `point;center` returns a
+  circle's center). During `rotateCoordinates` and `translateCoordinates`,
+  Java skips `preexists` elements to avoid double-rotation/translation.
+  The TS port has no equivalent — all elements in `_elementsForUpdate`
+  are rotated/translated, causing double-movement of shared references.
+  **Visible symptom**: rotating a 3D scene via pivot causes the xyplane
+  parallelogram to grow progressively. Discovered on propXI26 pivot test.
+  **Fix**: add a `preexists` flag to `GeomElement` (or a separate set in
+  `Slate`), set it for elements returned by first/last/vertex/center
+  constructions, and skip flagged elements in rotate/translate loops.
 - [x] **`pivot` rotation** — FIXED (2026-04-18): `setPivot` now handles
   Java's `"point,plane"` two-part format. The rotation math was already
   implemented in `Slate.rotateCoordinates` and `PointElement.rotate`

--- a/src/Slate.ts
+++ b/src/Slate.ts
@@ -306,14 +306,29 @@ export class Slate {
         return this._pick;
     }
 
-    setPivot(name : string) : void {
-        let e : GeomElement = this.lookupElement(name);
-        if ( e == null || !(e instanceof PointElement) ) {
-            throw new TypeError("Pivot element must be a PointElement");
-        }
+    // Set the pivot point for scene rotation.
+    // Format: "pointName" or "pointName,planeName"
+    // Without a plane, the pivot is set on the screen plane.
+    // With a plane, the pivot is set on that plane (for 3D rotation).
+    // (Java: Slate.java setPivot, lines 787-801)
+    setPivot(param : string) : void {
+        let parts = param.split(",");
+        let pointName = parts[0].trim();
+        let e : GeomElement = this.lookupElement(pointName);
+        if (e == null || !(e instanceof PointElement)) return;
         let piv : PointElement = e as PointElement;
-        piv.AP = this._screen;
-        this._screen.pivot = piv;
+
+        if (parts.length > 1) {
+            // "A,xyplane" — set pivot on a specific plane
+            let planeName = parts[1].trim();
+            let p : GeomElement = this.lookupElement(planeName);
+            if (p == null || !(p instanceof PlaneElement)) return;
+            (p as PlaneElement).pivot = piv;
+        } else {
+            // "A" — set pivot on screen plane
+            piv._AP = this._screen;
+            this._screen.pivot = piv;
+        }
     }
 
     movePick(c: number, d: number) : void {

--- a/view/applet-tests/point/pivot/applet.html
+++ b/view/applet-tests/point/pivot/applet.html
@@ -1,0 +1,45 @@
+<HTML><HEAD><TITLE>point;pivot — applet form of view/test/point/pivot.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS: view/test/point/pivot.html -->
+<!-- ORIGINAL: view/applet-tests/point/pivot/original.html (propXI26) -->
+<!--
+  Full propXI26 with pivot=A,xyplane. Exercises pivot rotation:
+  dragging B,C,D,E (non-A points on xyplane) rotates the scene around A.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=360 height=320>
+<param name=background value="35,19,100">
+<param name=title value="XI.26 — pivot rotation">
+<param name=e[1] value="origin;point;free;110,140;0;0,50,100">
+<param name=e[2] value="x;point;fixed;330,210,100;0;120,50,100">
+<param name=e[3] value="yzplane;plane;perpendicular;origin,x;0;0;0;0">
+<param name=e[4] value="y;point;planeSlider;yzplane,-90,202,90;0;0,50,100">
+<param name=e[5] value="xyplane;plane;3points;origin,x,y;0;0;lightGray">
+<param name=e[6] value="z1;point;perpendicular;origin,y,yzplane;0;0">
+<param name=e[7] value="z;point;lineSlider;origin,z1,40,40,100;0">
+<param name=e[8] value="Oz;line;connect;origin,z;0;0;lightGray">
+<param name=e[9] value="ceiling;plane;parallel;xyplane,z;0;0;0;0">
+<param name=e[10] value="A;point;planeSlider;xyplane,180,240,150">
+<param name=pivot value="A,xyplane">
+<param name=e[11] value="B;point;planeSlider;xyplane,220,220,210">
+<param name=e[12] value="AB;line;connect;A,B">
+<param name=e[13] value="C;point;planeSlider;xyplane,150,200,20">
+<param name=e[14] value="D;point;planeSlider;xyplane,50,210,100">
+<param name=e[15] value="E;point;planeSlider;xyplane,110,190,160">
+<param name=e[16] value="F;point;planeSlider;ceiling,160,140,110">
+<param name=e[17] value="G;point;foot;F,xyplane">
+<param name=e[18] value="FG;line;connect;F,G">
+<param name=e[19] value="DCG;polygon;triangle;D,C,G;0;0;black;270,70,100">
+<param name=e[20] value="DGE;polygon;triangle;D,G,E;0;0;black;270,70,100">
+<param name=e[21] value="DCF;polygon;triangle;D,C,F;0;0;black;random">
+<param name=e[22] value="DEF;polygon;triangle;D,E,F;0;0;black;random">
+<param name=e[23] value="L;point;similar;B,A,xyplane,E,D,C,xyplane">
+<param name=e[24] value="K';point;similar;B,A,xyplane,E,D,G,xyplane;0;0">
+<param name=e[25] value="K;point;cutoff;A,K',D,G">
+<param name=e[26] value="ABK;polygon;triangle;A,B,K;0;0;black;270,70,100">
+<param name=e[27] value="AKL;polygon;triangle;A,K,L;0;0;black;270,70,100">
+<param name=e[28] value="KH;line;perpendicular;K,xyplane,F,G">
+<param name=e[29] value="H;point;last;KH">
+<param name=e[30] value="ALH;polygon;triangle;A,L,H;0;0;black;random">
+<param name=e[31] value="ABH;polygon;triangle;A,B,H;0;0;black;random">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point/pivot/original.html
+++ b/view/applet-tests/point/pivot/original.html
@@ -1,0 +1,39 @@
+<HTML><HEAD><TITLE>XI.26 — original proposition (pivot rotation)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<applet code=Geometry codebase=../../.. archive=Geometry.zip width=360 height=320>
+<param name=background value="35,19,100">
+<param name=title value="XI.26">
+<param name=e[1] value="origin;point;free;110,140;0;0,50,100">
+<param name=e[2] value="x;point;fixed;330,210,100;0;120,50,100">
+<param name=e[3] value="yzplane;plane;perpendicular;origin,x;0;0;0;0">
+<param name=e[4] value="y;point;planeSlider;yzplane,-90,202,90;0;0,50,100">
+<param name=e[5] value="xyplane;plane;3points;origin,x,y;0;0;lightGray">
+<param name=e[6] value="z1;point;perpendicular;origin,y,yzplane;0;0">
+<param name=e[7] value="z;point;lineSlider;origin,z1,40,40,100;0">
+<param name=e[8] value="Oz;line;connect;origin,z;0;0;lightGray">
+<param name=e[9] value="ceiling;plane;parallel;xyplane,z;0;0;0;0">
+<param name=e[10] value="A;point;planeSlider;xyplane,180,240,150">
+<param name=pivot value="A,xyplane">
+<param name=e[11] value="B;point;planeSlider;xyplane,220,220,210">
+<param name=e[12] value="AB;line;connect;A,B">
+<param name=e[13] value="C;point;planeSlider;xyplane,150,200,20">
+<param name=e[14] value="D;point;planeSlider;xyplane,50,210,100">
+<param name=e[15] value="E;point;planeSlider;xyplane,110,190,160">
+<param name=e[16] value="F;point;planeSlider;ceiling,160,140,110">
+<param name=e[17] value="G;point;foot;F,xyplane">
+<param name=e[18] value="FG;line;connect;F,G">
+<param name=e[19] value="DCG;polygon;triangle;D,C,G;0;0;black;270,70,100">
+<param name=e[20] value="DGE;polygon;triangle;D,G,E;0;0;black;270,70,100">
+<param name=e[21] value="DCF;polygon;triangle;D,C,F;0;0;black;random">
+<param name=e[22] value="DEF;polygon;triangle;D,E,F;0;0;black;random">
+<param name=e[23] value="L;point;similar;B,A,xyplane,E,D,C,xyplane">
+<param name=e[24] value="K';point;similar;B,A,xyplane,E,D,G,xyplane;0;0">
+<param name=e[25] value="K;point;cutoff;A,K',D,G">
+<param name=e[26] value="ABK;polygon;triangle;A,B,K;0;0;black;270,70,100">
+<param name=e[27] value="AKL;polygon;triangle;A,K,L;0;0;black;270,70,100">
+<param name=e[28] value="KH;line;perpendicular;K,xyplane,F,G">
+<param name=e[29] value="H;point;last;KH">
+<param name=e[30] value="ALH;polygon;triangle;A,L,H;0;0;black;random">
+<param name=e[31] value="ABH;polygon;triangle;A,B,H;0;0;black;random">
+</applet>
+</BODY></HTML>

--- a/view/test/point/pivot.html
+++ b/view/test/point/pivot.html
@@ -1,0 +1,81 @@
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Test View - Pivot rotation (XI.26)</title>
+</head>
+<body>
+<canvas id="canvasId" style="width:360px; height: 320px;"></canvas>
+<script src="../../../../dist/bundle.js" type="text/javascript"></script>
+
+<!--
+  Full propXI26 with pivot=A,xyplane. Dragging any non-A point on the
+  xyplane should rotate the entire scene around A. This exercises:
+  - setPivot("A,xyplane") two-part format
+  - Slate.rotateCoordinates() 3D rotation math
+  - PointElement.rotate() for all element types
+-->
+
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "XI.26 — pivot rotation",
+        canvasid: "canvasId",
+        pivot: "A,xyplane",
+        elements: [
+            { name: "origin", construction: E.Point.free, params: [110, 140],
+              nameColor: 0, vertexColor: "0,50,100" },
+            { name: "x", construction: E.Point.fixed, params: [330, 210, 100],
+              nameColor: 0, vertexColor: "120,50,100" },
+            { name: "yzplane", construction: E.Plane.perpendicular, params: ["origin", "x"],
+              nameColor: 0, vertexColor: 0, edgeColor: 0, faceColor: 0 },
+            { name: "y", construction: E.Point.planeSlider, params: ["yzplane", -90, 202, 90],
+              nameColor: 0, vertexColor: "0,50,100" },
+            { name: "xyplane", construction: E.Plane.threePoints, params: ["origin", "x", "y"],
+              nameColor: 0, vertexColor: 0, edgeColor: "lightGray" },
+            { name: "z1", construction: E.Point.perpendicular, params: ["origin", "y", "yzplane"],
+              nameColor: 0, vertexColor: 0 },
+            { name: "z", construction: E.Point.lineSlider, params: ["origin", "z1", 40, 40, 100],
+              nameColor: 0 },
+            { name: "Oz", construction: E.Line.connect, params: ["origin", "z"],
+              nameColor: 0, vertexColor: 0, edgeColor: "lightGray" },
+            { name: "ceiling", construction: E.Plane.parallel, params: ["xyplane", "z"],
+              nameColor: 0, vertexColor: 0, edgeColor: 0, faceColor: 0 },
+
+            { name: "A", construction: E.Point.planeSlider, params: ["xyplane", 180, 240, 150] },
+            { name: "B", construction: E.Point.planeSlider, params: ["xyplane", 220, 220, 210] },
+            { name: "AB", construction: E.Line.connect, params: ["A", "B"] },
+            { name: "C", construction: E.Point.planeSlider, params: ["xyplane", 150, 200, 20] },
+            { name: "D", construction: E.Point.planeSlider, params: ["xyplane", 50, 210, 100] },
+            { name: "E", construction: E.Point.planeSlider, params: ["xyplane", 110, 190, 160] },
+            { name: "F", construction: E.Point.planeSlider, params: ["ceiling", 160, 140, 110] },
+            { name: "G", construction: E.Point.foot, params: ["F", "xyplane"] },
+            { name: "FG", construction: E.Line.connect, params: ["F", "G"] },
+            { name: "DCG", construction: E.Polygon.triangle, params: ["D", "C", "G"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black", faceColor: "270,70,100" },
+            { name: "DGE", construction: E.Polygon.triangle, params: ["D", "G", "E"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black", faceColor: "270,70,100" },
+            { name: "DCF", construction: E.Polygon.triangle, params: ["D", "C", "F"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black", faceColor: "random" },
+            { name: "DEF", construction: E.Polygon.triangle, params: ["D", "E", "F"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black", faceColor: "random" },
+
+            { name: "L", construction: E.Point.similar, params: ["B", "A", "xyplane", "E", "D", "C", "xyplane"] },
+            { name: "K'", construction: E.Point.similar, params: ["B", "A", "xyplane", "E", "D", "G", "xyplane"],
+              nameColor: 0, vertexColor: 0 },
+            { name: "K", construction: E.Point.cutoff, params: ["A", "K'", "D", "G"] },
+            { name: "ABK", construction: E.Polygon.triangle, params: ["A", "B", "K"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black", faceColor: "270,70,100" },
+            { name: "AKL", construction: E.Polygon.triangle, params: ["A", "K", "L"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black", faceColor: "270,70,100" },
+            { name: "KH", construction: E.Line.perpendicular, params: ["K", "xyplane", "F", "G"] },
+            { name: "H", construction: E.Point.last, params: ["KH"] },
+            { name: "ALH", construction: E.Polygon.triangle, params: ["A", "L", "H"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black", faceColor: "random" },
+            { name: "ABH", construction: E.Polygon.triangle, params: ["A", "B", "H"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black", faceColor: "random" },
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- `setPivot` now handles Java's `"point,plane"` two-part format (e.g., `"A,xyplane"`)
- Previously only accepted a bare point name and always set the pivot on the screen plane
- The rotation math (`Slate.rotateCoordinates`, `PointElement.rotate`) was already fully implemented — this was purely a param parsing gap
- Dragging a non-pivot point on a plane with a pivot set now triggers 3D scene rotation, matching Java's behavior

### Pivot test page with 3-way harness
- `view/test/point/pivot.html` — full propXI26 with `pivot=A,xyplane`, 31 elements
- `view/applet-tests/point/pivot/{original,applet}.html` — Java applet pair
- Auto-discovered by `run_euclid_applet.sh` as selection `point;pivot`

### Known bug discovered and documented
During pivot rotation, the xyplane parallelogram grows progressively. Root cause: Java's `Slate.java` has a `preexists[]` array that skips reference elements (`point;first`, `point;vertex`, `point;center`) during rotation to avoid double-movement. The TS port rotates ALL elements, causing shared references to be rotated twice. Documented in `doc/construction-tracker.md` with fix approach — will be addressed on a separate branch.

## Test plan

- [x] `npm run build` — no type errors
- [x] `npm test` — 116/116 passing
- [x] Manual: pivot.html renders, dragging B/C/D/E rotates scene around A
- [x] 3-way harness: `./run_euclid_applet.sh` → `point;pivot`
- [x] Known: plane grows during extended rotation (preexists bug, tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
