### PR TITLE
Feature/font fontsize

### DIFF
--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -35,7 +35,9 @@ These affect the library as a whole, independent of individual constructions.
   properties but `IConstructionInfo` doesn't expose them
 - [ ] **`PerpendicularPlane` division by zero** — `// TODO` in normalization
   step (~line 56)
-- [ ] **`font` / `fontsize` params** — hardcoded, not configurable
+- [x] **`font` / `fontsize` params** — FIXED (2026-04-18): `IInitialization`
+  accepts `font` and `fontsize`. Default matches Java: TimesRoman italic 18px.
+  `GeomElement.setFont()` updates the static font string used by all labels
 - [ ] **`preexists` tracking missing** — Java's `Slate.java` has a
   `preexists[]` boolean array that marks elements which are references
   to existing elements (e.g., `point;first` returns `P[0]`,

--- a/src/elements/GeomElement.ts
+++ b/src/elements/GeomElement.ts
@@ -68,7 +68,10 @@ export abstract class GeomElement {
     protected _getTextMetrics(ctx: CanvasRenderingContext2D, txt: string) : [number, number] {
         let textMetrics = ctx.measureText(txt);
         let w = textMetrics.width;
-        let h = 16; // assuming 12 font
+        // Use actual font metrics for height; fall back to ascent-based estimate
+        let h = (textMetrics.actualBoundingBoxAscent != null)
+            ? textMetrics.actualBoundingBoxAscent + textMetrics.actualBoundingBoxDescent
+            : 16;
         return [w, h];
     }
 
@@ -92,7 +95,7 @@ export abstract class GeomElement {
                 return;
             case Align.ABOVE:
                 ix -= w/2;
-                iy += h/2 + 4;
+                iy += -h/2 + 4;
                 ctx.fillText(this._name, ix, iy);
                 return;
             case Align.BELOW:

--- a/src/elements/GeomElement.ts
+++ b/src/elements/GeomElement.ts
@@ -51,7 +51,12 @@ export abstract class GeomElement {
     private _edgeHighlightColor   : string = '#FFFFFF';
     private _faceHighlightColor   : string = '#00FFFF';
 
-    protected static _font : string = "italic 10pt Times New Roman";
+    // Default matches Java: Font("TimesRoman", Font.ITALIC, 18)
+    protected static _font : string = "italic 18px Times New Roman";
+
+    static setFont(fontName: string, fontSize: number): void {
+        GeomElement._font = `italic ${fontSize}px ${fontName}`;
+    }
 
     private _draggable : boolean;
     private _dimension : number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,8 @@ export interface IInitialization {
     align? : align;
     canvasid? : string;
     pivot?: string;
+    font?: string;
+    fontsize?: number;
     elements: (IConstructionInfo | string)[];
 }
 
@@ -103,6 +105,11 @@ export function init(i : IInitialization) {
     resizeCanvasToDisplaySize(canvas);
     let slate : Slate = new Slate(canvas);
     slates.push(slate);
+
+    // Set font — Java defaults: Font("TimesRoman", Font.ITALIC, 18)
+    let fontName = i.font != null ? i.font : "Times New Roman";
+    let fontSize = i.fontsize != null ? i.fontsize : 18;
+    GeomElement.setFont(fontName, fontSize);
     // Parse background through parseColor so HSB triples like "35,19,100"
     // are converted to valid CSS rgb() strings for ctx.fillStyle.
     slate.bgcolor = parseColor(i.background, "#ffffff", "#ffffff");


### PR DESCRIPTION
## Summary

### Font/fontsize params
- `IInitialization` accepts optional `font` and `fontsize` params
- Default matches Java: `Font("TimesRoman", Font.ITALIC, 18)`
- Previous hardcoded default was `"italic 10pt Times New Roman"` — wrong size
- `GeomElement.setFont(name, size)` updates the static font string

### Label alignment fix
- **ABOVE alignment** had `iy += h/2 + 4` which pushed labels DOWN below the point. Fixed to `iy += -h/2 + 4` matching Java's `iy - h/2 + 4` (Element.java line 54)
- **Text height** was hardcoded at 16px regardless of font size. Now uses `actualBoundingBoxAscent + actualBoundingBoxDescent` from the canvas TextMetrics API for accurate height at any font size

Labels now sit clearly above/beside their points instead of overlapping them.

## Test plan

- [x] `npm run build` — no type errors
- [x] `npm test` — 116/116 passing
- [x] Manual: labels visually match Java applet positioning
- [x] Manual: verify across multiple harness selections

🤖 Generated with [Claude Code](https://claude.com/claude-code)
