### PR TITLE
Feature/snapshot verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules
 coverage
+tests/snapshots/**/*.png
+tests/snapshots/report.html
 .idea/
 dist/
 *.js

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,4 +1,3 @@
 {
-  "require": "ts-node/register",
-  "spec": ["tests/**/*.ts"]
+  "require": "ts-node/register"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "^22.19.17",
+        "@types/pngjs": "^6.0.5",
         "c8": "^11.0.0",
         "canvas": "^3.2.3",
         "css-loader": "^7.1.2",
@@ -19,6 +20,8 @@
         "install": "^0.13.0",
         "mocha": "^11.7.5",
         "node-loader": "^2.0.0",
+        "pixelmatch": "^5.3.0",
+        "pngjs": "^7.0.0",
         "style-loader": "^4.0.0",
         "ts-loader": "^9.5.7",
         "ts-node": "^10.9.2",
@@ -1036,6 +1039,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pngjs": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
+      "integrity": "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -4806,6 +4819,29 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pixelmatch": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
+      "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^6.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/pixelmatch/node_modules/pngjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -4886,6 +4922,16 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "build": "tsc --noEmit",
     "test": "npm run test:snapshot && npm run test:unit",
     "test:snapshot": "mocha --reporter min tests/SnapshotTest.ts",
-    "test:unit": "mocha tests/SlateTest.ts",
-    "coverage": "c8 mocha --reporter min tests/SnapshotTest.ts tests/SlateTest.ts",
-    "coverage:unit": "c8 mocha --reporter min tests/SlateTest.ts",
+    "test:unit": "mocha tests/CircleTest.ts tests/ColorsTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateTest.ts tests/SphereTest.ts",
+    "coverage": "c8 mocha --reporter min tests/SnapshotTest.ts tests/CircleTest.ts tests/ColorsTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateTest.ts tests/SphereTest.ts",
+    "coverage:unit": "c8 mocha --reporter min tests/CircleTest.ts tests/ColorsTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateTest.ts tests/SphereTest.ts",
     "coverage:report": "c8 report --reporter=html",
     "snapshots:clean": "rm -rf tests/snapshots && mkdir -p tests/snapshots && touch tests/snapshots/.gitkeep"
   },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.19.17",
+    "@types/pngjs": "^6.0.5",
     "c8": "^11.0.0",
     "canvas": "^3.2.3",
     "css-loader": "^7.1.2",
@@ -31,6 +32,8 @@
     "install": "^0.13.0",
     "mocha": "^11.7.5",
     "node-loader": "^2.0.0",
+    "pixelmatch": "^5.3.0",
+    "pngjs": "^7.0.0",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.5.7",
     "ts-node": "^10.9.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:snapshot": "mocha --reporter min tests/SnapshotTest.ts",
     "test:unit": "mocha tests/SlateTest.ts",
     "coverage": "c8 mocha --reporter min tests/SnapshotTest.ts tests/SlateTest.ts",
+    "coverage:unit": "c8 mocha --reporter min tests/SlateTest.ts",
     "coverage:report": "c8 report --reporter=html",
     "snapshots:clean": "rm -rf tests/snapshots && mkdir -p tests/snapshots && touch tests/snapshots/.gitkeep"
   },

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc --noEmit",
-    "test": "mocha",
-    "coverage": "c8 mocha",
-    "coverage:report": "c8 report --reporter=html"
+    "test": "npm run test:snapshot && npm run test:unit",
+    "test:snapshot": "mocha --reporter min tests/SnapshotTest.ts",
+    "test:unit": "mocha tests/SlateTest.ts",
+    "coverage": "c8 mocha --reporter min tests/SnapshotTest.ts tests/SlateTest.ts",
+    "coverage:report": "c8 report --reporter=html",
+    "snapshots:clean": "rm -rf tests/snapshots && mkdir -p tests/snapshots && touch tests/snapshots/.gitkeep"
   },
   "repository": {
     "type": "git",

--- a/src/elements/GeomElement.ts
+++ b/src/elements/GeomElement.ts
@@ -145,10 +145,6 @@ export abstract class GeomElement {
         this._name = n;
     }
 
-    public hitTest(x : number, y: number) : boolean {
-        return false;
-    }
-
     public abstract update() : void;
     public reset() { this.update(); }
     public defined() : boolean { return false; }

--- a/src/elements/circle/CircleElement.ts
+++ b/src/elements/circle/CircleElement.ts
@@ -47,10 +47,6 @@ export class CircleElement extends GeomElement {
         this.AP = ice.AP;
     }
 
-    public toString() : string {
-        return `[${this._name} (${this.Center}, ${this.A} ${this.B})]`;
-    }
-
     get radius() {
         return this.A.distance(this.B);
     }
@@ -96,15 +92,12 @@ export class CircleElement extends GeomElement {
         let minory :number = factor*majorx;
         let majorR : number = Math.sqrt(majorx*majorx + majory*majory);
         let minorR : number = Math.sqrt(minorx*minorx + minory*minory);
-        // Degenerate case: ellipse is so thin it looks like a line
+        // Degenerate case: ellipse is so thin it looks like a line.
+        // (minorR <= majorR always since minorR = factor * majorR with
+        // factor in [0,1], so we only need to check minorR.)
         if (minorR < 0.5) {
             ctx.moveTo(this.Center.x - majorx, this.Center.y - majory);
             ctx.lineTo(this.Center.x + majorx, this.Center.y + majory);
-            return;
-        }
-        if (majorR < 0.5) {
-            ctx.moveTo(this.Center.x - minorx, this.Center.y - minory);
-            ctx.lineTo(this.Center.x + minorx, this.Center.y + minory);
             return;
         }
         // Rotation angle of the major axis

--- a/src/elements/point/PointElement.ts
+++ b/src/elements/point/PointElement.ts
@@ -59,22 +59,10 @@ export class PointElement extends GeomElement {
             && this._x != null && true && this._y != null && true && this._z != null;
     }
 
-    public toString() : string {
-        return `[${this._name} (${this._x}, ${this._y}, ${this._z})]`;
-    }
-
-    public hitTest(x: number, y: number) : boolean {
-        return Math.sqrt((this._x - x) * (this._x - x) + (this._y - y) * (this._y - y)) <= this._pixelTolerance;
-    }
-
     to(B : PointElement ) : PointElement {this._x = B._x; this._y = B._y; this._z= B._z; return this;}
     plus(B : PointElement ) : PointElement {this._x += B._x; this._y += B._y; this._z+= B._z; return this;}
     minus(B : PointElement) : PointElement {this._x -= B._x; this._y -= B._y; this._z-= B._z; return this;}
     times(a : number) : PointElement {this._x *= a; this._y *= a; this._z *= a; return this;}
-
-    static sum(A : PointElement, B: PointElement) : PointElement {
-        return new PointElement({x: A.x+B.x,y: A.y+B.y, z:A.z+B.z, AP: null});
-    }
 
     static difference(A : PointElement, B : PointElement) : PointElement {
         return new PointElement({x:A.x-B.x, y:A.y-B.y, z:A.z-B.z, AP: null});

--- a/src/elements/sector/SectorElement.ts
+++ b/src/elements/sector/SectorElement.ts
@@ -50,16 +50,8 @@ export class SectorElement extends GeomElement {
         }
     }
 
-    public toString(): string {
-        return `[${this._name}: Center=${this._Center} A=${this._A} B=${this._B}]`;
-    }
-
     radius() : number {
         return this._Center.distance(this._A);
-    }
-
-    radius2() : number {
-        return this._Center.distance2(this._A);
     }
 
     defined() {

--- a/tests/CircleTest.ts
+++ b/tests/CircleTest.ts
@@ -1,0 +1,145 @@
+import "mocha";
+import * as assert from "assert";
+import {Slate} from "../src/Slate";
+import {E, IConstructionInfo} from "../src/index";
+import {PointElement} from "../src/elements/point/PointElement";
+import {PlaneElement} from "../src/elements/plane/PlaneElement";
+import {CircleElement} from "../src/elements/circle/CircleElement";
+import {CircumcircleElement} from "../src/elements/circle/CircumcircleElement";
+import {createCanvas} from "canvas";
+import {almostEqual, toElements} from "./shared/testHelpers";
+
+describe("circle", () => {
+
+    let circle_center_circumcircle_data: IConstructionInfo[] = [
+        { construction: E.Point.free, name: "B", params: [150, 40] },
+        { construction: E.Point.free, name: "F", params: [110, 100] },
+        { construction: E.Point.free, name: "H", params: [190, 100] },
+        { construction: E.Circle.circumcircle, name: "ABC", params: ["B", "F", "H"] },
+        { construction: E.Point.center, name: "P", params: ["ABC"] },
+    ];
+
+    it("should create a circumcircle and center elements", () => {
+        let slate: Slate = new Slate(createCanvas(200, 200));
+        let elms = toElements(slate, circle_center_circumcircle_data);
+        slate.elements.forEach(e => e.update());
+        let p3 = elms[3] as CircumcircleElement;
+        let p4 = elms[4] as PointElement;
+        assert.equal(p3.Center, p4);
+        almostEqual(p4.x, 150, 1);
+        almostEqual(p4.y, 83, 1);
+    });
+
+    // circle;radius 3-point — circle at Center with radius = |A-B|
+    it("should create a circle with center H and radius |GA| (3-point form)", () => {
+        let data: IConstructionInfo[] = [
+            { name: "G",   construction: E.Point.free,    params: [120, 115] },
+            { name: "A",   construction: E.Point.free,    params: [75, 30] },
+            { name: "H",   construction: E.Point.free,    params: [340, 115] },
+            { name: "DEF", construction: E.Circle.radius, params: ["H", "G", "A"] },
+        ];
+        let slate = new Slate(createCanvas(500, 300));
+        toElements(slate, data);
+        let circle = slate.lookupElement("DEF") as CircleElement;
+        almostEqual(circle.Center.x, 340, 0.01);
+        almostEqual(circle.Center.y, 115, 0.01);
+        let expectedRadius = Math.sqrt(45*45 + 85*85);
+        almostEqual(circle.radius, expectedRadius, 0.01);
+        assert.notEqual(circle.A, circle.Center);
+    });
+
+    // circle;intersection — intersection circle of two spheres
+    it("should compute the intersection circle of two spheres", () => {
+        let data: IConstructionInfo[] = [
+            { name: "O1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "R1", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "S", construction: E.Sphere.radius, params: ["O1", "R1"] },
+            { name: "O2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "R2", construction: E.Point.fixed, params: [200, 0, 0] },
+            { name: "T", construction: E.Sphere.radius, params: ["O2", "R2"] },
+            { name: "C", construction: E.Circle.intersection, params: ["S", "T"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let circle = slate.lookupElement("C") as CircleElement;
+        almostEqual(circle.Center.x, 50, 0.1);
+        almostEqual(circle.Center.y, 0, 0.1);
+        almostEqual(circle.radius, Math.sqrt(7500), 0.1);
+    });
+
+    it("should compute the inversion of a circle in another circle", () => {
+        let data: IConstructionInfo[] = [
+            { name: "O1", construction: E.Point.free, params: [100, 100] },
+            { name: "R1", construction: E.Point.free, params: [130, 100] },
+            { name: "C", construction: E.Circle.radius, params: ["O1", "R1"] },
+            { name: "O2", construction: E.Point.free, params: [200, 100] },
+            { name: "R2", construction: E.Point.free, params: [250, 100] },
+            { name: "D", construction: E.Circle.radius, params: ["O2", "R2"] },
+            { name: "E", construction: E.Circle.invert, params: ["C", "D"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let inverted = slate.lookupElement("E") as CircleElement;
+        assert.ok(!isNaN(inverted.Center.x));
+        assert.ok(!isNaN(inverted.Center.y));
+        assert.ok(inverted.radius > 0);
+    });
+
+    // 3D signature variants
+    it("should create a circle with explicit plane (3D variant)", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 50, 0] },
+            { name: "B", construction: E.Point.fixed, params: [100, 50, 0] },
+            { name: "C", construction: E.Circle.radius, params: ["A", "B", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        let circle = slate.lookupElement("C") as CircleElement;
+        almostEqual(circle.radius, 50, 0.01);
+        assert.ok(circle.AP != null);
+    });
+
+    it("should create a 3-point circle with explicit plane (3D variant)", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 50, 0] },
+            { name: "B", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [60, 80, 0] },
+            { name: "circ", construction: E.Circle.radius, params: ["A", "B", "C", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        let circle = slate.lookupElement("circ") as CircleElement;
+        almostEqual(circle.radius, 100, 0.01);
+    });
+
+    // CircleElement._drawCircle has a degenerate branch for edge-on rendering
+    // (minor axis < 0.5 px). Hand-craft a tilted AP to exercise it.
+    it("CircleElement.drawEdge should handle an edge-on circle without throwing", () => {
+        let canvas = createCanvas(100, 100);
+        let center = new PointElement({x: 50, y: 50, z: 0});
+        let B      = new PointElement({x: 51, y: 50, z: 0});
+
+        let plane = new PlaneElement({
+            A: new PointElement({x: 0, y: 0, z: 0}),
+            B: new PointElement({x: 1, y: 0, z: 0}),
+            C: new PointElement({x: 0, y: 1, z: 0}),
+        });
+        plane.S = new PointElement({x: 0.1, y: 0, z: 0.995});
+        plane.T = new PointElement({x: 0,   y: 1, z: 0});
+        plane.U = new PointElement({x: 1,   y: 0, z: 0});
+
+        let circle = new CircleElement({C: center, A: center, B: B, AP: plane});
+        circle.edgeColor = "black";
+        circle.drawEdge(canvas as any);
+    });
+});

--- a/tests/ColorsTest.ts
+++ b/tests/ColorsTest.ts
@@ -1,0 +1,172 @@
+import "mocha";
+import * as assert from "assert";
+import {parseColor, brighter, darker, darken} from "../src/Colors";
+
+describe("parseColor", () => {
+
+    let bgcolor = "rgb(255,233,205)"; // #ffe9cd — the standard proposition background
+
+    // 1. Transparent inputs → null
+    it("should return null for null input (uses default)", () => {
+        assert.equal(parseColor(null, "black", bgcolor), "black");
+    });
+    it("should return null for 'none'", () => {
+        assert.equal(parseColor("none", "black", bgcolor), null);
+    });
+    it("should return null for string '0'", () => {
+        assert.equal(parseColor("0", "black", bgcolor), null);
+    });
+    it("should return null for numeric 0", () => {
+        assert.equal(parseColor(0, "black", bgcolor), null);
+    });
+    it("should return null for empty string", () => {
+        assert.equal(parseColor("", "black", bgcolor), null);
+    });
+
+    // 2. Special keywords
+    it("should return a random color for 'random'", () => {
+        let c = parseColor("random", "black", bgcolor);
+        assert.ok(c.startsWith("rgb("));
+    });
+    it("should return bgcolor for 'background'", () => {
+        assert.equal(parseColor("background", "black", bgcolor), bgcolor);
+    });
+    it("should return a brighter color for 'brighter'", () => {
+        let c = parseColor("brighter", "black", bgcolor);
+        assert.ok(c.startsWith("rgb("));
+        assert.notEqual(c, bgcolor);
+    });
+    it("should return a darker color for 'darker'", () => {
+        let c = parseColor("darker", "black", bgcolor);
+        assert.ok(c.startsWith("rgb("));
+        assert.notEqual(c, bgcolor);
+    });
+
+    // 3. Named colors (all 13)
+    it("should resolve all 13 named colors", () => {
+        assert.equal(parseColor("black", null, bgcolor), "rgb(0,0,0)");
+        assert.equal(parseColor("blue", null, bgcolor), "rgb(0,0,255)");
+        assert.equal(parseColor("cyan", null, bgcolor), "rgb(0,255,255)");
+        assert.equal(parseColor("darkGray", null, bgcolor), "rgb(64,64,64)");
+        assert.equal(parseColor("gray", null, bgcolor), "rgb(128,128,128)");
+        assert.equal(parseColor("green", null, bgcolor), "rgb(0,255,0)");
+        assert.equal(parseColor("lightGray", null, bgcolor), "rgb(192,192,192)");
+        assert.equal(parseColor("magenta", null, bgcolor), "rgb(255,0,255)");
+        assert.equal(parseColor("orange", null, bgcolor), "rgb(255,200,0)");
+        assert.equal(parseColor("pink", null, bgcolor), "rgb(255,175,175)");
+        assert.equal(parseColor("red", null, bgcolor), "rgb(255,0,0)");
+        assert.equal(parseColor("white", null, bgcolor), "rgb(255,255,255)");
+        assert.equal(parseColor("yellow", null, bgcolor), "rgb(255,255,0)");
+    });
+
+    // 4. Hex color parsing
+    it("should parse 6-digit hex 'ff0000' as red", () => {
+        assert.equal(parseColor("ff0000", null, bgcolor), "rgb(255,0,0)");
+    });
+    it("should parse hex '0000ff' as blue", () => {
+        assert.equal(parseColor("0000ff", null, bgcolor), "rgb(0,0,255)");
+    });
+    it("should parse hex 'ffffff' as white", () => {
+        assert.equal(parseColor("ffffff", null, bgcolor), "rgb(255,255,255)");
+    });
+
+    // 5. HSB comma triple parsing
+    it("should parse '35,19,100' (standard background) as warm peach", () => {
+        // h=35/360, s=19/100, b=100/100
+        let c = parseColor("35,19,100", null, bgcolor);
+        assert.ok(c.startsWith("rgb("));
+        // Should be approximately rgb(255,233,205) — the peach background
+        let m = c.match(/rgb\((\d+),(\d+),(\d+)\)/);
+        let r = parseInt(m[1]), g = parseInt(m[2]), b = parseInt(m[3]);
+        // Java produces Color(255,233,206) for HSB(35/360, 19/100, 100/100)
+        assert.ok(r >= 250 && r <= 255, `red ${r} should be ~255`);
+        assert.ok(g >= 228 && g <= 238, `green ${g} should be ~233`);
+        assert.ok(b >= 200 && b <= 210, `blue ${b} should be ~206`);
+    });
+    it("should parse '0,0,0' as black", () => {
+        assert.equal(parseColor("0,0,0", null, bgcolor), "rgb(0,0,0)");
+    });
+    it("should parse '0,0,100' as white (full brightness, no saturation)", () => {
+        let c = parseColor("0,0,100", null, bgcolor);
+        assert.equal(c, "rgb(255,255,255)");
+    });
+    it("should parse '270,70,100' as a purple", () => {
+        let c = parseColor("270,70,100", null, bgcolor);
+        let m = c.match(/rgb\((\d+),(\d+),(\d+)\)/);
+        let r = parseInt(m[1]), b = parseInt(m[3]);
+        // Hue 270 = purple region, high saturation
+        assert.ok(b > r, `blue ${b} should exceed red ${r} for purple`);
+    });
+
+    // 6. Unrecognized → null
+    it("should return null for unrecognized input", () => {
+        assert.equal(parseColor("notacolor", null, bgcolor), null);
+    });
+});
+
+describe("brighter / darker", () => {
+
+    it("brighter should increase RGB components", () => {
+        let c = brighter("rgb(100,100,100)");
+        let m = c.match(/rgb\((\d+),(\d+),(\d+)\)/);
+        let r = parseInt(m[1]);
+        assert.ok(r > 100, `brighter(100) = ${r} should be > 100`);
+        // Java: floor(100 / 0.7) = 142
+        assert.equal(r, 142);
+    });
+
+    it("brighter should handle black (all zeros)", () => {
+        let c = brighter("rgb(0,0,0)");
+        // Java: ceil(1.0 / (1.0 - 0.7)) = ceil(3.333) = 4
+        assert.equal(c, "rgb(4,4,4)");
+    });
+
+    it("brighter should cap at 255", () => {
+        let c = brighter("rgb(200,200,200)");
+        let m = c.match(/rgb\((\d+),(\d+),(\d+)\)/);
+        let r = parseInt(m[1]);
+        assert.ok(r <= 255, `brighter(200) = ${r} should be <= 255`);
+    });
+
+    it("darker should reduce RGB components by factor 0.7", () => {
+        let c = darker("rgb(100,100,100)");
+        // Java: floor(100 * 0.7) = 70
+        assert.equal(c, "rgb(70,70,70)");
+    });
+
+    it("darker should handle black", () => {
+        let c = darker("rgb(0,0,0)");
+        assert.equal(c, "rgb(0,0,0)");
+    });
+
+    it("brighter should work with HSB triple input", () => {
+        // "35,19,100" → rgb(~255,~233,~206) → brighter clamps near 255
+        let c = brighter("35,19,100");
+        assert.ok(c.startsWith("rgb("), `expected rgb string, got: ${c}`);
+    });
+
+    it("darker should work with named color input", () => {
+        let c = darker("red");
+        // red = rgb(255,0,0) → darker = rgb(178,0,0)
+        assert.equal(c, "rgb(178,0,0)");
+    });
+
+    // Internal parseRGB gaps reached only via brighter/darker.
+
+    it("darken() should delegate to darker() for a given color", () => {
+        assert.equal(darken("rgb(200,100,50)"), darker("rgb(200,100,50)"));
+    });
+
+    it("brighter() should accept a 6-digit hex string via parseRGB", () => {
+        // "ff8040" → rgb(255,128,64). brighter(...) recomputes per component
+        // and produces a valid rgb() result.
+        let out = brighter("ff8040");
+        assert.ok(/^rgb\(\d+,\d+,\d+\)$/.test(out),
+            `brighter('ff8040') should return an rgb() string, got '${out}'`);
+    });
+
+    it("brighter() should return the input unchanged when it's unparseable", () => {
+        // parseRGB returns null → brighter returns col unchanged.
+        assert.equal(brighter("not-a-color"), "not-a-color");
+    });
+});

--- a/tests/HtmlParamParser.ts
+++ b/tests/HtmlParamParser.ts
@@ -1,0 +1,177 @@
+/*----------------------------------------------------------------------+
+|    HTML Param Parser — extracts applet configurations from Java HTML   |
+|    Reads <applet> blocks and their <param> tags, producing configs     |
+|    compatible with the TS geomlib.init() / buildScene() API.           |
++----------------------------------------------------------------------*/
+
+import * as fs from "fs";
+import * as path from "path";
+
+export interface SlateConfig {
+    width: number;
+    height: number;
+    background: string;
+    title: string;
+    pivot?: string;
+    elements: string[];  // parseParam-compatible strings
+}
+
+export interface HtmlFileResult {
+    filePath: string;
+    fileName: string;          // e.g., "propI1"
+    category: string;          // e.g., "euclid/bookI", "compass", "round"
+    slates: SlateConfig[];     // one per <applet> block
+}
+
+// Deterministic color to replace "random" — cycles through a fixed palette
+const FIXED_COLORS = [
+    "200,70,90",   // blue-ish
+    "30,70,90",    // orange-ish
+    "120,70,90",   // green-ish
+    "280,70,90",   // purple-ish
+    "60,70,90",    // yellow-ish
+    "330,70,90",   // pink-ish
+    "180,70,90",   // cyan-ish
+    "0,70,90",     // red-ish
+];
+let colorIndex = 0;
+
+function nextFixedColor(): string {
+    let color = FIXED_COLORS[colorIndex % FIXED_COLORS.length];
+    colorIndex++;
+    return color;
+}
+
+function replaceRandomColors(value: string): string {
+    // Split on semicolons to find color fields (positions 4-7 in the param format)
+    let parts = value.split(";");
+    if (parts.length <= 4) return value;
+    // Color fields start at index 4: nameColor, vertexColor, edgeColor, faceColor
+    for (let i = 4; i < parts.length; i++) {
+        if (parts[i].toLowerCase() === "random") {
+            parts[i] = nextFixedColor();
+        }
+    }
+    return parts.join(";");
+}
+
+// Parse a single <applet>...</applet> block into a SlateConfig
+function parseAppletBlock(block: string): SlateConfig | null {
+    // Extract width and height from <applet> tag
+    let widthMatch = block.match(/width\s*=\s*(\d+)/i);
+    let heightMatch = block.match(/height\s*=\s*(\d+)/i);
+    let width = widthMatch ? parseInt(widthMatch[1]) : 400;
+    let height = heightMatch ? parseInt(heightMatch[1]) : 400;
+
+    // Extract all <param> tags
+    // Match both quoted and unquoted param values:
+    //   <param name=background value="35,19,100">
+    //   <param name=pivot value=C>
+    let paramRegex = /<param\s+name\s*=\s*(\S+)\s+value\s*=\s*(?:"([^"]*)"|(\S+?))\s*>/gi;
+    let match: RegExpExecArray | null;
+    let background = "35,19,100";
+    let title = "";
+    let pivot: string | undefined;
+    let elements: {index: number, value: string}[] = [];
+
+    while ((match = paramRegex.exec(block)) !== null) {
+        let name = match[1].toLowerCase();
+        let value = match[2] || match[3]; // group 2 = quoted, group 3 = unquoted
+
+        if (name === "background") {
+            background = value;
+        } else if (name === "title") {
+            title = value;
+        } else if (name === "pivot") {
+            pivot = value;
+        } else {
+            // Match e[N] pattern
+            let eMatch = name.match(/^e\[(\d+)\]$/);
+            if (eMatch) {
+                let idx = parseInt(eMatch[1]);
+                elements.push({index: idx, value: replaceRandomColors(value)});
+            }
+        }
+    }
+
+    if (elements.length === 0) return null;
+
+    // Sort by index and extract values
+    elements.sort((a, b) => a.index - b.index);
+    let elementStrings = elements.map(e => e.value);
+
+    return { width, height, background, title, pivot, elements: elementStrings };
+}
+
+// Parse an HTML file and extract all applet configurations
+export function parseHtmlFile(filePath: string): HtmlFileResult {
+    let content = fs.readFileSync(filePath, "utf-8");
+    let fileName = path.basename(filePath, ".html");
+
+    // Determine category from path
+    let category: string;
+    if (filePath.includes("compass_geometry")) {
+        category = "compass";
+    } else if (filePath.includes("round_geometry")) {
+        category = "round";
+    } else {
+        // Euclid books: extract bookN from path
+        let bookMatch = filePath.match(/book(\w+)/i);
+        category = bookMatch ? `euclid/book${bookMatch[1].toUpperCase()}` : "euclid/other";
+    }
+
+    // Reset color index for each file so colors are deterministic per-file
+    colorIndex = 0;
+
+    // Split into applet blocks
+    // Handle both multi-line and single-line applet blocks
+    let slates: SlateConfig[] = [];
+    let appletRegex = /<applet[^>]*>[\s\S]*?<\/applet>/gi;
+    let appletMatch: RegExpExecArray | null;
+
+    while ((appletMatch = appletRegex.exec(content)) !== null) {
+        let config = parseAppletBlock(appletMatch[0]);
+        if (config != null) {
+            slates.push(config);
+        }
+    }
+
+    return { filePath, fileName, category, slates };
+}
+
+// Discover all HTML files with applets across all source directories
+export function discoverAllHtmlFiles(repoRoot: string): HtmlFileResult[] {
+    let results: HtmlFileResult[] = [];
+    let dirs = [
+        { base: path.join(repoRoot, "view/euclid-html"), pattern: /\.(html)$/ },
+        { base: path.join(repoRoot, "geom_applet/compass_geometry"), pattern: /\.html$/ },
+        { base: path.join(repoRoot, "geom_applet/round_geometry"), pattern: /\.html$/ },
+    ];
+
+    for (let dir of dirs) {
+        if (!fs.existsSync(dir.base)) continue;
+        let files = findHtmlFiles(dir.base, dir.pattern);
+        for (let file of files) {
+            let result = parseHtmlFile(file);
+            if (result.slates.length > 0) {
+                results.push(result);
+            }
+        }
+    }
+
+    return results;
+}
+
+function findHtmlFiles(dir: string, pattern: RegExp): string[] {
+    let files: string[] = [];
+    let entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (let entry of entries) {
+        let fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            files.push(...findHtmlFiles(fullPath, pattern));
+        } else if (pattern.test(entry.name)) {
+            files.push(fullPath);
+        }
+    }
+    return files.sort();
+}

--- a/tests/LineTest.ts
+++ b/tests/LineTest.ts
@@ -1,0 +1,355 @@
+import "mocha";
+import * as assert from "assert";
+import {Slate} from "../src/Slate";
+import {E, IConstructionInfo} from "../src/index";
+import {PointElement} from "../src/elements/point/PointElement";
+import {LineElement} from "../src/elements/line/LineElement";
+import {CircumcircleElement} from "../src/elements/circle/CircumcircleElement";
+import {Chord} from "../src/elements/line/Chord";
+import {createCanvas} from "canvas";
+import {almostEqual, toElements} from "./shared/testHelpers";
+
+describe("line", () => {
+
+    let connected_line_data: IConstructionInfo[] = [
+        { construction: E.Point.free,   name: "A",  params: [10, 100] },
+        { construction: E.Point.free,   name: "B",  params: [100, 100] },
+        { construction: E.Line.connect, name: "AB", params: ["A", "B"] },
+    ];
+
+    it("should create a connection as a LineElement", () => {
+        let slate: Slate = new Slate(createCanvas(200, 200));
+        let elms = toElements(slate, connected_line_data);
+        let p1 = elms[0] as PointElement;
+        let p2 = elms[1] as PointElement;
+        let l1 = elms[2] as LineElement;
+        assert.ok(p1 == l1.A);
+        assert.ok(p2 == l1.B);
+    });
+
+    // Book III, Prop 25a — circumcenter via perpendicular bisector lineSlider
+    let circumcenter_data: IConstructionInfo[] = [
+        { construction: E.Point.free,        name: "A",  params: [60, 30] },
+        { construction: E.Point.free,        name: "C",  params: [60, 200] },
+        { construction: E.Line.connect,      name: "AC", params: ["A", "C"] },
+        { construction: E.Point.midpoint,    name: "D",  params: ["AC"] },
+        { construction: E.Line.perpendicular,name: "DB", params: ["D", "A"] },
+        { construction: E.Point.lineSlider,  name: "B",  params: ["DB", 30, 115] },
+        { construction: E.Point.circumcenter,name: "E",  params: ["A", "B", "C"] },
+    ];
+
+    it("should create a circumcenter and line perpendicular element", () => {
+        let slate: Slate = new Slate(createCanvas(200, 200));
+        let elms = toElements(slate, circumcenter_data);
+        slate.elements.forEach(e => e.update());
+        let elmsUpdate = slate.elementsForUpdate;
+        let n = elmsUpdate.length;
+        let pcircle = elmsUpdate[n - 2] as CircumcircleElement;
+        let pcenter = elmsUpdate[n - 1] as PointElement;
+        assert.equal(pcircle.Center, pcenter);
+        almostEqual(pcenter.x, 165, 1);
+        almostEqual(pcenter.y, 115, 1);
+    });
+
+    // Book I, Prop 12 — chord of circle cut by a line
+    // Hand-computed: chord.A = (82.540, 180), chord.B = (237.460, 180)
+    let chord_propI12_data: IConstructionInfo[] = [
+        { name: "A",   construction: E.Point.free,     params: [30, 180] },
+        { name: "B",   construction: E.Point.free,     params: [290, 180] },
+        { name: "AB",  construction: E.Line.connect,   params: ["A", "B"] },
+        { name: "C",   construction: E.Point.free,     params: [160, 130] },
+        { name: "D",   construction: E.Point.free,     params: [180, 220] },
+        { name: "EFG", construction: E.Circle.radius,  params: ["C", "D"] },
+        { name: "EG",  construction: E.Line.chord,     params: ["AB", "EFG"] },
+    ];
+
+    it("should compute the chord of a circle cut by a line", () => {
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, chord_propI12_data);
+        slate.elements.forEach(e => e.update());
+        let chord = slate.lookupElement("EG") as Chord;
+        almostEqual(chord.A.x,  82.540, 0.01);
+        almostEqual(chord.A.y, 180.000, 0.01);
+        almostEqual(chord.B.x, 237.460, 0.01);
+        almostEqual(chord.B.y, 180.000, 0.01);
+        let center = slate.lookupElement("C") as PointElement;
+        let r = Math.sqrt(8500);
+        almostEqual(chord.A.distance(center), r, 0.001);
+        almostEqual(chord.B.distance(center), r, 0.001);
+    });
+
+    it("should NaN the chord when the line misses the circle entirely", () => {
+        let miss_data: IConstructionInfo[] = [
+            { name: "A",   construction: E.Point.free,    params: [30, 180] },
+            { name: "B",   construction: E.Point.free,    params: [290, 180] },
+            { name: "AB",  construction: E.Line.connect,  params: ["A", "B"] },
+            { name: "C",   construction: E.Point.free,    params: [160, 10] },
+            { name: "D",   construction: E.Point.free,    params: [165, 20] },
+            { name: "EFG", construction: E.Circle.radius, params: ["C", "D"] },
+            { name: "EG",  construction: E.Line.chord,    params: ["AB", "EFG"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, miss_data);
+        slate.elements.forEach(e => e.update());
+        let chord = slate.lookupElement("EG") as Chord;
+        assert.ok(isNaN(chord.A.x) && isNaN(chord.A.y));
+        assert.ok(isNaN(chord.B.x) && isNaN(chord.B.y));
+    });
+
+    it("should translate only the chord endpoints, leaving inputs untouched", () => {
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, chord_propI12_data);
+        slate.elements.forEach(e => e.update());
+        let chord = slate.lookupElement("EG") as Chord;
+        let ax0 = chord.A.x, ay0 = chord.A.y;
+        let bx0 = chord.B.x, by0 = chord.B.y;
+        chord.translate(5, 7);
+        almostEqual(chord.A.x, ax0 + 5, 0.001);
+        almostEqual(chord.A.y, ay0 + 7, 0.001);
+        almostEqual(chord.B.x, bx0 + 5, 0.001);
+        almostEqual(chord.B.y, by0 + 7, 0.001);
+        let A = slate.lookupElement("A") as PointElement;
+        let B = slate.lookupElement("B") as PointElement;
+        let C = slate.lookupElement("C") as PointElement;
+        let D = slate.lookupElement("D") as PointElement;
+        almostEqual(A.x,  30, 0.001); almostEqual(A.y, 180, 0.001);
+        almostEqual(B.x, 290, 0.001); almostEqual(B.y, 180, 0.001);
+        almostEqual(C.x, 160, 0.001); almostEqual(C.y, 130, 0.001);
+        almostEqual(D.x, 180, 0.001); almostEqual(D.y, 220, 0.001);
+    });
+
+    it("should rotate only the chord endpoints around a pivot", () => {
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, chord_propI12_data);
+        slate.elements.forEach(e => e.update());
+        let chord = slate.lookupElement("EG") as Chord;
+        let A = slate.lookupElement("A") as PointElement;
+        // 90° CCW rotation around A: expected chord.A=(30, 232.540), chord.B=(30, 387.460)
+        chord.rotate(A, 0, 1);
+        almostEqual(chord.A.x,  30.000, 0.01);
+        almostEqual(chord.A.y, 232.540, 0.01);
+        almostEqual(chord.B.x,  30.000, 0.01);
+        almostEqual(chord.B.y, 387.460, 0.01);
+        let B = slate.lookupElement("B") as PointElement;
+        let C = slate.lookupElement("C") as PointElement;
+        let D = slate.lookupElement("D") as PointElement;
+        almostEqual(A.x,  30, 0.001); almostEqual(A.y, 180, 0.001);
+        almostEqual(B.x, 290, 0.001); almostEqual(B.y, 180, 0.001);
+        almostEqual(C.x, 160, 0.001); almostEqual(C.y, 130, 0.001);
+        almostEqual(D.x, 180, 0.001); almostEqual(D.y, 220, 0.001);
+    });
+
+    let parallel_data: IConstructionInfo[] = [
+        { name: "A",  construction: E.Point.free,     params: [50, 100] },
+        { name: "B",  construction: E.Point.free,     params: [100, 100] },
+        { name: "C",  construction: E.Point.free,     params: [200, 200] },
+        { name: "AD", construction: E.Line.parallel,  params: ["A", "B", "C"] },
+    ];
+
+    it("should compute a line through A parallel and equal to BC", () => {
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, parallel_data);
+        slate.elements.forEach(e => e.update());
+        let line = slate.lookupElement("AD") as LineElement;
+        almostEqual(line.A.x,  50, 0.01);
+        almostEqual(line.A.y, 100, 0.01);
+        almostEqual(line.B.x, 150, 0.01);
+        almostEqual(line.B.y, 200, 0.01);
+    });
+
+    it("should recompute the parallel line when an input point moves", () => {
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, parallel_data);
+        slate.elements.forEach(e => e.update());
+        let C = slate.lookupElement("C") as PointElement;
+        C.x = 250; C.y = 150;
+        slate.elements.forEach(e => e.update());
+        let line = slate.lookupElement("AD") as LineElement;
+        almostEqual(line.A.x,  50, 0.01);
+        almostEqual(line.A.y, 100, 0.01);
+        almostEqual(line.B.x, 200, 0.01);
+        almostEqual(line.B.y, 150, 0.01);
+    });
+
+    // line;foot (2D)
+    it("should compute a line from A to the foot of the perpendicular on BC", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [100, 50] },
+            { name: "B", construction: E.Point.free, params: [50, 200] },
+            { name: "C", construction: E.Point.free, params: [250, 200] },
+            { name: "AL", construction: E.Line.foot, params: ["A", "B", "C"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let line = slate.lookupElement("AL") as LineElement;
+        almostEqual(line.A.x, 100, 0.01);
+        almostEqual(line.A.y,  50, 0.01);
+        almostEqual(line.B.x, 100, 0.01);
+        almostEqual(line.B.y, 200, 0.01);
+        let dx_line = line.B.x - line.A.x;
+        let dy_line = line.B.y - line.A.y;
+        let dx_bc = 250 - 50;
+        let dy_bc = 0;
+        almostEqual(dx_line * dx_bc + dy_line * dy_bc, 0, 0.01);
+    });
+
+    // line;similar
+    it("should create a similar line", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [50, 200] },
+            { name: "B", construction: E.Point.free, params: [150, 200] },
+            { name: "D", construction: E.Point.free, params: [0, 0] },
+            { name: "E", construction: E.Point.free, params: [100, 0] },
+            { name: "F", construction: E.Point.free, params: [0, 100] },
+            { name: "AH", construction: E.Line.similar, params: ["A", "B", "D", "E", "F"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let line = slate.lookupElement("AH") as LineElement;
+        almostEqual(line.A.x,  50, 0.01); almostEqual(line.A.y, 200, 0.01);
+        almostEqual(line.B.x,  50, 0.01); almostEqual(line.B.y, 300, 0.01);
+    });
+
+    // line;cutoff
+    it("should create a line cutoff equal to a given length", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [50, 100] },
+            { name: "B", construction: E.Point.free, params: [200, 100] },
+            { name: "C", construction: E.Point.free, params: [0, 0] },
+            { name: "D", construction: E.Point.free, params: [60, 0] },
+            { name: "AE", construction: E.Line.cutoff, params: ["A", "B", "C", "D"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let line = slate.lookupElement("AE") as LineElement;
+        almostEqual(line.A.x, 50, 0.01);
+        almostEqual(line.A.y, 100, 0.01);
+        almostEqual(line.B.x, 110, 0.01);
+        almostEqual(line.B.y, 100, 0.01);
+    });
+
+    it("should bisect a right angle and intersect the opposite side", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [0, 100] },
+            { name: "B", construction: E.Point.free, params: [0, 0] },
+            { name: "C", construction: E.Point.free, params: [100, 0] },
+            { name: "Bbis", construction: E.Line.angleBisector, params: ["A", "B", "C"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let line = slate.lookupElement("Bbis") as LineElement;
+        almostEqual(line.A.x, 0, 0.01);
+        almostEqual(line.A.y, 0, 0.01);
+        almostEqual(line.B.x, 50, 0.01);
+        almostEqual(line.B.y, 50, 0.01);
+    });
+
+    // line;proportion
+    it("should compute a proportion line", () => {
+        let data: IConstructionInfo[] = [
+            { name: "S0", construction: E.Point.free, params: [0, 0] },
+            { name: "S1", construction: E.Point.free, params: [100, 0] },
+            { name: "T0", construction: E.Point.free, params: [0, 0] },
+            { name: "T1", construction: E.Point.free, params: [50, 0] },
+            { name: "U0", construction: E.Point.free, params: [0, 0] },
+            { name: "U1", construction: E.Point.free, params: [80, 0] },
+            { name: "V0", construction: E.Point.free, params: [0, 200] },
+            { name: "V1", construction: E.Point.free, params: [200, 200] },
+            { name: "L",  construction: E.Line.proportion, params: ["S0","S1","T0","T1","U0","U1","V0","V1"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let line = slate.lookupElement("L") as LineElement;
+        almostEqual(line.A.x, 0, 0.01);
+        almostEqual(line.A.y, 200, 0.01);
+        almostEqual(line.B.x, 40, 0.01);
+        almostEqual(line.B.y, 200, 0.01);
+    });
+
+    // line;foot (plane variant)
+    it("should compute a line from a point to the foot on a plane", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "P", construction: E.Plane.threePoints, params: ["A", "B", "C"] },
+            { name: "D", construction: E.Point.fixed, params: [50, 50, 100] },
+            { name: "DF", construction: E.Line.foot, params: ["D", "P"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let line = slate.lookupElement("DF") as LineElement;
+        almostEqual(line.A.x, 50, 0.01);
+        almostEqual(line.A.y, 50, 0.01);
+        almostEqual(line.A.z, 100, 0.01);
+        almostEqual(line.B.x, 50, 0.01);
+        almostEqual(line.B.y, 50, 0.01);
+        almostEqual(line.B.z, 0, 0.01);
+    });
+
+    // 3D signature variants
+    it("should compute line angle bisector with explicit plane (3D variant)", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "B", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "L", construction: E.Line.angleBisector, params: ["A", "B", "C", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let L = slate.lookupElement("L") as LineElement;
+        almostEqual(L.A.x, 0, 0.1);
+        almostEqual(L.A.y, 0, 0.1);
+    });
+
+    it("should compute line angle divider with explicit plane (3D variant)", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "B", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "L", construction: E.Line.angleDivider, params: ["A", "B", "C", "plane", 3] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let L = slate.lookupElement("L") as LineElement;
+        assert.ok(L != null);
+        assert.ok(!isNaN(L.A.x));
+    });
+
+    it("should compute a similar line with explicit planes (3D variant)", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 200, 0] },
+            { name: "B", construction: E.Point.fixed, params: [150, 200, 0] },
+            { name: "D", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "Ep", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "F", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "L", construction: E.Line.similar, params: ["A", "B", "plane", "D", "Ep", "F", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let L = slate.lookupElement("L") as LineElement;
+        almostEqual(L.A.x, 50, 0.1);
+        assert.ok(!isNaN(L.B.x));
+    });
+});

--- a/tests/ParseParamTest.ts
+++ b/tests/ParseParamTest.ts
@@ -1,0 +1,109 @@
+import "mocha";
+import * as assert from "assert";
+import {E, parseParam} from "../src/index";
+
+describe("parseParam", () => {
+
+    it("should parse a free point with coordinates", () => {
+        let p = parseParam("A;point;free;60,100");
+        assert.equal(p.name, "A");
+        assert.equal(p.construction, E.Point.free);
+        assert.deepEqual(p.params, [60, 100]);
+    });
+
+    it("should parse a midpoint with string references", () => {
+        let p = parseParam("M;point;midpoint;A,B");
+        assert.equal(p.name, "M");
+        assert.equal(p.construction, E.Point.midpoint);
+        assert.deepEqual(p.params, ["A", "B"]);
+    });
+
+    it("should parse a circle construction", () => {
+        let p = parseParam("C;circle;radius;A,B");
+        assert.equal(p.construction, E.Circle.radius);
+        assert.deepEqual(p.params, ["A", "B"]);
+    });
+
+    it("should parse a line construction", () => {
+        let p = parseParam("AB;line;connect;A,B");
+        assert.equal(p.construction, E.Line.connect);
+        assert.deepEqual(p.params, ["A", "B"]);
+    });
+
+    it("should parse a polygon construction", () => {
+        let p = parseParam("T;polygon;triangle;A,B,C");
+        assert.equal(p.construction, E.Polygon.triangle);
+        assert.deepEqual(p.params, ["A", "B", "C"]);
+    });
+
+    it("should parse a sector construction", () => {
+        let p = parseParam("S;sector;sector;A,B,C");
+        assert.equal(p.construction, E.Sector.sector);
+    });
+
+    it("should parse a plane construction", () => {
+        let p = parseParam("P;plane;3points;A,B,C");
+        assert.equal(p.construction, E.Plane.threePoints);
+    });
+
+    it("should parse a sphere construction", () => {
+        let p = parseParam("S;sphere;radius;A,B");
+        assert.equal(p.construction, E.Sphere.radius);
+    });
+
+    it("should parse a polyhedron construction", () => {
+        let p = parseParam("P;polyhedron;pyramid;base,D");
+        assert.equal(p.construction, E.Polyhedra.pyramid);
+        assert.deepEqual(p.params, ["base", "D"]);
+    });
+
+    it("should convert numeric params to numbers", () => {
+        let p = parseParam("A;point;fixed;50,100,0");
+        assert.deepEqual(p.params, [50, 100, 0]);
+        assert.equal(typeof p.params[0], "number");
+    });
+
+    it("should handle mixed string and numeric params", () => {
+        let p = parseParam("R;polygon;regularPolygon;A,B,5");
+        assert.deepEqual(p.params, ["A", "B", 5]);
+    });
+
+    it("should handle negative numeric params", () => {
+        let p = parseParam("Y;point;planeSlider;P,-90,202,90");
+        assert.deepEqual(p.params, ["P", -90, 202, 90]);
+    });
+
+    it("should parse color fields", () => {
+        let p = parseParam("T;polygon;triangle;A,B,C;0;0;black;random");
+        assert.equal(p.nameColor, "0");
+        assert.equal(p.vertexColor, "0");
+        assert.equal(p.edgeColor, "black");
+        assert.equal(p.faceColor, "random");
+    });
+
+    it("should parse partial color fields", () => {
+        let p = parseParam("D;point;fixed;50,100,0;black;green");
+        assert.equal(p.nameColor, "black");
+        assert.equal(p.vertexColor, "green");
+        assert.equal(p.edgeColor, undefined);
+        assert.equal(p.faceColor, undefined);
+    });
+
+    it("should parse a single color field", () => {
+        let p = parseParam("Z;point;lineSlider;A,B,40,40,100;0");
+        assert.equal(p.nameColor, "0");
+        assert.equal(p.vertexColor, undefined);
+    });
+
+    it("should throw on unknown element type", () => {
+        assert.throws(() => parseParam("A;bogus;free;60,100"), /unknown element type/);
+    });
+
+    it("should throw on unknown construction name", () => {
+        assert.throws(() => parseParam("A;point;bogus;60,100"), /unknown construction/);
+    });
+
+    it("should throw on too few fields", () => {
+        assert.throws(() => parseParam("A;point"), /at least 4/);
+    });
+});

--- a/tests/PlaneTest.ts
+++ b/tests/PlaneTest.ts
@@ -1,0 +1,78 @@
+import "mocha";
+import * as assert from "assert";
+import {Slate} from "../src/Slate";
+import {E, IConstructionInfo} from "../src/index";
+import {PlaneElement} from "../src/elements/plane/PlaneElement";
+import {createCanvas} from "canvas";
+import {almostEqual, toElements} from "./shared/testHelpers";
+
+describe("plane", () => {
+
+    // Book XI, Def 24
+    let perpendicular_plane_data: IConstructionInfo[] = [
+        { construction: E.Point.free,  name: "origin",  params: [70, 220] },
+        { construction: E.Point.fixed, name: "z",       params: [70, 80, 100] },
+        { construction: E.Plane.perpendicular, name: "xyplane", params: ["origin", "z"] },
+    ];
+
+    it("should create a perpendicular plane", () => {
+        let slate: Slate = new Slate(createCanvas(200, 200));
+        let elms = toElements(slate, perpendicular_plane_data);
+        let p1 = elms[0] as PlaneElement;
+        p1.update();
+    });
+
+    it("should create a parallel plane through a point", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "P", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 50, 100] },
+            { name: "Q", construction: E.Plane.parallel, params: ["P", "A"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let Q = slate.lookupElement("Q") as PlaneElement;
+        almostEqual(Q.A.x, 50, 0.01);
+        almostEqual(Q.A.y, 50, 0.01);
+        almostEqual(Q.A.z, 100, 0.01);
+    });
+
+    it("should create a plane through 3 points with computed S,T,U frame", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "P", construction: E.Plane.threePoints, params: ["A", "B", "C"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let plane = slate.lookupElement("P") as PlaneElement;
+        almostEqual(plane.S.x, 1, 0.01); almostEqual(plane.S.y, 0, 0.01); almostEqual(plane.S.z, 0, 0.01);
+        almostEqual(plane.T.x, 0, 0.01); almostEqual(plane.T.y, 1, 0.01); almostEqual(plane.T.z, 0, 0.01);
+        almostEqual(plane.U.x, 0, 0.01); almostEqual(plane.U.y, 0, 0.01); almostEqual(plane.U.z, 1, 0.01);
+    });
+
+    // plane;ambient (point variant) — returns the ambient plane of a point
+    it("should return the ambient plane of a point", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "P", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.planeSlider, params: ["P", 50, 50, 0] },
+            { name: "AP", construction: E.Plane.ambient, params: ["A"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let ambient = slate.lookupElement("AP") as PlaneElement;
+        assert.ok(ambient != null);
+        assert.ok(ambient instanceof PlaneElement);
+        almostEqual(ambient.S.x, 1, 0.01);
+        almostEqual(ambient.S.y, 0, 0.01);
+    });
+});

--- a/tests/PointTest.ts
+++ b/tests/PointTest.ts
@@ -1,0 +1,420 @@
+import "mocha";
+import * as assert from "assert";
+import {Slate} from "../src/Slate";
+import {E, IConstructionInfo} from "../src/index";
+import {PlaneSlider} from "../src/elements/point/PlaneSlider";
+import {Intersection} from "../src/elements/point/Intersection";
+import {PointElement} from "../src/elements/point/PointElement";
+import {CircleSlider} from "../src/elements/point/CircleSlider";
+import {HarmonicElement} from "../src/elements/point/HarmonicElement";
+import {SimilarElement} from "../src/elements/point/SimilarElement";
+import {createCanvas} from "canvas";
+import {almostEqual, toElements} from "./shared/testHelpers";
+
+describe("point", () => {
+
+    it("should create a free point as a PlaneSlider", () => {
+        let slate: Slate = new Slate(createCanvas(200, 200));
+        let e = slate.createElement(E.Point.free, [100, 100], "A");
+        assert.ok(e == slate.elements[slate.elements.length - 1]);
+        assert.ok(e instanceof PlaneSlider);
+        let ps: PlaneSlider = e as PlaneSlider;
+        assert.ok(e.name == "A");
+        assert.ok(ps.distance(new PointElement({x: 100, y: 100})) <= 0.001);
+    });
+
+    // Book I, Def I11
+    let circle_slider_midpoint_data: IConstructionInfo[] = [
+        { construction: E.Point.free,         name: "A",    params: [40, 110] },
+        { construction: E.Point.free,         name: "C",    params: [210, 110] },
+        { construction: E.Line.connect,       name: "AC",   params: ["A", "C"] },
+        { construction: E.Point.lineSlider,   name: "B",    params: ["AC", 100, 110] },
+        { construction: E.Point.midpoint,     name: "E",    params: ["B", "C"] },
+        { construction: E.Circle.radius,      name: "circ", params: ["E", "C"] },
+        { construction: E.Point.circleSlider, name: "D",    params: ["circ", 140, 40] }
+    ];
+
+    it("should create a circle, circle slider, and midpoint", () => {
+        let slate: Slate = new Slate(createCanvas(200, 200));
+        let elms = toElements(slate, circle_slider_midpoint_data);
+        slate.elements.forEach(e => e.update());
+        let p7 = elms[6] as CircleSlider;
+        almostEqual(p7.x, 143, 1);
+        almostEqual(p7.y, 56, 1);
+    });
+
+    // Book I, Def I2
+    let intersection_data: IConstructionInfo[] = [
+        { construction: E.Point.free,          name: "A",   params: [40, 70] },
+        { construction: E.Point.free,          name: "B",   params: [110, 100] },
+        { construction: E.Point.free,          name: "C",   params: [190, 100] },
+        { construction: E.Point.free,          name: "D",   params: [280, 50] },
+        { construction: E.Line.connect,        name: "BC",  params: ["B", "C"] },
+        { construction: E.Point.perpendicular, name: "E'",  params: ["B", "C"] },
+        { construction: E.Point.midpoint,      name: "M",   params: ["A", "B"] },
+        { construction: E.Point.perpendicular, name: "E''", params: ["M", "B"] },
+        { construction: E.Point.intersection,  name: "E",   params: ["B", "E'", "M", "E''"] },
+    ];
+
+    it("should create an intersection element", () => {
+        let slate: Slate = new Slate(createCanvas(200, 200));
+        let elms = toElements(slate, intersection_data);
+        slate.elements.forEach(e => e.update());
+        let p8 = elms[8] as Intersection;
+        almostEqual(p8.x, 110, 1);
+        almostEqual(p8.y, 3, 1);
+    });
+
+    it("should return the nth vertex of a triangle", () => {
+        const data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [100, 50] },
+            { name: "B", construction: E.Point.free, params: [50, 200] },
+            { name: "C", construction: E.Point.free, params: [250, 200] },
+            { name: "T", construction: E.Polygon.triangle, params: ["A", "B", "C"] },
+            { name: "V1", construction: E.Point.vertex, params: ["T", 1] },
+            { name: "V2", construction: E.Point.vertex, params: ["T", 2] },
+            { name: "V3", construction: E.Point.vertex, params: ["T", 3] },
+        ];
+        let slate = new Slate(createCanvas(400, 300));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let V1 = slate.lookupElement("V1") as PointElement;
+        let V2 = slate.lookupElement("V2") as PointElement;
+        let V3 = slate.lookupElement("V3") as PointElement;
+        almostEqual(V1.x, 100, 1); almostEqual(V1.y, 50, 1);
+        almostEqual(V2.x, 50, 1);  almostEqual(V2.y, 200, 1);
+        almostEqual(V3.x, 250, 1); almostEqual(V3.y, 200, 1);
+    });
+
+    it("should compute the 4th vertex of a parallelogram", () => {
+        // propI28: A(40,80), B(190,80), C(40,120) → D' = C + (B-A) = (190,120)
+        const data: IConstructionInfo[] = [
+            { name: "A",  construction: E.Point.free,          params: [40, 80] },
+            { name: "B",  construction: E.Point.free,          params: [190, 80] },
+            { name: "C",  construction: E.Point.free,          params: [40, 120] },
+            { name: "D'", construction: E.Point.parallelogram, params: ["C", "A", "B"] },
+        ];
+        const slate = new Slate(createCanvas(400, 300));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        const D = slate.lookupElement("D'") as PointElement;
+        almostEqual(D.x, 190, 1);
+        almostEqual(D.y, 120, 1);
+    });
+
+    it("should compute the harmonic conjugate in the 3D branch when any z != 0", () => {
+        // The 2D branch is hit when B.z === C.z === D.z === 0; lines 46-59.
+        // Lines 61-72 are the 3D branch — exercised as soon as any point
+        // has a non-zero z. Picks three collinear points on z=5.
+        let B = new PointElement({x: 10, y: 10, z: 5});
+        let C = new PointElement({x: 30, y: 10, z: 5});
+        let D = new PointElement({x: 50, y: 10, z: 5});
+        let H = new HarmonicElement(B, C, D);
+        H.update();
+
+        // Harmonic conjugate of B w.r.t. collinear C,D: cross-ratio (A,B;C,D) = -1
+        // → A = 110/3 ≈ 36.667, same line → same y, same z.
+        almostEqual(H.x, 110 / 3, 0.01);
+        almostEqual(H.y, 10, 0.01);
+        almostEqual(H.z, 5, 0.01);
+    });
+
+    it("should compute the harmonic conjugate (2D collinear case)", () => {
+        // Collinear case: C=(0,0), D=(100,0), B=(25,0). Expected A=(-50,0).
+        let data: IConstructionInfo[] = [
+            { name: "B", construction: E.Point.free, params: [25, 0] },
+            { name: "C", construction: E.Point.free, params: [0, 0] },
+            { name: "D", construction: E.Point.free, params: [100, 0] },
+            { name: "A", construction: E.Point.harmonic, params: ["B", "C", "D"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let A = slate.lookupElement("A") as PointElement;
+        almostEqual(A.x, -50, 0.01);
+        almostEqual(A.y,   0, 0.01);
+    });
+
+    // point;meanProportional — S:U' = U':T (geometric mean)
+    it("should compute a mean proportional point (geometric mean)", () => {
+        let data: IConstructionInfo[] = [
+            { name: "S0", construction: E.Point.free, params: [0, 0] },
+            { name: "S1", construction: E.Point.free, params: [100, 0] },
+            { name: "T0", construction: E.Point.free, params: [0, 0] },
+            { name: "T1", construction: E.Point.free, params: [25, 0] },
+            { name: "U0", construction: E.Point.free, params: [0, 0] },
+            { name: "U1", construction: E.Point.free, params: [200, 0] },
+            { name: "P",  construction: E.Point.meanProportional, params: ["S0","S1","T0","T1","U0","U1"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let P = slate.lookupElement("P") as PointElement;
+        almostEqual(P.x, 50, 0.01);
+        almostEqual(P.y,  0, 0.01);
+        let S = Math.sqrt(100*100);
+        let T = Math.sqrt(25*25);
+        let Up = P.distance(slate.lookupElement("U0") as PointElement);
+        almostEqual(S / Up, Up / T, 0.001);
+    });
+
+    it("should compute a fourth proportional point", () => {
+        let data: IConstructionInfo[] = [
+            { name: "S0", construction: E.Point.free, params: [0, 0] },
+            { name: "S1", construction: E.Point.free, params: [100, 0] },
+            { name: "T0", construction: E.Point.free, params: [0, 0] },
+            { name: "T1", construction: E.Point.free, params: [50, 0] },
+            { name: "U0", construction: E.Point.free, params: [0, 0] },
+            { name: "U1", construction: E.Point.free, params: [80, 0] },
+            { name: "V0", construction: E.Point.free, params: [0, 0] },
+            { name: "V1", construction: E.Point.free, params: [200, 0] },
+            { name: "P",  construction: E.Point.proportion, params: ["S0","S1","T0","T1","U0","U1","V0","V1"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let P = slate.lookupElement("P") as PointElement;
+        almostEqual(P.x, 40, 0.01);
+        almostEqual(P.y,  0, 0.01);
+    });
+
+    // point;invert — factor = r²/d² = 4; result = (300,100)
+    it("should compute the inversion of a point in a circle", () => {
+        let data: IConstructionInfo[] = [
+            { name: "O", construction: E.Point.free, params: [100, 100] },
+            { name: "R", construction: E.Point.free, params: [200, 100] },
+            { name: "C", construction: E.Circle.radius, params: ["O", "R"] },
+            { name: "A", construction: E.Point.free, params: [150, 100] },
+            { name: "B", construction: E.Point.invert, params: ["A", "C"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let B = slate.lookupElement("B") as PointElement;
+        almostEqual(B.x, 300, 0.01);
+        almostEqual(B.y, 100, 0.01);
+    });
+
+    it("should create a planeSlider point on a 3-point plane", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.planeSlider, params: ["plane", 50, 50, 99] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let A = slate.lookupElement("A") as PointElement;
+        // xy-plane (z=0) → point should project to z=0
+        almostEqual(A.x, 50, 0.01);
+        almostEqual(A.y, 50, 0.01);
+        almostEqual(A.z, 0, 0.01);
+        assert.ok((A as any).draggable);
+    });
+
+    // sphereSlider — projects onto sphere surface (distance from center = radius)
+    it("should project a sphereSlider point onto the sphere surface", () => {
+        let data: IConstructionInfo[] = [
+            { name: "O", construction: E.Point.fixed, params: [100, 100, 0] },
+            { name: "R", construction: E.Point.fixed, params: [200, 100, 0] },
+            { name: "S", construction: E.Sphere.radius, params: ["O", "R"] },
+            { name: "A", construction: E.Point.sphereSlider, params: ["S", 150, 100, 50] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let A = slate.lookupElement("A") as PointElement;
+        let O = slate.lookupElement("O") as PointElement;
+        let dist = Math.sqrt((A.x-O.x)*(A.x-O.x) + (A.y-O.y)*(A.y-O.y) + (A.z-O.z)*(A.z-O.z));
+        almostEqual(dist, 100, 0.1);
+        assert.ok((A as any).draggable);
+    });
+
+    it("should compute the foot of a perpendicular from a point to a plane", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "P", construction: E.Plane.threePoints, params: ["A", "B", "C"] },
+            { name: "D", construction: E.Point.fixed, params: [50, 50, 100] },
+            { name: "F", construction: E.Point.foot, params: ["D", "P"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let foot = slate.lookupElement("F") as PointElement;
+        almostEqual(foot.x, 50, 0.01);
+        almostEqual(foot.y, 50, 0.01);
+        almostEqual(foot.z, 0, 0.01);
+    });
+
+    it("should compute a similar point with factor=1 (isosceles right triangle)", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [50, 200] },
+            { name: "B", construction: E.Point.free, params: [150, 200] },
+            { name: "D", construction: E.Point.free, params: [0, 0] },
+            { name: "E", construction: E.Point.free, params: [100, 0] },
+            { name: "F", construction: E.Point.free, params: [0, 100] },
+            { name: "C", construction: E.Point.similar, params: ["A", "B", "D", "E", "F"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let C = slate.lookupElement("C") as SimilarElement;
+        almostEqual(C.x, 50, 0.01);
+        almostEqual(C.y, 300, 0.01);
+        let A = slate.lookupElement("A") as PointElement;
+        let B = slate.lookupElement("B") as PointElement;
+        almostEqual(A.distance(C) / A.distance(B), 1.0, 0.001);
+    });
+
+    it("should compute a similar point with factor=0.5 (non-isosceles right triangle)", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [50, 200] },
+            { name: "B", construction: E.Point.free, params: [150, 200] },
+            { name: "D", construction: E.Point.free, params: [0, 0] },
+            { name: "E", construction: E.Point.free, params: [200, 0] },
+            { name: "F", construction: E.Point.free, params: [0, 100] },
+            { name: "C", construction: E.Point.similar, params: ["A", "B", "D", "E", "F"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let C = slate.lookupElement("C") as SimilarElement;
+        almostEqual(C.x, 50, 0.01);
+        almostEqual(C.y, 250, 0.01);
+        let A = slate.lookupElement("A") as PointElement;
+        let B = slate.lookupElement("B") as PointElement;
+        almostEqual(A.distance(C) / A.distance(B), 0.5, 0.001);
+    });
+
+    it("should compute the angle bisector point", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [0, 100] },
+            { name: "B", construction: E.Point.free, params: [0, 0] },
+            { name: "C", construction: E.Point.free, params: [100, 0] },
+            { name: "D", construction: E.Point.angleBisector, params: ["A", "B", "C"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let D = slate.lookupElement("D") as PointElement;
+        almostEqual(D.x, 50, 0.01);
+        almostEqual(D.y, 50, 0.01);
+    });
+
+    // point;intersection (plane-line) — PlaneIntersection
+    // Plane z=0, line (50,50,100)→(50,50,-100) → intersects at (50,50,0)
+    it("should compute plane-line intersection", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "P", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 50, 100] },
+            { name: "B", construction: E.Point.fixed, params: [50, 50, -100] },
+            { name: "X", construction: E.Point.intersection, params: ["P", "A", "B"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let X = slate.lookupElement("X") as PointElement;
+        almostEqual(X.x, 50, 0.1);
+        almostEqual(X.y, 50, 0.1);
+        almostEqual(X.z, 0, 0.1);
+    });
+
+    // 3D signature variants
+    it("should compute a similar point with explicit planes (3D variant)", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 200, 0] },
+            { name: "B", construction: E.Point.fixed, params: [150, 200, 0] },
+            { name: "D", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "Ep", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "F", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "C", construction: E.Point.similar, params: ["A", "B", "plane", "D", "Ep", "F", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let C = slate.lookupElement("C") as PointElement;
+        assert.ok(!isNaN(C.x));
+        assert.ok(!isNaN(C.y));
+    });
+
+    it("should compute angle bisector with explicit plane (3D variant)", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "B", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "D", construction: E.Point.angleBisector, params: ["A", "B", "C", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let D = slate.lookupElement("D") as PointElement;
+        almostEqual(D.x, 50, 0.1);
+        almostEqual(D.y, 50, 0.1);
+    });
+
+    it("should compute angle divider with explicit plane (3D variant)", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "B", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "D", construction: E.Point.angleDivider, params: ["A", "B", "C", "plane", 3] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let D = slate.lookupElement("D") as PointElement;
+        assert.ok(!isNaN(D.x));
+        assert.ok(!isNaN(D.y));
+    });
+
+    // point;perpendicular has five signatures. Variant 5 (3 pts + plane) is
+    // exercised by the drag scene (scene3d's "Pperp"); these cover the rest.
+    it("E.Point.perpendicular with 4 points (no plane) should construct variant 3", () => {
+        let slate = new Slate(createCanvas(300, 300));
+        toElements(slate, [
+            { name: "A", construction: E.Point.free, params: [10, 10] },
+            { name: "B", construction: E.Point.free, params: [50, 10] },
+            { name: "C", construction: E.Point.free, params: [30, 30] },
+            { name: "D", construction: E.Point.free, params: [40, 40] },
+        ]);
+        let g = slate.createElement(
+            E.Point.perpendicular, ["A","B","C","D"], "FP3");
+        assert.ok(g instanceof PointElement);
+    });
+
+    it("E.Point.perpendicular with 4 points + plane should construct variant 4", () => {
+        let slate = new Slate(createCanvas(300, 300));
+        toElements(slate, [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [10, 10, 0] },
+            { name: "B", construction: E.Point.fixed, params: [50, 10, 0] },
+            { name: "C", construction: E.Point.fixed, params: [30, 30, 0] },
+            { name: "D", construction: E.Point.fixed, params: [40, 40, 0] },
+        ]);
+        let g = slate.createElement(
+            E.Point.perpendicular, ["A","B","plane","C","D"], "FP4");
+        assert.ok(g instanceof PointElement);
+    });
+});

--- a/tests/PolygonTest.ts
+++ b/tests/PolygonTest.ts
@@ -1,0 +1,286 @@
+import "mocha";
+import * as assert from "assert";
+import {Slate} from "../src/Slate";
+import {E, IConstructionInfo} from "../src/index";
+import {PointElement} from "../src/elements/point/PointElement";
+import {PolygonElement} from "../src/elements/polygon/PolygonElement";
+import {ApplicationElement} from "../src/elements/polygon/ApplicationElement";
+import {createCanvas} from "canvas";
+import {almostEqual, toElements} from "./shared/testHelpers";
+
+describe("polygon", () => {
+
+    it("should produce an equilateral triangle", () => {
+        const data: IConstructionInfo[] = [
+            { name: "A",   construction: E.Point.free,               params: [40, 170] },
+            { name: "B",   construction: E.Point.free,               params: [200, 170] },
+            { name: "ABC", construction: E.Polygon.equilateralTriangle, params: ["A", "B"] },
+            { name: "C",   construction: E.Point.vertex,             params: ["ABC", 3] },
+        ];
+        const slate = new Slate(createCanvas(400, 300));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        const A = slate.lookupElement("A") as PointElement;
+        const B = slate.lookupElement("B") as PointElement;
+        const C = slate.lookupElement("C") as PointElement;
+        const ab = Math.hypot(B.x - A.x, B.y - A.y);
+        const ac = Math.hypot(C.x - A.x, C.y - A.y);
+        const bc = Math.hypot(C.x - B.x, C.y - B.y);
+        almostEqual(ac, ab, 1);
+        almostEqual(bc, ab, 1);
+        assert.ok(C.y < A.y);
+    });
+
+    // polygon;parallelogram — propI34 fixture
+    let pgram_propI34_data: IConstructionInfo[] = [
+        { name: "A",    construction: E.Point.free,              params: [90, 50] },
+        { name: "B",    construction: E.Point.free,              params: [250, 50] },
+        { name: "C",    construction: E.Point.free,              params: [50, 175] },
+        { name: "CABD", construction: E.Polygon.parallelogram,   params: ["C", "A", "B"] },
+        { name: "D",    construction: E.Point.vertex,            params: ["CABD", 4] },
+    ];
+
+    it("should compute a parallelogram with the 4th vertex via Layoff", () => {
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, pgram_propI34_data);
+        slate.elements.forEach(e => e.update());
+        let poly = slate.lookupElement("CABD") as PolygonElement;
+        assert.equal(poly.V.length, 4);
+        almostEqual(poly.V[0].x,  50, 0.01); almostEqual(poly.V[0].y, 175, 0.01);
+        almostEqual(poly.V[1].x,  90, 0.01); almostEqual(poly.V[1].y,  50, 0.01);
+        almostEqual(poly.V[2].x, 250, 0.01); almostEqual(poly.V[2].y,  50, 0.01);
+        almostEqual(poly.V[3].x, 210, 0.01); almostEqual(poly.V[3].y, 175, 0.01);
+        let CA = poly.V[0].distance(poly.V[1]);
+        let BD = poly.V[2].distance(poly.V[3]);
+        almostEqual(CA, BD, 0.001);
+        let AB = poly.V[1].distance(poly.V[2]);
+        let CD = poly.V[0].distance(poly.V[3]);
+        almostEqual(AB, CD, 0.001);
+    });
+
+    it("should extract the 4th vertex via point;vertex", () => {
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, pgram_propI34_data);
+        slate.elements.forEach(e => e.update());
+        let D = slate.lookupElement("D") as PointElement;
+        almostEqual(D.x, 210, 0.01);
+        almostEqual(D.y, 175, 0.01);
+    });
+
+    it("should create a parallelogram with the same area as the input polygon", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.free, params: [0, 0] },
+            { name: "P2", construction: E.Point.free, params: [100, 0] },
+            { name: "P3", construction: E.Point.free, params: [0, 80] },
+            { name: "P",  construction: E.Polygon.triangle, params: ["P1", "P2", "P3"] },
+            { name: "A",  construction: E.Point.free, params: [50, 200] },
+            { name: "B",  construction: E.Point.free, params: [150, 200] },
+            { name: "C",  construction: E.Point.free, params: [50, 100] },
+            { name: "ABEF", construction: E.Polygon.application, params: ["P", "A", "B", "C"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let app = slate.lookupElement("ABEF") as ApplicationElement;
+        assert.equal(app.V.length, 4);
+        almostEqual(app.V[0].x,  50, 0.01); almostEqual(app.V[0].y, 200, 0.01);
+        almostEqual(app.V[1].x, 150, 0.01); almostEqual(app.V[1].y, 200, 0.01);
+        almostEqual(app.V[3].x,  50, 0.01); almostEqual(app.V[3].y, 160, 0.01);
+        almostEqual(app.V[2].x, 150, 0.01); almostEqual(app.V[2].y, 160, 0.01);
+        almostEqual(app.area(), 4000, 1);
+    });
+
+    it("should create a similar triangle polygon", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [50, 200] },
+            { name: "B", construction: E.Point.free, params: [150, 200] },
+            { name: "D", construction: E.Point.free, params: [0, 0] },
+            { name: "E", construction: E.Point.free, params: [100, 0] },
+            { name: "F", construction: E.Point.free, params: [0, 100] },
+            { name: "ABH", construction: E.Polygon.similar, params: ["A", "B", "D", "E", "F"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let poly = slate.lookupElement("ABH") as PolygonElement;
+        assert.equal(poly.V.length, 3);
+        almostEqual(poly.V[0].x,  50, 0.01); almostEqual(poly.V[0].y, 200, 0.01);
+        almostEqual(poly.V[1].x, 150, 0.01); almostEqual(poly.V[1].y, 200, 0.01);
+        almostEqual(poly.V[2].x,  50, 0.01); almostEqual(poly.V[2].y, 300, 0.01);
+    });
+
+    it("should compute a square with 4 vertices at right angles", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [50, 190] },
+            { name: "B", construction: E.Point.free, params: [170, 190] },
+            { name: "ABED", construction: E.Polygon.square, params: ["A", "B"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let sq = slate.lookupElement("ABED") as PolygonElement;
+        assert.equal(sq.V.length, 4);
+        almostEqual(sq.V[0].x,  50, 0.01); almostEqual(sq.V[0].y, 190, 0.01);
+        almostEqual(sq.V[1].x, 170, 0.01); almostEqual(sq.V[1].y, 190, 0.01);
+        almostEqual(sq.V[2].x, 170, 0.01); almostEqual(sq.V[2].y,  70, 0.01);
+        almostEqual(sq.V[3].x,  50, 0.01); almostEqual(sq.V[3].y,  70, 0.01);
+        let side = sq.V[0].distance(sq.V[1]);
+        almostEqual(side, 120, 0.01);
+        almostEqual(sq.V[1].distance(sq.V[2]), side, 0.01);
+        almostEqual(sq.V[2].distance(sq.V[3]), side, 0.01);
+        almostEqual(sq.V[3].distance(sq.V[0]), side, 0.01);
+    });
+
+    it("should create a regular pentagon with 5 equal sides", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [100, 50] },
+            { name: "B", construction: E.Point.free, params: [200, 50] },
+            { name: "ABCDE", construction: E.Polygon.regularPolygon, params: ["A", "B", 5] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let poly = slate.lookupElement("ABCDE") as PolygonElement;
+        assert.equal(poly.V.length, 5);
+        let side = poly.V[0].distance(poly.V[1]);
+        almostEqual(side, 100, 0.01);
+        for (let i = 1; i < 5; i++) {
+            almostEqual(poly.V[i].distance(poly.V[(i+1) % 5]), side, 0.01);
+        }
+    });
+
+    it("should create a quadrilateral with 4 vertices", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [80, 40] },
+            { name: "B", construction: E.Point.free, params: [40, 210] },
+            { name: "C", construction: E.Point.free, params: [210, 210] },
+            { name: "D", construction: E.Point.free, params: [250, 40] },
+            { name: "ABCD", construction: E.Polygon.quadrilateral, params: ["A", "B", "C", "D"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        let poly = slate.lookupElement("ABCD") as PolygonElement;
+        assert.equal(poly.V.length, 4);
+        almostEqual(poly.V[0].x,  80, 0.01); almostEqual(poly.V[0].y,  40, 0.01);
+        almostEqual(poly.V[1].x,  40, 0.01); almostEqual(poly.V[1].y, 210, 0.01);
+        almostEqual(poly.V[2].x, 210, 0.01); almostEqual(poly.V[2].y, 210, 0.01);
+        almostEqual(poly.V[3].x, 250, 0.01); almostEqual(poly.V[3].y,  40, 0.01);
+    });
+
+    it("should create an octagon with 8 vertices", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [100, 50] },
+            { name: "B", construction: E.Point.free, params: [150, 50] },
+            { name: "C", construction: E.Point.free, params: [175, 100] },
+            { name: "D", construction: E.Point.free, params: [150, 150] },
+            { name: "E", construction: E.Point.free, params: [100, 150] },
+            { name: "F", construction: E.Point.free, params: [75, 100] },
+            { name: "G", construction: E.Point.free, params: [85, 70] },
+            { name: "H", construction: E.Point.free, params: [115, 70] },
+            { name: "OCT", construction: E.Polygon.octagon, params: ["A","B","C","D","E","F","G","H"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        let poly = slate.lookupElement("OCT") as PolygonElement;
+        assert.equal(poly.V.length, 8);
+        almostEqual(poly.V[0].x, 100, 0.01);
+        almostEqual(poly.V[7].x, 115, 0.01);
+    });
+
+    // polygon;starPolygon — {5/2} pentagram
+    it("should create a star polygon (pentagram) with 5 vertices", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.free, params: [100, 50] },
+            { name: "B", construction: E.Point.free, params: [200, 50] },
+            { name: "S", construction: E.Polygon.starPolygon, params: ["A", "B", 5, 2] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let poly = slate.lookupElement("S") as PolygonElement;
+        assert.equal(poly.V.length, 5);
+        almostEqual(poly.V[0].x, 100, 0.01);
+        almostEqual(poly.V[1].x, 200, 0.01);
+        assert.ok(!isNaN(poly.V[2].x));
+        assert.ok(!isNaN(poly.V[2].y));
+    });
+
+    // 3D signature variants
+    it("should create an equilateral triangle with explicit plane (3D variant)", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 50, 0] },
+            { name: "B", construction: E.Point.fixed, params: [150, 50, 0] },
+            { name: "T", construction: E.Polygon.equilateralTriangle, params: ["A", "B", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let tri = slate.lookupElement("T") as PolygonElement;
+        assert.equal(tri.V.length, 3);
+        let side = tri.V[0].distance(tri.V[1]);
+        almostEqual(side, 100, 0.01);
+        almostEqual(tri.V[1].distance(tri.V[2]), side, 0.01);
+        almostEqual(tri.V[2].distance(tri.V[0]), side, 0.01);
+    });
+
+    it("should create a square with explicit plane (3D variant)", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 190, 0] },
+            { name: "B", construction: E.Point.fixed, params: [170, 190, 0] },
+            { name: "S", construction: E.Polygon.square, params: ["A", "B", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let sq = slate.lookupElement("S") as PolygonElement;
+        assert.equal(sq.V.length, 4);
+        let side = sq.V[0].distance(sq.V[1]);
+        almostEqual(side, 120, 0.01);
+    });
+
+    it("should create a regular pentagon with explicit plane (3D variant)", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [100, 50, 0] },
+            { name: "B", construction: E.Point.fixed, params: [200, 50, 0] },
+            { name: "pent", construction: E.Polygon.regularPolygon, params: ["A", "B", "plane", 5] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let poly = slate.lookupElement("pent") as PolygonElement;
+        assert.equal(poly.V.length, 5);
+    });
+
+    it("should create a similar polygon with explicit planes (3D variant)", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 200, 0] },
+            { name: "B", construction: E.Point.fixed, params: [150, 200, 0] },
+            { name: "D", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "Ep", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "F", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "T", construction: E.Polygon.similar, params: ["A", "B", "plane", "D", "Ep", "F", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let tri = slate.lookupElement("T") as PolygonElement;
+        assert.equal(tri.V.length, 3);
+        assert.ok(!isNaN(tri.V[2].x));
+    });
+});

--- a/tests/PolyhedronTest.ts
+++ b/tests/PolyhedronTest.ts
@@ -1,0 +1,72 @@
+import "mocha";
+import * as assert from "assert";
+import {Slate} from "../src/Slate";
+import {E, IConstructionInfo} from "../src/index";
+import {PolygonElement} from "../src/elements/polygon/PolygonElement";
+import {createCanvas} from "canvas";
+import {almostEqual, toElements} from "./shared/testHelpers";
+import {buildSpecializedScene} from "./shared/dragScenes";
+
+describe("polyhedron", () => {
+
+    it("should create a tetrahedron with 4 triangular faces", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [50, 87, 0] },
+            { name: "D", construction: E.Point.fixed, params: [50, 29, 82] },
+            { name: "T", construction: E.Polyhedra.tetrahedron, params: ["A", "B", "C", "D"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        let tetra = slate.lookupElement("T");
+        assert.ok(tetra != null);
+        assert.equal((tetra as any).P.length, 4);
+    });
+
+    it("should create a prism with base+2 triangles and 3 side quads", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [50, 87, 0] },
+            { name: "base", construction: E.Polygon.triangle, params: ["A", "B", "C"] },
+            { name: "D", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "E", construction: E.Point.fixed, params: [0, 0, 100] },
+            { name: "P", construction: E.Polyhedra.prism, params: ["base", "D", "E"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let prism = slate.lookupElement("P");
+        assert.ok(prism != null);
+        assert.equal((prism as any).P.length, 5);
+        let top = (prism as any).P[1] as PolygonElement;
+        almostEqual(top.V[0].z, 100, 0.01);
+        almostEqual(top.V[1].z, 100, 0.01);
+        almostEqual(top.V[2].z, 100, 0.01);
+    });
+
+    it("should create a parallelepiped with 6 faces", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "D", construction: E.Point.fixed, params: [0, 0, 100] },
+            { name: "PP", construction: E.Polyhedra.parallelepiped, params: ["A", "B", "C", "D"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let pp = slate.lookupElement("PP");
+        assert.ok(pp != null);
+        assert.equal((pp as any).P.length, 6);
+    });
+
+    it("PolyhedronElement.drawVertex should render face vertices when vertexColor is set", () => {
+        let slate = buildSpecializedScene();
+        let pep = slate.lookupElement("pep");  // parallelepiped
+        assert.ok(pep != null, "parallelepiped should exist");
+        pep.vertexColor = "black";
+        pep.drawVertex(createCanvas(300, 300) as any);
+    });
+});

--- a/tests/SectorTest.ts
+++ b/tests/SectorTest.ts
@@ -1,0 +1,89 @@
+import "mocha";
+import * as assert from "assert";
+import {Slate} from "../src/Slate";
+import {E, IConstructionInfo} from "../src/index";
+import {PointElement} from "../src/elements/point/PointElement";
+import {ArcElement} from "../src/elements/sector/ArcElement";
+import {createCanvas} from "canvas";
+import {almostEqual, toElements} from "./shared/testHelpers";
+
+describe("sector", () => {
+
+    // Book III, Prop 2 — arc through three points
+    // A=(50,130), E=(70,210), B=(120,200)
+    // Expected center: (86.667, 163.333), radius ≈ 49.554
+    let arc_propIII2_data: IConstructionInfo[] = [
+        { name: "A",   construction: E.Point.free,  params: [50, 130] },
+        { name: "E",   construction: E.Point.free,  params: [70, 210] },
+        { name: "B",   construction: E.Point.free,  params: [120, 200] },
+        { name: "AEB", construction: E.Sector.arc, params: ["A", "E", "B"] },
+    ];
+
+    it("should compute the circumcenter of an arc through three points", () => {
+        let slate = new Slate(createCanvas(260, 260));
+        toElements(slate, arc_propIII2_data);
+        slate.elements.forEach(e => e.update());
+        let arc = slate.lookupElement("AEB") as ArcElement;
+        almostEqual(arc._Center.x, 86.667, 0.01);
+        almostEqual(arc._Center.y, 163.333, 0.01);
+        let rA = arc._Center.distance(arc._A);
+        let rM = arc._Center.distance(arc._M);
+        let rB = arc._Center.distance(arc._B);
+        almostEqual(rA, 49.554, 0.01);
+        almostEqual(rM, 49.554, 0.01);
+        almostEqual(rB, 49.554, 0.01);
+    });
+
+    it("should translate only the arc center, leaving A, M, B untouched", () => {
+        let slate = new Slate(createCanvas(260, 260));
+        toElements(slate, arc_propIII2_data);
+        slate.elements.forEach(e => e.update());
+        let arc = slate.lookupElement("AEB") as ArcElement;
+        let cx0 = arc._Center.x;
+        let cy0 = arc._Center.y;
+        arc.translate(5, 7);
+        almostEqual(arc._Center.x, cx0 + 5, 0.001);
+        almostEqual(arc._Center.y, cy0 + 7, 0.001);
+        let A = slate.lookupElement("A") as PointElement;
+        let M = slate.lookupElement("E") as PointElement;
+        let B = slate.lookupElement("B") as PointElement;
+        almostEqual(A.x, 50,  0.001); almostEqual(A.y, 130, 0.001);
+        almostEqual(M.x, 70,  0.001); almostEqual(M.y, 210, 0.001);
+        almostEqual(B.x, 120, 0.001); almostEqual(B.y, 200, 0.001);
+    });
+
+    it("should rotate only the arc center around a pivot", () => {
+        let slate = new Slate(createCanvas(260, 260));
+        toElements(slate, arc_propIII2_data);
+        slate.elements.forEach(e => e.update());
+        let arc = slate.lookupElement("AEB") as ArcElement;
+        let A = slate.lookupElement("A") as PointElement;
+        // 90° CCW around A=(50,130): ac=0, as=1
+        arc.rotate(A, 0, 1);
+        almostEqual(arc._Center.x, 16.667, 0.01);
+        almostEqual(arc._Center.y, 166.667, 0.01);
+        let M = slate.lookupElement("E") as PointElement;
+        let B = slate.lookupElement("B") as PointElement;
+        almostEqual(A.x, 50,  0.001); almostEqual(A.y, 130, 0.001);
+        almostEqual(M.x, 70,  0.001); almostEqual(M.y, 210, 0.001);
+        almostEqual(B.x, 120, 0.001); almostEqual(B.y, 200, 0.001);
+    });
+
+    it("should create an arc with explicit plane (3D variant)", () => {
+        let data: IConstructionInfo[] = [
+            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
+            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
+            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
+            { name: "A", construction: E.Point.fixed, params: [50, 130, 0] },
+            { name: "M", construction: E.Point.fixed, params: [70, 210, 0] },
+            { name: "B", construction: E.Point.fixed, params: [120, 200, 0] },
+            { name: "arc", construction: E.Sector.arc, params: ["A", "M", "B", "plane"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        let arc = slate.lookupElement("arc");
+        assert.ok(arc != null);
+    });
+});

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -17,6 +17,7 @@ import {ApplicationElement} from "../src/elements/polygon/ApplicationElement";
 import {SimilarElement} from "../src/elements/point/SimilarElement";
 import {CircleElement} from "../src/elements/circle/CircleElement";
 import {HarmonicElement} from "../src/elements/point/HarmonicElement";
+import {parseColor, brighter, darker, darken} from "../src/Colors";
 import {createCanvas} from "canvas";
 import {create} from "domain";
 
@@ -573,6 +574,7 @@ describe("slate", ()=> {
         { name: "D",    construction: E.Point.free,              params: [50, 180] },
         { name: "c1",   construction: E.Circle.radius,           params: ["A","B"] },
         { name: "c2",   construction: E.Circle.radius,           params: ["B","A"] },
+        { name: "bich", construction: E.Line.bichord,            params: ["c1","c2"] },
         { name: "P",    construction: E.Point.circleSlider,      params: ["c1", 120, 30] },
         { name: "inv",  construction: E.Circle.invert,           params: ["c1","c2"] },
         { name: "s1",   construction: E.Sphere.radius,           params: ["A","B"] },
@@ -620,6 +622,32 @@ describe("slate", ()=> {
 
         almostEqual(A.x, aInitX + deltaX, 0.001);
         almostEqual(A.y, aInitY + deltaY, 0.001);
+    });
+
+    it("should rotate specialized elements around a pivot", () => {
+        let slate = buildSpecializedScene();
+        // Pivot on C → dragging M (midpoint of A,B) rotates every non-
+        // preexisting element, including the InvertCircle, Sector, Prism,
+        // and Parallelepiped's rotate() methods.
+        slate.setPivot("C");
+
+        let M = slate.lookupElement("M") as PointElement;
+        let A = slate.lookupElement("A") as PointElement;
+        let C = slate.lookupElement("C") as PointElement;
+        let aInitX = A.x, aInitY = A.y;
+        let cInitX = C.x, cInitY = C.y;
+
+        let dx0 = Math.round(M.x), dy0 = Math.round(M.y);
+        slate._onMouseDown(dx0, dy0);
+        slate._onMouseDrag(dx0 + 20, dy0 + 15);
+        slate._onMouseUp(dx0 + 20, dy0 + 15);
+
+        // Pivot unchanged.
+        almostEqual(C.x, cInitX, 0.001);
+        almostEqual(C.y, cInitY, 0.001);
+        // A rotated.
+        assert.ok(Math.hypot(A.x - aInitX, A.y - aInitY) > 0.5,
+            `A should have rotated; stayed at (${A.x},${A.y})`);
     });
 
     it("should restore all slider initial positions when slate.reset() is called", () => {
@@ -691,6 +719,99 @@ describe("slate", ()=> {
         almostEqual(x.x, xInit[0], 0.001);
         almostEqual(x.y, xInit[1], 0.001);
         almostEqual(x.z, xInit[2], 0.001);
+    });
+
+    // Slate.createElement error paths.
+    it("createElement should throw TypeError when a param is not a string or number", () => {
+        let slate = new Slate(createCanvas(100, 100));
+        slate.createElement(E.Point.free, [10, 10], "A");
+        // Mixed-in boolean hits convertParams' default case (line 188).
+        assert.throws(
+            () => slate.createElement(E.Point.midpoint, ["A", true as any], "X"),
+            TypeError);
+    });
+
+    it("createElement should throw a descriptive TypeError when no construction matches", () => {
+        let slate = new Slate(createCanvas(100, 100));
+        // Pass no params — no Midpoint construction takes zero points, so
+        // findConstruction returns null. With name omitted, the error path
+        // at createElement exercises the name-is-null fallback (lines 209-210).
+        assert.throws(
+            () => slate.createElement(E.Point.midpoint, []),
+            /Construction not found/);
+    });
+
+    // Colors.ts residual gaps — darken alias and parseRGB's hex + fallback
+    // branches (only reached via brighter/darker, not parseColor).
+    it("darken() should delegate to darker() for a given color", () => {
+        assert.equal(darken("rgb(200,100,50)"), darker("rgb(200,100,50)"));
+    });
+
+    it("brighter() should accept a 6-digit hex string via parseRGB", () => {
+        // "ff8040" → rgb(255,128,64). brighter(...) recomputes per component
+        // and produces a valid rgb() result (exact values don't matter — we
+        // just need the hex branch of parseRGB to fire).
+        let out = brighter("ff8040");
+        assert.ok(/^rgb\(\d+,\d+,\d+\)$/.test(out),
+            `brighter('ff8040') should return an rgb() string, got '${out}'`);
+    });
+
+    it("brighter() should return the input unchanged when it's unparseable", () => {
+        // parseRGB returns null → brighter returns col unchanged, hitting
+        // the fallback branch (line 144-145).
+        assert.equal(brighter("not-a-color"), "not-a-color");
+    });
+
+    // point;perpendicular has five signatures. Variant 5 (3 points + plane)
+    // is already covered by scene3d's "Pperp". These two tests cover the
+    // remaining uncovered variants.
+    it("E.Point.perpendicular with 4 points (no plane) should construct variant 3", () => {
+        let slate = buildScene3d();
+        let g = slate.createElement(
+            E.Point.perpendicular, ["A","B","C","origin"], "FP3");
+        assert.ok(g instanceof PointElement);
+    });
+
+    it("E.Point.perpendicular with 4 points + plane should construct variant 4", () => {
+        let slate = buildScene3d();
+        let g = slate.createElement(
+            E.Point.perpendicular, ["A","B","xyplane","C","origin"], "FP4");
+        assert.ok(g instanceof PointElement);
+    });
+
+    it("PolyhedronElement.drawVertex should render face vertices when vertexColor is set", () => {
+        let slate = buildSpecializedScene();
+        let pep = slate.lookupElement("pep");  // parallelepiped
+        assert.ok(pep != null, "parallelepiped should exist");
+        pep.vertexColor = "black";
+        // Should iterate every face and call drawVertex on each vertex
+        // without throwing.
+        pep.drawVertex(createCanvas(300, 300) as any);
+    });
+
+    // CircleElement._drawCircle has a degenerate branch for edge-on
+    // rendering (minor axis < 0.5 px) that our snapshot suite never
+    // triggers. Hand-craft a CircleElement with a tilted AP to exercise it.
+    it("CircleElement.drawEdge should handle an edge-on circle without throwing", () => {
+        let canvas = createCanvas(100, 100);
+        let center = new PointElement({x: 50, y: 50, z: 0});
+        let B      = new PointElement({x: 51, y: 50, z: 0});   // radius = 1
+
+        // A plane whose S.z² + T.z² ≈ 0.99 → factor = sqrt(1-amp2) ≈ 0.1,
+        // minorR ≈ 0.1 * 1 = 0.1 (< 0.5) → takes the degenerate branch.
+        let plane = new PlaneElement({
+            A: new PointElement({x: 0, y: 0, z: 0}),
+            B: new PointElement({x: 1, y: 0, z: 0}),
+            C: new PointElement({x: 0, y: 1, z: 0}),
+        });
+        plane.S = new PointElement({x: 0.1, y: 0, z: 0.995});
+        plane.T = new PointElement({x: 0,   y: 1, z: 0});
+        plane.U = new PointElement({x: 1,   y: 0, z: 0});
+
+        let circle = new CircleElement({C: center, A: center, B: B, AP: plane});
+        circle.edgeColor = "black";
+        // Should not throw even though the ellipse degenerates to a line.
+        circle.drawEdge(canvas as any);
     });
 
     // Exercises src/index.ts init() — the public entry point. Snapshot
@@ -2067,8 +2188,6 @@ describe("slate", ()=> {
     });
 
 });
-
-import {parseColor, brighter, darker} from "../src/Colors";
 
 describe("parseColor", () => {
 

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -1,7 +1,7 @@
 import "mocha";
 import * as assert from "assert";
 import {Slate} from "../src/Slate";
-import {E, IConstructionInfo} from "../src/index";
+import {E, IConstructionInfo, init, slates} from "../src/index";
 import {PlaneSlider} from "../src/elements/point/PlaneSlider";
 import {Intersection} from "../src/elements/point/Intersection";
 import {PointElement} from "../src/elements/point/PointElement";
@@ -460,6 +460,203 @@ describe("slate", ()=> {
         almostEqual(A.y, aInitY + 15, 0.001);
         almostEqual(D.x, dInitX + 20, 0.001);
         almostEqual(D.y, dInitY + 15, 0.001);
+    });
+
+    // propXI11-style 3D scene: exercises FixedPoint, PerpendicularPlane,
+    // ParallelPlane, Perpendicular (point), LineSlider, PlaneSlider on a
+    // non-screen plane, and the 3D foot-of-perpendicular Foot element.
+    // A drag through translateCoordinates / rotateCoordinates invokes
+    // translate()/rotate() on every element type — the biggest lever
+    // for the 50%-function files in the coverage report.
+    let scene3d_data : IConstructionInfo[] = [
+        { name: "origin",  construction: E.Point.free,          params: [120, 160] },
+        { name: "x",       construction: E.Point.fixed,         params: [280, 160, 100] },
+        { name: "yzplane", construction: E.Plane.perpendicular, params: ["origin","x"] },
+        { name: "y",       construction: E.Point.planeSlider,   params: ["yzplane", -90, 260, 40] },
+        { name: "xyplane", construction: E.Plane.threePoints,   params: ["origin","x","y"] },
+        { name: "z1",      construction: E.Point.perpendicular, params: ["origin","y","yzplane"] },
+        { name: "z",       construction: E.Point.lineSlider,    params: ["origin","z1",50,50,100] },
+        { name: "Oz",      construction: E.Line.connect,        params: ["origin","z"] },
+        { name: "ceiling", construction: E.Plane.parallel,      params: ["xyplane","z"] },
+        { name: "A",       construction: E.Point.planeSlider,   params: ["ceiling", 140, 100, 180] },
+        { name: "B",       construction: E.Point.planeSlider,   params: ["xyplane", 208, 270, 140] },
+        { name: "C",       construction: E.Point.planeSlider,   params: ["xyplane", 245, 190, 80] },
+        { name: "BC",      construction: E.Line.connect,        params: ["B","C"] },
+        { name: "D",       construction: E.Point.foot,          params: ["A","BC"] },
+    ];
+
+    function buildScene3d(): Slate {
+        let slate = new Slate(createCanvas(330, 330));
+        toElements(slate, scene3d_data);
+        for (let e of slate.elements) {
+            if (e instanceof PointElement) e.vertexColor = "black";
+        }
+        slate.elements.forEach(e => e.update());
+        return slate;
+    }
+
+    it("should translate 3D plane elements when dragging a non-draggable point", () => {
+        let slate = buildScene3d();
+
+        let origin = slate.lookupElement("origin") as PointElement;
+        let x = slate.lookupElement("x") as PointElement;
+        let D = slate.lookupElement("D") as PointElement;
+        let A = slate.lookupElement("A") as PointElement;
+        let oInitX = origin.x, oInitY = origin.y;
+        let xInitX = x.x, xInitY = x.y;
+        let aInitX = A.x, aInitY = A.y;
+
+        // Drag D (Foot — non-draggable). No pivot → translateCoordinates.
+        // Slate derives the drag delta from the pick's actual position,
+        // not the rounded mouse-down coordinates, so compute the expected
+        // delta the same way.
+        let dInitX = D.x, dInitY = D.y;
+        let dx0 = Math.round(dInitX), dy0 = Math.round(dInitY);
+        let targetX = dx0 + 15, targetY = dy0 - 10;
+        let deltaX = targetX - dInitX;
+        let deltaY = targetY - dInitY;
+        slate._onMouseDown(dx0, dy0);
+        slate._onMouseDrag(targetX, targetY);
+        slate._onMouseUp(targetX, targetY);
+
+        // Every non-preexisting element shifts by exactly the drag delta.
+        // Exercises translate() on PlaneSlider, FixedPoint, Foot (via
+        // PointElement), and indirectly on PerpendicularPlane /
+        // ParallelPlane / PlaneElement through their constituent points.
+        almostEqual(origin.x, oInitX + deltaX, 0.001);
+        almostEqual(origin.y, oInitY + deltaY, 0.001);
+        almostEqual(x.x, xInitX + deltaX, 0.001);
+        almostEqual(x.y, xInitY + deltaY, 0.001);
+        almostEqual(A.x, aInitX + deltaX, 0.001);
+        almostEqual(A.y, aInitY + deltaY, 0.001);
+    });
+
+    it("should rotate 3D plane elements around a pivot on xyplane", () => {
+        let slate = buildScene3d();
+        slate.setPivot("origin,xyplane");
+
+        let origin = slate.lookupElement("origin") as PointElement;
+        let D = slate.lookupElement("D") as PointElement;
+        let A = slate.lookupElement("A") as PointElement;
+        let oInitX = origin.x, oInitY = origin.y;
+        let aInitX = A.x, aInitY = A.y;
+
+        // Drag D through rotateCoordinates on xyplane → every non-
+        // preexisting element rotates via its rotate() method.
+        let dx0 = Math.round(D.x), dy0 = Math.round(D.y);
+        slate._onMouseDown(dx0, dy0);
+        slate._onMouseDrag(dx0 + 20, dy0 + 12);
+        slate._onMouseUp(dx0 + 20, dy0 + 12);
+
+        // Pivot doesn't move.
+        almostEqual(origin.x, oInitX, 0.001);
+        almostEqual(origin.y, oInitY, 0.001);
+        // A (planeSlider on ceiling) rotated — exercises PerpendicularPlane,
+        // ParallelPlane, and PlaneSlider rotate paths through updates.
+        assert.ok(Math.hypot(A.x - aInitX, A.y - aInitY) > 0.5,
+            `A should have rotated; went from (${aInitX},${aInitY}) to (${A.x},${A.y})`);
+    });
+
+    // Grab-bag scene covering the construction types whose translate() /
+    // rotate() methods were the long tail in the coverage report:
+    // RegularPolygon, Application, InvertCircle, SphereIntersection,
+    // CircleSlider, SphereSlider, Sector, Prism, Parallelepiped.
+    let specialized_data : IConstructionInfo[] = [
+        { name: "A",    construction: E.Point.free,              params: [50, 50] },
+        { name: "B",    construction: E.Point.free,              params: [140, 50] },
+        { name: "C",    construction: E.Point.free,              params: [100, 140] },
+        { name: "D",    construction: E.Point.free,              params: [50, 180] },
+        { name: "c1",   construction: E.Circle.radius,           params: ["A","B"] },
+        { name: "c2",   construction: E.Circle.radius,           params: ["B","A"] },
+        { name: "P",    construction: E.Point.circleSlider,      params: ["c1", 120, 30] },
+        { name: "inv",  construction: E.Circle.invert,           params: ["c1","c2"] },
+        { name: "s1",   construction: E.Sphere.radius,           params: ["A","B"] },
+        { name: "s2",   construction: E.Sphere.radius,           params: ["B","A"] },
+        { name: "sInt", construction: E.Circle.intersection,     params: ["s1","s2"] },
+        { name: "Q",    construction: E.Point.sphereSlider,      params: ["s1", 90, 70, 50] },
+        { name: "reg",  construction: E.Polygon.regularPolygon,  params: ["A","B", 5] },
+        { name: "poly", construction: E.Polygon.triangle,        params: ["A","B","C"] },
+        { name: "app",  construction: E.Polygon.application,     params: ["poly", "A", "B", "C"] },
+        { name: "sec",  construction: E.Sector.sector,           params: ["A","B","C"] },
+        { name: "pep",  construction: E.Polyhedra.parallelepiped,params: ["A","B","C","D"] },
+        { name: "M",    construction: E.Point.midpoint,          params: ["A","B"] },  // pick target
+    ];
+
+    it("should translate specialized elements (RegularPolygon, Application, InvertCircle, etc.)", () => {
+        let slate = new Slate(createCanvas(300, 300));
+        toElements(slate, specialized_data);
+        for (let e of slate.elements) {
+            if (e instanceof PointElement) e.vertexColor = "black";
+        }
+        slate.elements.forEach(e => e.update());
+
+        let A = slate.lookupElement("A") as PointElement;
+        let M = slate.lookupElement("M") as PointElement;
+        let aInitX = A.x, aInitY = A.y;
+        let mInitX = M.x, mInitY = M.y;
+
+        // Drag M (midpoint — non-draggable) → translateCoordinates fires,
+        // calling translate() on every non-preexisting element. That
+        // exercises the translate paths on RegularPolygonElement,
+        // ApplicationElement, InvertCircleElement, SphereIntersectionElement,
+        // CircleSlider, SphereSliderElement, SectorElement, PrismElement.
+        let dx0 = Math.round(mInitX), dy0 = Math.round(mInitY);
+        let targetX = dx0 + 25, targetY = dy0 + 15;
+        let deltaX = targetX - mInitX;
+        let deltaY = targetY - mInitY;
+        slate._onMouseDown(dx0, dy0);
+        slate._onMouseDrag(targetX, targetY);
+        slate._onMouseUp(targetX, targetY);
+
+        almostEqual(A.x, aInitX + deltaX, 0.001);
+        almostEqual(A.y, aInitY + deltaY, 0.001);
+    });
+
+    // Exercises src/index.ts init() — the public entry point. Snapshot
+    // tests use buildScene() directly; unit tests construct Slate without
+    // going through init(). This stubs the DOM lookup init() needs.
+    it("init() should build a slate from an IInitialization config", () => {
+        let canvas: any = createCanvas(250, 250);
+        canvas.clientWidth = 250;
+        canvas.clientHeight = 250;
+        canvas.parentElement = null;  // skip createControls — no DOM tree
+
+        let savedDoc = (global as any).document;
+        (global as any).document = {
+            getElementById: (id: string) => id === "myCanvas" ? canvas : null,
+        };
+
+        try {
+            let before = slates.length;
+            init({
+                background: "35,19,100",
+                title: "init-test",
+                canvasid: "myCanvas",
+                elements: [
+                    // Mix of string (parseParam path) and object form.
+                    "A;point;free;60,60",
+                    { name: "B", construction: E.Point.free, params: [180, 60] },
+                    { name: "C", construction: E.Point.free, params: [120, 180] },
+                    "circABC;circle;circumcircle;A,B,C",
+                    { name: "F", construction: E.Point.center, params: ["circABC"] },
+                ],
+                pivot: "F",
+            });
+
+            assert.equal(slates.length, before + 1,
+                "init() should have pushed one slate onto geomlib.slates");
+            let slate = slates[slates.length - 1];
+            let A = slate.lookupElement("A") as PointElement;
+            assert.ok(A instanceof PlaneSlider, "A should be a PlaneSlider");
+            almostEqual(A.x, 60, 0.001);
+            almostEqual(A.y, 60, 0.001);
+            // Pivot applied: screen.pivot must be F.
+            let F = slate.lookupElement("F") as PointElement;
+            assert.ok(F != null, "F should be constructed");
+        } finally {
+            if (savedDoc === undefined) delete (global as any).document;
+            else (global as any).document = savedDoc;
+        }
     });
 
     // Book I, Prop 12 — chord of circle cut by a line

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -382,6 +382,86 @@ describe("slate", ()=> {
         almostEqual(B.x, 120, 0.001); almostEqual(B.y, 200, 0.001);
     });
 
+    // propIV5a-style scene: triangle ABC with circumcenter F.
+    // Dragging a non-draggable point (midpoint D) exercises
+    // Slate.movePick's rotate branch (when a pivot is set) and its
+    // translate branch (when no pivot is set), and propagates
+    // rotate()/translate() onto every element type in the scene.
+    let pivotScene_data : IConstructionInfo[] = [
+        { name: "A",       construction: E.Point.free,         params: [140, 40] },
+        { name: "B",       construction: E.Point.free,         params: [50, 180] },
+        { name: "C",       construction: E.Point.free,         params: [200, 180] },
+        { name: "circABC", construction: E.Circle.circumcircle,params: ["A","B","C"] },
+        { name: "triABC",  construction: E.Polygon.triangle,   params: ["A","B","C"] },
+        { name: "D",       construction: E.Point.midpoint,     params: ["A","B"] },
+        { name: "F",       construction: E.Point.center,       params: ["circABC"] },
+        { name: "AF",      construction: E.Line.connect,       params: ["A","F"] },
+    ];
+
+    it("should rotate non-pivot elements around F when dragging a derived point", () => {
+        let slate = new Slate(createCanvas(250, 250));
+        toElements(slate, pivotScene_data);
+        // Picks use closestVisiblePoint which filters on vertexColor;
+        // buildScene sets this in the snapshot path — do it here too.
+        for (let e of slate.elements) {
+            if (e instanceof PointElement) e.vertexColor = "black";
+        }
+        slate.elements.forEach(e => e.update());
+        slate.setPivot("F");
+
+        let A = slate.lookupElement("A") as PointElement;
+        let D = slate.lookupElement("D") as PointElement;
+        let F = slate.lookupElement("F") as PointElement;
+        let fInitX = F.x, fInitY = F.y;
+        let aInitX = A.x, aInitY = A.y;
+
+        // Drag D (non-draggable midpoint) → movePick falls through to
+        // rotateCoordinates because screen.pivot == F and the pick != F.
+        let dx0 = Math.round(D.x), dy0 = Math.round(D.y);
+        slate._onMouseDown(dx0, dy0);
+        slate._onMouseDrag(dx0 + 20, dy0 + 15);
+        slate._onMouseUp(dx0 + 20, dy0 + 15);
+
+        // Pivot itself doesn't rotate.
+        almostEqual(F.x, fInitX, 0.001);
+        almostEqual(F.y, fInitY, 0.001);
+        // rotateCoordinates solves for (ac, as) so the dragged point lands
+        // exactly at the drag target.
+        almostEqual(D.x, dx0 + 20, 0.5);
+        almostEqual(D.y, dy0 + 15, 0.5);
+        // A rotated visibly (non-preexisting, gets rotated around F).
+        assert.ok(Math.hypot(A.x - aInitX, A.y - aInitY) > 1,
+            `A should have moved; went from (${aInitX},${aInitY}) to (${A.x},${A.y})`);
+    });
+
+    it("should translate every non-preexisting element when dragging with no pivot", () => {
+        let slate = new Slate(createCanvas(250, 250));
+        toElements(slate, pivotScene_data);
+        // Picks use closestVisiblePoint which filters on vertexColor;
+        // buildScene sets this in the snapshot path — do it here too.
+        for (let e of slate.elements) {
+            if (e instanceof PointElement) e.vertexColor = "black";
+        }
+        slate.elements.forEach(e => e.update());
+        // No setPivot call — the drag branch becomes translateCoordinates.
+
+        let A = slate.lookupElement("A") as PointElement;
+        let D = slate.lookupElement("D") as PointElement;
+        let aInitX = A.x, aInitY = A.y;
+        let dInitX = D.x, dInitY = D.y;
+
+        let dx0 = Math.round(D.x), dy0 = Math.round(D.y);
+        slate._onMouseDown(dx0, dy0);
+        slate._onMouseDrag(dx0 + 20, dy0 + 15);
+        slate._onMouseUp(dx0 + 20, dy0 + 15);
+
+        // Every non-preexisting element shifts by exactly the drag delta.
+        almostEqual(A.x, aInitX + 20, 0.001);
+        almostEqual(A.y, aInitY + 15, 0.001);
+        almostEqual(D.x, dInitX + 20, 0.001);
+        almostEqual(D.y, dInitY + 15, 0.001);
+    });
+
     // Book I, Prop 12 — chord of circle cut by a line
     // <param name=e[1]  value="A;point;free;30,180">
     // <param name=e[2]  value="B;point;free;290,180">

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -3,729 +3,75 @@ import * as assert from "assert";
 import {Slate} from "../src/Slate";
 import {E, IConstructionInfo, init, slates} from "../src/index";
 import {PlaneSlider} from "../src/elements/point/PlaneSlider";
-import {Intersection} from "../src/elements/point/Intersection";
 import {PointElement} from "../src/elements/point/PointElement";
-import {CircleSlider} from "../src/elements/point/CircleSlider";
-import {PlaneElement} from "../src/elements/plane/PlaneElement";
-import {LineElement} from "../src/elements/line/LineElement";
-import {CircumcircleElement} from "../src/elements/circle/CircumcircleElement";
-import {SphereElement} from "../src/elements/sphere/SphereElement";
-import {ArcElement} from "../src/elements/sector/ArcElement";
-import {Chord} from "../src/elements/line/Chord";
-import {PolygonElement} from "../src/elements/polygon/PolygonElement";
-import {ApplicationElement} from "../src/elements/polygon/ApplicationElement";
-import {SimilarElement} from "../src/elements/point/SimilarElement";
-import {CircleElement} from "../src/elements/circle/CircleElement";
-import {HarmonicElement} from "../src/elements/point/HarmonicElement";
-import {parseColor, brighter, darker, darken} from "../src/Colors";
 import {createCanvas} from "canvas";
-import {create} from "domain";
+import {almostEqual, toElements} from "./shared/testHelpers";
+import {
+    buildPivotScene,
+    buildScene3d,
+    buildSpecializedScene,
+} from "./shared/dragScenes";
 
-let almostEqual = function (actual : number, expected : number, precision: number) {
-    return assert.equal(Math.abs(actual-expected) < precision, true, 
-                        "expected: " + expected + " actual: " + actual + " tolerance: " + precision);
-}
+describe("slate", () => {
 
-describe("slate", ()=> {
-
-    function toElements(slate : Slate, data : IConstructionInfo[]) {
-        return data.map(
-            cld => slate.createElement(cld.construction, cld.params, cld.name)
-        );
-    }
-
-    it("should create a free point as a PlaneSlider", () => {
-        let slate : Slate = new Slate(createCanvas(200,200));
-        let e = slate.createElement(E.Point.free, [100,100], "A");
-        assert.ok(e == slate.elements[slate.elements.length-1])
-        assert.ok(e instanceof PlaneSlider);
-        let ps : PlaneSlider = e as PlaneSlider;
-        assert.ok(e.name == "A");
-        assert.ok(ps.distance(new PointElement({x:100,y:100})) <= 0.001);
-    });
-    
-    let connected_line_data : IConstructionInfo[] = [
-        { construction: E.Point.free,   name: "A",  params: [10,100]},
-        { construction: E.Point.free,   name: "B",  params: [100,100]},
-        { construction: E.Line.connect, name: "AB", params: ["A","B"]},
+    let connected_line_data: IConstructionInfo[] = [
+        { construction: E.Point.free,   name: "A",  params: [10, 100] },
+        { construction: E.Point.free,   name: "B",  params: [100, 100] },
+        { construction: E.Line.connect, name: "AB", params: ["A", "B"] },
     ];
 
-    it("should create a connection as a LineElement", () => {
-        let slate : Slate = new Slate(createCanvas(200,200));
-        let elms = toElements(slate, connected_line_data);
-        let p1 = elms[0] as PointElement;
-        let p2 = elms[1] as PointElement;
-        let l1 = elms[2] as LineElement;
-        assert.ok(p1 == l1.A);
-        assert.ok(p2 == l1.B);
-    });
-    
-    // Book XI, Def 24
-    let perpendicular_plane_data : IConstructionInfo[] = [
-        { construction: E.Point.free,   name: "origin",  params: [70,220]},
-        { construction: E.Point.fixed,  name: "z",  params: [70,80,100]},
-        { construction: E.Plane.perpendicular, name: "xyplane", params: ["origin","z"]},
-    ];
-    
-    it("should create a perpendicular plane", () => {
-        let slate : Slate = new Slate(createCanvas(200,200));
-        let elms = toElements(slate, perpendicular_plane_data);
-        let p1 = elms[0] as PlaneElement;
-        p1.update();
-    });
-
-    // Book I, Def I11
-    let circle_slider_midpoint_data : IConstructionInfo[] = [
-        /*<param name=e[1] value="A;point;free;40,110">
-        <param name=e[2] value="C;point;free;210,110">
-        <param name=e[3] value="AC;line;connect;A,C">
-        <param name=e[4] value="B;point;lineSlider;AC,100,110">
-        <param name=e[5] value="E;point;midpoint;B,C;0;0">
-        <param name=e[6] value="circ;circle;radius;E,C;0;0;0;0">
-        <param name=e[7] value="D;point;circleSlider;circ,140,40">*/
-        { construction: E.Point.free, name: "A", params: [40, 110]},
-        { construction: E.Point.free, name: "C", params: [210, 110]},
-        { construction: E.Line.connect, name: "AC", params: ["A", "C"]},
-        { construction: E.Point.lineSlider, name: "B", params: ["AC", 100, 110]},
-        { construction: E.Point.midpoint, name: "E", params: ["B", "C"]},
-        { construction: E.Circle.radius, name: "circ", params: ["E", "C"]},
-        { construction: E.Point.circleSlider, name: "D", params: ["circ", 140, 40]}
-    ];
-
-    it("should create a circle, circle slider, and midpoint", () => {
-        let slate : Slate = new Slate(createCanvas(200, 200));
-        let elms = toElements(slate, circle_slider_midpoint_data);
-        slate.elements.forEach(e => e.update());
-        let p7 = elms[6] as CircleSlider;
-        almostEqual(p7.x, 143, 1);
-        almostEqual(p7.y, 56, 1);
-    });
-
-    // Book I, Def I2
-    let intersection_data : IConstructionInfo[] = [
-        /* 
-        <param name=e[1] value="A;point;free;40,170;0">
-        <param name=e[2] value="B;point;free;110,100;0">
-        <param name=e[3] value="C;point;free;190,100;0">
-        <param name=e[4] value="D;point;free;280,50;0">
-        <param name=e[5] value="BC;line;connect;B,C">
-        <param name=e[6] value="E';point;perpendicular;B,C;0;0">
-        <param name=e[7] value="M;point;midpoint;A,B;0;0">
-        <param name=e[8] value="E'';point;perpendicular;M,B;0;0">
-        <param name=e[9] value="E;point;intersection;B,E',M,E'';0;0"> */
-        { construction: E.Point.free, name: "A", params: [40, 70]},
-        { construction: E.Point.free, name: "B", params: [110, 100]},
-        { construction: E.Point.free, name: "C", params: [190,100]},
-        { construction: E.Point.free, name: "D", params: [280,50]},
-        { construction: E.Line.connect, name: "BC", params: ["B", "C"]},
-        { construction: E.Point.perpendicular, name: "E'", params: ["B", "C"]},
-        { construction: E.Point.midpoint, name: "M", params: ["A", "B"]},
-        { construction: E.Point.perpendicular, name: "E''", params: ["M", "B"]},
-        { construction: E.Point.intersection, name: "E", params: ["B", "E'", "M", "E''"]},
-    ]
-
-    it("should create an intersection element", () => {
-        let slate : Slate = new Slate(createCanvas(200, 200));
-        let elms = toElements(slate, intersection_data);
-        slate.elements.forEach(e => e.update());
-        let p8 = elms[8] as Intersection;
-        almostEqual(p8.x, 110, 1);
-        almostEqual(p8.y, 3, 1);
-    });
-
-
-    let circle_center_circumcircle_data : IConstructionInfo[] = [
-    /*
-    <img src=propIII10.gif alt="java applet or image">
-    <param name=background value="35,19,100">
-    <param name=title value="III.10">
-    <param name=e[1] value="B;point;free;150,40">
-    <param name=e[2] value="F;point;free;150,260">
-    <param name=e[3] value="H;point;free;40,180">
-    <param name=e[4] value="ABC;circle;circumcircle;B,F,H;0;0;black;random">
-    <param name=e[5] value="P;point;center;ABC;black;green">
-    */
-        { construction: E.Point.free, name: "B", params: [150, 40]},
-        { construction: E.Point.free, name: "F", params: [110, 100]},
-        { construction: E.Point.free, name: "H", params: [190,100]},
-        { construction: E.Circle.circumcircle, name: "ABC", params: ["B","F","H"]},
-        { construction: E.Point.center, name: "P", params: ["ABC"]},
-    ]
-
-    it("should create a circumcircle and center elements", () => {
-        let slate : Slate = new Slate(createCanvas(200, 200));
-        let elms = toElements(slate, circle_center_circumcircle_data);
-        slate.elements.forEach(e => e.update());
-        let p3 = elms[3] as CircumcircleElement;
-        let p4 = elms[4] as PointElement;
-        assert.equal(p3.Center, p4);
-        almostEqual(p4.x, 150, 1);
-        almostEqual(p4.y, 83, 1);
-    });
-
-
-    let circumcenter_data : IConstructionInfo[] = [
-    /*
-        <img src=propIII25a.gif alt="java applet or image">
-        <param name=background value="35,19,100">
-        <param name=title value="III.25a">
-        <param name=e[1] value="A;point;free;60,30">
-        <param name=e[2] value="C;point;free;60,200">
-        <param name=e[3] value="AC;line;connect;A,C">
-        <param name=e[4] value="D;point;midpoint;AC">
-        <param name=e[5] value="DB;line;perpendicular;D,A;0;0;0">
-        <param name=e[6] value="B;point;lineSlider;DB,30,115">
-        <param name=e[7] value="E;point;circumcenter;A,B,C;black;green">
-    */
-        { construction: E.Point.free, name: "A", params: [60, 30]},
-        { construction: E.Point.free, name: "C", params: [60, 200]},
-        { construction: E.Line.connect, name: "AC", params: ["A", "C"]},
-        { construction: E.Point.midpoint, name: "D", params: ["AC"]},
-        { construction: E.Line.perpendicular, name: "DB", params: ["D", "A"]},
-        { construction: E.Point.lineSlider, name: "B", params: ["DB", 30, 115]},
-        { construction: E.Point.circumcenter, name: "E", params: ["A", "B", "C"]},
-    ]
-
-    it("should create a circumcenter and line perpendiular element", () => {
-        let slate : Slate = new Slate(createCanvas(200, 200));
-        let elms = toElements(slate, circumcenter_data);
-        slate.elements.forEach(e => e.update());
-        // circumcenter pushes two elements on the update list
-        // the circumcircle as one, and the circumcenter as the other
-        let elmsUpdate = slate.elementsForUpdate;
-        let n = elmsUpdate.length;
-        let pcircle = elmsUpdate[n-2] as CircumcircleElement;
-        let pcenter = elmsUpdate[n-1] as PointElement;
-        assert.equal(pcircle.Center, pcenter);
-        almostEqual(pcenter.x, 165, 1);
-        almostEqual(pcenter.y, 115, 1);
-    });
-
-    let sphere_data : IConstructionInfo[] = [
-    /*
-        <img src="propXII17.gif" alt="java applet or image">
-        <param name=background value="35,19,100">
-        <param name=title value="XII.17">
-        <param name=fontsize value=14>
-        <param name=e[1] value="zen;point;fixed;250,-10000,5000;0;0">
-        <param name=e[2] value="A;point;free;250,250">
-        <param name=e[3] value="eqplane;plane;perpendicular;A,zen;0;0;0;0">
-        <param name=e[4] value="B;point;planeSlider;eqplane,450,360,60">
-        <param name=e[5] value="Bsphere;sphere;radius;A,B;0;0;black;random">
-    */
-        { construction: E.Point.free, name: "A", params: [60, 30]},
-        { construction: E.Point.free, name: "B", params: [60, 200]},
-        { construction: E.Sphere.radius, name: "Asphere", params: ["A", "B"]},
-    ]
-
-    it("should create a sphere", () => {
-        let slate : Slate = new Slate(createCanvas(200, 200));
-        let elms = toElements(slate, sphere_data);
-        slate.elements.forEach(e => e.update());
-        let elmsUpdate = slate.elementsForUpdate;
-        let pcenter = elmsUpdate[2] as SphereElement;
-        /*assert.equal(pcircle.Center, pcenter);
-        almostEqual(pcenter.x, 165, 1);
-        almostEqual(pcenter.y, 115, 1);*/
-    });
-    
     it("should facilitate updates", () => {
-        let slate : Slate = new Slate(createCanvas(200,200));
-        let elms = toElements(slate, connected_line_data);
+        let slate: Slate = new Slate(createCanvas(200, 200));
+        toElements(slate, connected_line_data);
         slate.elements.forEach(e => e.update());
     });
 
     it("should translate coordinates", () => {
-        let slate : Slate = new Slate(createCanvas(200,200));
+        let slate: Slate = new Slate(createCanvas(200, 200));
         slate.inTest = true;
-        let elms = toElements(slate, connected_line_data);
-        slate.translateCoordinates(1,0);
+        toElements(slate, connected_line_data);
+        slate.translateCoordinates(1, 0);
         let A = slate.lookupElement("A") as PointElement;
         let B = slate.lookupElement("B") as PointElement;
-        let AB = slate.lookupElement("AB") as LineElement;
         assert.equal(A.x, 11);
         assert.equal(A.y, 100);
         assert.equal(B.x, 101);
         assert.equal(B.y, 100);
     });
 
-    it("should return the nth vertex of a triangle", () => {
-        const data: IConstructionInfo[] = [
-            { name: "A", construction: E.Point.free, params: [100, 50] },
-            { name: "B", construction: E.Point.free, params: [50, 200] },
-            { name: "C", construction: E.Point.free, params: [250, 200] },
-            { name: "T", construction: E.Polygon.triangle, params: ["A", "B", "C"] },
-            { name: "V1", construction: E.Point.vertex, params: ["T", 1] },
-            { name: "V2", construction: E.Point.vertex, params: ["T", 2] },
-            { name: "V3", construction: E.Point.vertex, params: ["T", 3] },
-        ];
-        let slate = new Slate(createCanvas(400, 300));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let V1 = slate.lookupElement("V1") as PointElement;
-        let V2 = slate.lookupElement("V2") as PointElement;
-        let V3 = slate.lookupElement("V3") as PointElement;
-        almostEqual(V1.x, 100, 1); almostEqual(V1.y, 50, 1);
-        almostEqual(V2.x, 50, 1);  almostEqual(V2.y, 200, 1);
-        almostEqual(V3.x, 250, 1); almostEqual(V3.y, 200, 1);
-    });
-
-    it("should compute the 4th vertex of a parallelogram", () => {
-        // propI28: A(40,80), B(190,80), C(40,120) → D' = C + (B-A) = (190,120)
-        const data: IConstructionInfo[] = [
-            { name: "A",  construction: E.Point.free,          params: [40, 80] },
-            { name: "B",  construction: E.Point.free,          params: [190, 80] },
-            { name: "C",  construction: E.Point.free,          params: [40, 120] },
-            { name: "D'", construction: E.Point.parallelogram, params: ["C", "A", "B"] },
-        ];
-        const slate = new Slate(createCanvas(400, 300));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        const D = slate.lookupElement("D'") as PointElement;
-        almostEqual(D.x, 190, 1);
-        almostEqual(D.y, 120, 1);
-    });
-
-    it("should produce an equilateral triangle", () => {
-        const data: IConstructionInfo[] = [
-            { name: "A",   construction: E.Point.free,               params: [40, 170] },
-            { name: "B",   construction: E.Point.free,               params: [200, 170] },
-            { name: "ABC", construction: E.Polygon.equilateralTriangle, params: ["A", "B"] },
-            { name: "C",   construction: E.Point.vertex,             params: ["ABC", 3] },
-        ];
-        const slate = new Slate(createCanvas(400, 300));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        const A = slate.lookupElement("A") as PointElement;
-        const B = slate.lookupElement("B") as PointElement;
-        const C = slate.lookupElement("C") as PointElement;
-        // All three sides must be equal length (equilateral)
-        const ab = Math.hypot(B.x - A.x, B.y - A.y);
-        const ac = Math.hypot(C.x - A.x, C.y - A.y);
-        const bc = Math.hypot(C.x - B.x, C.y - B.y);
-        almostEqual(ac, ab, 1);
-        almostEqual(bc, ab, 1);
-        // Apex should be above the base (smaller y in screen coordinates)
-        assert.ok(C.y < A.y);
-    });
-
-    // Book III, Prop 2 — arc through three points
-    // <param name=e[1] value="A;point;free;50,130">
-    // <param name=e[2] value="B;point;free;120,200">
-    // <param name=e[6] value="E;point;free;70,210">
-    // <param name=e[7] value="AEB;sector;arc;A,E,B">
-    //
-    // The arc's internal _Center should be the circumcenter of A, E, B.
-    // Hand-computed:
-    //   u=-14800, v=-2700, den=-4200
-    //   cx = -364000 / -4200 ≈ 86.667
-    //   cy = -686000 / -4200 ≈ 163.333
-    //   r  = |Center-A| = sqrt(1344.5 + 1111.1) ≈ 49.554
-    let arc_propIII2_data : IConstructionInfo[] = [
-        { name: "A",   construction: E.Point.free,  params: [50, 130] },
-        { name: "E",   construction: E.Point.free,  params: [70, 210] },
-        { name: "B",   construction: E.Point.free,  params: [120, 200] },
-        { name: "AEB", construction: E.Sector.arc, params: ["A", "E", "B"] },
-    ];
-
-    it("should compute the circumcenter of an arc through three points", () => {
-        let slate = new Slate(createCanvas(260, 260));
-        toElements(slate, arc_propIII2_data);
-        slate.elements.forEach(e => e.update());
-        let arc = slate.lookupElement("AEB") as ArcElement;
-        almostEqual(arc._Center.x, 86.667, 0.01);
-        almostEqual(arc._Center.y, 163.333, 0.01);
-        // All three given points should be equidistant from the center
-        let rA = arc._Center.distance(arc._A);
-        let rM = arc._Center.distance(arc._M);
-        let rB = arc._Center.distance(arc._B);
-        almostEqual(rA, 49.554, 0.01);
-        almostEqual(rM, 49.554, 0.01);
-        almostEqual(rB, 49.554, 0.01);
-    });
-
-    it("should translate only the arc center, leaving A, M, B untouched", () => {
-        let slate = new Slate(createCanvas(260, 260));
-        toElements(slate, arc_propIII2_data);
-        slate.elements.forEach(e => e.update());
-        let arc = slate.lookupElement("AEB") as ArcElement;
-        let cx0 = arc._Center.x;
-        let cy0 = arc._Center.y;
-        arc.translate(5, 7);
-        almostEqual(arc._Center.x, cx0 + 5, 0.001);
-        almostEqual(arc._Center.y, cy0 + 7, 0.001);
-        // A, M, B are independent slate elements; arc.translate() must not touch them
+    it("should be able to find the closest visible point within a tolerance", () => {
+        let slate: Slate = new Slate(createCanvas(200, 200));
+        toElements(slate, connected_line_data);
         let A = slate.lookupElement("A") as PointElement;
-        let M = slate.lookupElement("E") as PointElement;
         let B = slate.lookupElement("B") as PointElement;
-        almostEqual(A.x, 50,  0.001); almostEqual(A.y, 130, 0.001);
-        almostEqual(M.x, 70,  0.001); almostEqual(M.y, 210, 0.001);
-        almostEqual(B.x, 120, 0.001); almostEqual(B.y, 200, 0.001);
-    });
+        A.vertexColor = "red";
+        B.vertexColor = "red";
 
-    it("should rotate only the arc center around a pivot", () => {
-        let slate = new Slate(createCanvas(260, 260));
-        toElements(slate, arc_propIII2_data);
-        slate.elements.forEach(e => e.update());
-        let arc = slate.lookupElement("AEB") as ArcElement;
-        let A = slate.lookupElement("A") as PointElement;
-        // 90° CCW rotation around A=(50,130): ac=cos(90°)=0, as=sin(90°)=1
-        // dx=36.667, dy=33.333
-        // new x = 50 + 0*36.667 - 1*33.333 = 16.667
-        // new y = 130 + 1*36.667 + 0*33.333 = 166.667
-        arc.rotate(A, 0, 1);
-        almostEqual(arc._Center.x, 16.667, 0.01);
-        almostEqual(arc._Center.y, 166.667, 0.01);
-        // A, M, B untouched
-        let M = slate.lookupElement("E") as PointElement;
-        let B = slate.lookupElement("B") as PointElement;
-        almostEqual(A.x, 50,  0.001); almostEqual(A.y, 130, 0.001);
-        almostEqual(M.x, 70,  0.001); almostEqual(M.y, 210, 0.001);
-        almostEqual(B.x, 120, 0.001); almostEqual(B.y, 200, 0.001);
-    });
+        let P = slate.closestVisiblePoint(slate.elements,
+            new PointElement({x: (10 + 100) / 2 - 1, y: 100}), 100);
+        assert(P.name == "A");
+        P = slate.closestVisiblePoint(slate.elements,
+            new PointElement({x: (10 + 100) / 2 + 1, y: 100}), 100);
+        assert(P.name == "B");
 
-    // propIV5a-style scene: triangle ABC with circumcenter F.
-    // Dragging a non-draggable point (midpoint D) exercises
-    // Slate.movePick's rotate branch (when a pivot is set) and its
-    // translate branch (when no pivot is set), and propagates
-    // rotate()/translate() onto every element type in the scene.
-    let pivotScene_data : IConstructionInfo[] = [
-        { name: "A",       construction: E.Point.free,         params: [140, 40] },
-        { name: "B",       construction: E.Point.free,         params: [50, 180] },
-        { name: "C",       construction: E.Point.free,         params: [200, 180] },
-        { name: "circABC", construction: E.Circle.circumcircle,params: ["A","B","C"] },
-        { name: "triABC",  construction: E.Polygon.triangle,   params: ["A","B","C"] },
-        { name: "D",       construction: E.Point.midpoint,     params: ["A","B"] },
-        { name: "F",       construction: E.Point.center,       params: ["circABC"] },
-        { name: "AF",      construction: E.Line.connect,       params: ["A","F"] },
-    ];
+        P = slate.closestVisiblePoint(slate.elements,
+            new PointElement({x: (10 + 100) / 2 - 1, y: 100}), 10);
+        assert(P == null);
 
-    it("should rotate non-pivot elements around F when dragging a derived point", () => {
-        let slate = new Slate(createCanvas(250, 250));
-        toElements(slate, pivotScene_data);
-        // Picks use closestVisiblePoint which filters on vertexColor;
-        // buildScene sets this in the snapshot path — do it here too.
-        for (let e of slate.elements) {
-            if (e instanceof PointElement) e.vertexColor = "black";
-        }
-        slate.elements.forEach(e => e.update());
-        slate.setPivot("F");
+        P = slate.closestVisiblePoint(slate.elements,
+            new PointElement({x: 89, y: 100}), 10);
+        assert(P == null);
 
-        let A = slate.lookupElement("A") as PointElement;
-        let D = slate.lookupElement("D") as PointElement;
-        let F = slate.lookupElement("F") as PointElement;
-        let fInitX = F.x, fInitY = F.y;
-        let aInitX = A.x, aInitY = A.y;
-
-        // Drag D (non-draggable midpoint) → movePick falls through to
-        // rotateCoordinates because screen.pivot == F and the pick != F.
-        let dx0 = Math.round(D.x), dy0 = Math.round(D.y);
-        slate._onMouseDown(dx0, dy0);
-        slate._onMouseDrag(dx0 + 20, dy0 + 15);
-        slate._onMouseUp(dx0 + 20, dy0 + 15);
-
-        // Pivot itself doesn't rotate.
-        almostEqual(F.x, fInitX, 0.001);
-        almostEqual(F.y, fInitY, 0.001);
-        // rotateCoordinates solves for (ac, as) so the dragged point lands
-        // exactly at the drag target.
-        almostEqual(D.x, dx0 + 20, 0.5);
-        almostEqual(D.y, dy0 + 15, 0.5);
-        // A rotated visibly (non-preexisting, gets rotated around F).
-        assert.ok(Math.hypot(A.x - aInitX, A.y - aInitY) > 1,
-            `A should have moved; went from (${aInitX},${aInitY}) to (${A.x},${A.y})`);
-    });
-
-    it("should translate every non-preexisting element when dragging with no pivot", () => {
-        let slate = new Slate(createCanvas(250, 250));
-        toElements(slate, pivotScene_data);
-        // Picks use closestVisiblePoint which filters on vertexColor;
-        // buildScene sets this in the snapshot path — do it here too.
-        for (let e of slate.elements) {
-            if (e instanceof PointElement) e.vertexColor = "black";
-        }
-        slate.elements.forEach(e => e.update());
-        // No setPivot call — the drag branch becomes translateCoordinates.
-
-        let A = slate.lookupElement("A") as PointElement;
-        let D = slate.lookupElement("D") as PointElement;
-        let aInitX = A.x, aInitY = A.y;
-        let dInitX = D.x, dInitY = D.y;
-
-        let dx0 = Math.round(D.x), dy0 = Math.round(D.y);
-        slate._onMouseDown(dx0, dy0);
-        slate._onMouseDrag(dx0 + 20, dy0 + 15);
-        slate._onMouseUp(dx0 + 20, dy0 + 15);
-
-        // Every non-preexisting element shifts by exactly the drag delta.
-        almostEqual(A.x, aInitX + 20, 0.001);
-        almostEqual(A.y, aInitY + 15, 0.001);
-        almostEqual(D.x, dInitX + 20, 0.001);
-        almostEqual(D.y, dInitY + 15, 0.001);
-    });
-
-    // propXI11-style 3D scene: exercises FixedPoint, PerpendicularPlane,
-    // ParallelPlane, Perpendicular (point), LineSlider, PlaneSlider on a
-    // non-screen plane, and the 3D foot-of-perpendicular Foot element.
-    // A drag through translateCoordinates / rotateCoordinates invokes
-    // translate()/rotate() on every element type — the biggest lever
-    // for the 50%-function files in the coverage report.
-    let scene3d_data : IConstructionInfo[] = [
-        { name: "origin",  construction: E.Point.free,          params: [120, 160] },
-        { name: "x",       construction: E.Point.fixed,         params: [280, 160, 100] },
-        { name: "yzplane", construction: E.Plane.perpendicular, params: ["origin","x"] },
-        { name: "y",       construction: E.Point.planeSlider,   params: ["yzplane", -90, 260, 40] },
-        { name: "xyplane", construction: E.Plane.threePoints,   params: ["origin","x","y"] },
-        { name: "z1",      construction: E.Point.perpendicular, params: ["origin","y","yzplane"] },
-        { name: "z",       construction: E.Point.lineSlider,    params: ["origin","z1",50,50,100] },
-        { name: "Oz",      construction: E.Line.connect,        params: ["origin","z"] },
-        { name: "ceiling", construction: E.Plane.parallel,      params: ["xyplane","z"] },
-        { name: "A",       construction: E.Point.planeSlider,   params: ["ceiling", 140, 100, 180] },
-        { name: "B",       construction: E.Point.planeSlider,   params: ["xyplane", 208, 270, 140] },
-        { name: "C",       construction: E.Point.planeSlider,   params: ["xyplane", 245, 190, 80] },
-        { name: "BC",      construction: E.Line.connect,        params: ["B","C"] },
-        { name: "D",       construction: E.Point.foot,          params: ["A","BC"] },
-        // point;perpendicular variant 5: point A, plane P, points C, D
-        // constructs a PlanePerpendicularLine internally — the line
-        // perpendicular to xyplane through B, with length |BC|.
-        { name: "Pperp",   construction: E.Point.perpendicular, params: ["B","xyplane","B","C"] },
-    ];
-
-    function buildScene3d(): Slate {
-        let slate = new Slate(createCanvas(330, 330));
-        toElements(slate, scene3d_data);
-        for (let e of slate.elements) {
-            if (e instanceof PointElement) e.vertexColor = "black";
-        }
-        slate.elements.forEach(e => e.update());
-        return slate;
-    }
-
-    it("should translate 3D plane elements when dragging a non-draggable point", () => {
-        let slate = buildScene3d();
-
-        let origin = slate.lookupElement("origin") as PointElement;
-        let x = slate.lookupElement("x") as PointElement;
-        let D = slate.lookupElement("D") as PointElement;
-        let A = slate.lookupElement("A") as PointElement;
-        let oInitX = origin.x, oInitY = origin.y;
-        let xInitX = x.x, xInitY = x.y;
-        let aInitX = A.x, aInitY = A.y;
-
-        // Drag D (Foot — non-draggable). No pivot → translateCoordinates.
-        // Slate derives the drag delta from the pick's actual position,
-        // not the rounded mouse-down coordinates, so compute the expected
-        // delta the same way.
-        let dInitX = D.x, dInitY = D.y;
-        let dx0 = Math.round(dInitX), dy0 = Math.round(dInitY);
-        let targetX = dx0 + 15, targetY = dy0 - 10;
-        let deltaX = targetX - dInitX;
-        let deltaY = targetY - dInitY;
-        slate._onMouseDown(dx0, dy0);
-        slate._onMouseDrag(targetX, targetY);
-        slate._onMouseUp(targetX, targetY);
-
-        // Every non-preexisting element shifts by exactly the drag delta.
-        // Exercises translate() on PlaneSlider, FixedPoint, Foot (via
-        // PointElement), and indirectly on PerpendicularPlane /
-        // ParallelPlane / PlaneElement through their constituent points.
-        almostEqual(origin.x, oInitX + deltaX, 0.001);
-        almostEqual(origin.y, oInitY + deltaY, 0.001);
-        almostEqual(x.x, xInitX + deltaX, 0.001);
-        almostEqual(x.y, xInitY + deltaY, 0.001);
-        almostEqual(A.x, aInitX + deltaX, 0.001);
-        almostEqual(A.y, aInitY + deltaY, 0.001);
-    });
-
-    it("should rotate 3D plane elements around a pivot on xyplane", () => {
-        let slate = buildScene3d();
-        slate.setPivot("origin,xyplane");
-
-        let origin = slate.lookupElement("origin") as PointElement;
-        let D = slate.lookupElement("D") as PointElement;
-        let A = slate.lookupElement("A") as PointElement;
-        let oInitX = origin.x, oInitY = origin.y;
-        let aInitX = A.x, aInitY = A.y;
-
-        // Drag D through rotateCoordinates on xyplane → every non-
-        // preexisting element rotates via its rotate() method.
-        let dx0 = Math.round(D.x), dy0 = Math.round(D.y);
-        slate._onMouseDown(dx0, dy0);
-        slate._onMouseDrag(dx0 + 20, dy0 + 12);
-        slate._onMouseUp(dx0 + 20, dy0 + 12);
-
-        // Pivot doesn't move.
-        almostEqual(origin.x, oInitX, 0.001);
-        almostEqual(origin.y, oInitY, 0.001);
-        // A (planeSlider on ceiling) rotated — exercises PerpendicularPlane,
-        // ParallelPlane, and PlaneSlider rotate paths through updates.
-        assert.ok(Math.hypot(A.x - aInitX, A.y - aInitY) > 0.5,
-            `A should have rotated; went from (${aInitX},${aInitY}) to (${A.x},${A.y})`);
-    });
-
-    // Grab-bag scene covering the construction types whose translate() /
-    // rotate() methods were the long tail in the coverage report:
-    // RegularPolygon, Application, InvertCircle, SphereIntersection,
-    // CircleSlider, SphereSlider, Sector, Prism, Parallelepiped.
-    let specialized_data : IConstructionInfo[] = [
-        { name: "A",    construction: E.Point.free,              params: [50, 50] },
-        { name: "B",    construction: E.Point.free,              params: [140, 50] },
-        { name: "C",    construction: E.Point.free,              params: [100, 140] },
-        { name: "D",    construction: E.Point.free,              params: [50, 180] },
-        { name: "c1",   construction: E.Circle.radius,           params: ["A","B"] },
-        { name: "c2",   construction: E.Circle.radius,           params: ["B","A"] },
-        { name: "bich", construction: E.Line.bichord,            params: ["c1","c2"] },
-        { name: "P",    construction: E.Point.circleSlider,      params: ["c1", 120, 30] },
-        { name: "inv",  construction: E.Circle.invert,           params: ["c1","c2"] },
-        { name: "s1",   construction: E.Sphere.radius,           params: ["A","B"] },
-        { name: "s2",   construction: E.Sphere.radius,           params: ["B","A"] },
-        { name: "sInt", construction: E.Circle.intersection,     params: ["s1","s2"] },
-        { name: "Q",    construction: E.Point.sphereSlider,      params: ["s1", 90, 70, 50] },
-        { name: "reg",  construction: E.Polygon.regularPolygon,  params: ["A","B", 5] },
-        { name: "poly", construction: E.Polygon.triangle,        params: ["A","B","C"] },
-        { name: "app",  construction: E.Polygon.application,     params: ["poly", "A", "B", "C"] },
-        { name: "sec",  construction: E.Sector.sector,           params: ["A","B","C"] },
-        { name: "pep",  construction: E.Polyhedra.parallelepiped,params: ["A","B","C","D"] },
-        { name: "M",    construction: E.Point.midpoint,          params: ["A","B"] },  // pick target
-    ];
-
-    function buildSpecializedScene(): Slate {
-        let slate = new Slate(createCanvas(300, 300));
-        toElements(slate, specialized_data);
-        for (let e of slate.elements) {
-            if (e instanceof PointElement) e.vertexColor = "black";
-        }
-        slate.elements.forEach(e => e.update());
-        return slate;
-    }
-
-    it("should translate specialized elements (RegularPolygon, Application, InvertCircle, etc.)", () => {
-        let slate = buildSpecializedScene();
-
-        let A = slate.lookupElement("A") as PointElement;
-        let M = slate.lookupElement("M") as PointElement;
-        let aInitX = A.x, aInitY = A.y;
-        let mInitX = M.x, mInitY = M.y;
-
-        // Drag M (midpoint — non-draggable) → translateCoordinates fires,
-        // calling translate() on every non-preexisting element. That
-        // exercises the translate paths on RegularPolygonElement,
-        // ApplicationElement, InvertCircleElement, SphereIntersectionElement,
-        // CircleSlider, SphereSliderElement, SectorElement, PrismElement.
-        let dx0 = Math.round(mInitX), dy0 = Math.round(mInitY);
-        let targetX = dx0 + 25, targetY = dy0 + 15;
-        let deltaX = targetX - mInitX;
-        let deltaY = targetY - mInitY;
-        slate._onMouseDown(dx0, dy0);
-        slate._onMouseDrag(targetX, targetY);
-        slate._onMouseUp(targetX, targetY);
-
-        almostEqual(A.x, aInitX + deltaX, 0.001);
-        almostEqual(A.y, aInitY + deltaY, 0.001);
-    });
-
-    it("should rotate specialized elements around a pivot", () => {
-        let slate = buildSpecializedScene();
-        // Pivot on C → dragging M (midpoint of A,B) rotates every non-
-        // preexisting element, including the InvertCircle, Sector, Prism,
-        // and Parallelepiped's rotate() methods.
-        slate.setPivot("C");
-
-        let M = slate.lookupElement("M") as PointElement;
-        let A = slate.lookupElement("A") as PointElement;
-        let C = slate.lookupElement("C") as PointElement;
-        let aInitX = A.x, aInitY = A.y;
-        let cInitX = C.x, cInitY = C.y;
-
-        let dx0 = Math.round(M.x), dy0 = Math.round(M.y);
-        slate._onMouseDown(dx0, dy0);
-        slate._onMouseDrag(dx0 + 20, dy0 + 15);
-        slate._onMouseUp(dx0 + 20, dy0 + 15);
-
-        // Pivot unchanged.
-        almostEqual(C.x, cInitX, 0.001);
-        almostEqual(C.y, cInitY, 0.001);
-        // A rotated.
-        assert.ok(Math.hypot(A.x - aInitX, A.y - aInitY) > 0.5,
-            `A should have rotated; stayed at (${A.x},${A.y})`);
-    });
-
-    it("should restore all slider initial positions when slate.reset() is called", () => {
-        let slate = buildSpecializedScene();
-
-        // Snapshot initial positions of each slider type.
-        let A    = slate.lookupElement("A") as PointElement;   // PlaneSlider
-        let P    = slate.lookupElement("P") as PointElement;   // CircleSlider
-        let Q    = slate.lookupElement("Q") as PointElement;   // SphereSlider
-        let inits = new Map<PointElement, [number,number,number]>();
-        for (let p of [A, P, Q]) inits.set(p, [p.x, p.y, p.z]);
-
-        // Translate everything, then reset — every slider's reset() runs.
-        let M = slate.lookupElement("M") as PointElement;
-        slate._onMouseDown(Math.round(M.x), Math.round(M.y));
-        slate._onMouseDrag(Math.round(M.x) + 25, Math.round(M.y) + 15);
-        slate._onMouseUp(Math.round(M.x) + 25, Math.round(M.y) + 15);
-
-        // Sanity: A actually moved.
-        let [ax, ay] = inits.get(A)!;
-        assert.ok(A.x !== ax || A.y !== ay, "A should have moved before reset");
-
-        slate.reset();
-
-        for (let [p, [x, y, z]] of inits) {
-            almostEqual(p.x, x, 0.01);
-            almostEqual(p.y, y, 0.01);
-            almostEqual(p.z, z, 0.01);
-        }
-    });
-
-    it("should compute the harmonic conjugate in the 3D branch when any z != 0", () => {
-        // The 2D branch is hit when B.z === C.z === D.z === 0; lines 46-59.
-        // Lines 61-72 are the 3D branch — exercised as soon as any point
-        // has a non-zero z. Picks three collinear points on z=5.
-        let B = new PointElement({x: 10, y: 10, z: 5});
-        let C = new PointElement({x: 30, y: 10, z: 5});
-        let D = new PointElement({x: 50, y: 10, z: 5});
-        let H = new HarmonicElement(B, C, D);
-        H.update();
-
-        // Harmonic conjugate of B w.r.t. collinear C,D satisfies
-        // cross-ratio (A,B;C,D) = -1 → A = (B*C + B*D - 2*C*D) / (2B - C - D)
-        // along the line. With B=10, C=30, D=50: A = (10*30 + 10*50 - 2*30*50) / (20 - 30 - 50)
-        //                                          = (300 + 500 - 3000) / -60
-        //                                          = -2200 / -60 = 36.667
-        // (Same line → same y, same z.)
-        almostEqual(H.x, 110 / 3, 0.01);
-        almostEqual(H.y, 10, 0.01);
-        almostEqual(H.z, 5, 0.01);
-    });
-
-    it("should also restore the FixedPoint from the 3D scene on reset", () => {
-        let slate = buildScene3d();
-        let x = slate.lookupElement("x") as PointElement;   // FixedPoint
-        let xInit: [number,number,number] = [x.x, x.y, x.z];
-
-        // Translate then reset.
-        let D = slate.lookupElement("D") as PointElement;
-        slate._onMouseDown(Math.round(D.x), Math.round(D.y));
-        slate._onMouseDrag(Math.round(D.x) + 15, Math.round(D.y) - 10);
-        slate._onMouseUp(Math.round(D.x) + 15, Math.round(D.y) - 10);
-
-        assert.ok(x.x !== xInit[0] || x.y !== xInit[1],
-            "FixedPoint should have translated before reset");
-
-        slate.reset();
-
-        almostEqual(x.x, xInit[0], 0.001);
-        almostEqual(x.y, xInit[1], 0.001);
-        almostEqual(x.z, xInit[2], 0.001);
+        P = slate.closestVisiblePoint(slate.elements,
+            new PointElement({x: 91, y: 100}), 10);
+        assert(P.name == "B");
     });
 
     // Slate.createElement error paths.
     it("createElement should throw TypeError when a param is not a string or number", () => {
         let slate = new Slate(createCanvas(100, 100));
         slate.createElement(E.Point.free, [10, 10], "A");
-        // Mixed-in boolean hits convertParams' default case (line 188).
+        // Mixed-in boolean hits convertParams' default case.
         assert.throws(
             () => slate.createElement(E.Point.midpoint, ["A", true as any], "X"),
             TypeError);
@@ -733,90 +79,206 @@ describe("slate", ()=> {
 
     it("createElement should throw a descriptive TypeError when no construction matches", () => {
         let slate = new Slate(createCanvas(100, 100));
-        // Pass no params — no Midpoint construction takes zero points, so
-        // findConstruction returns null. With name omitted, the error path
-        // at createElement exercises the name-is-null fallback (lines 209-210).
+        // No construction takes zero points → findConstruction returns null.
+        // Omitting name exercises the name-is-null fallback.
         assert.throws(
             () => slate.createElement(E.Point.midpoint, []),
             /Construction not found/);
     });
 
-    // Colors.ts residual gaps — darken alias and parseRGB's hex + fallback
-    // branches (only reached via brighter/darker, not parseColor).
-    it("darken() should delegate to darker() for a given color", () => {
-        assert.equal(darken("rgb(200,100,50)"), darker("rgb(200,100,50)"));
-    });
+    describe("drag coordinates: 2D pivot scene", () => {
 
-    it("brighter() should accept a 6-digit hex string via parseRGB", () => {
-        // "ff8040" → rgb(255,128,64). brighter(...) recomputes per component
-        // and produces a valid rgb() result (exact values don't matter — we
-        // just need the hex branch of parseRGB to fire).
-        let out = brighter("ff8040");
-        assert.ok(/^rgb\(\d+,\d+,\d+\)$/.test(out),
-            `brighter('ff8040') should return an rgb() string, got '${out}'`);
-    });
+        it("should rotate non-pivot elements around F when dragging a derived point", () => {
+            let slate = buildPivotScene();
+            slate.setPivot("F");
 
-    it("brighter() should return the input unchanged when it's unparseable", () => {
-        // parseRGB returns null → brighter returns col unchanged, hitting
-        // the fallback branch (line 144-145).
-        assert.equal(brighter("not-a-color"), "not-a-color");
-    });
+            let A = slate.lookupElement("A") as PointElement;
+            let D = slate.lookupElement("D") as PointElement;
+            let F = slate.lookupElement("F") as PointElement;
+            let fInitX = F.x, fInitY = F.y;
+            let aInitX = A.x, aInitY = A.y;
 
-    // point;perpendicular has five signatures. Variant 5 (3 points + plane)
-    // is already covered by scene3d's "Pperp". These two tests cover the
-    // remaining uncovered variants.
-    it("E.Point.perpendicular with 4 points (no plane) should construct variant 3", () => {
-        let slate = buildScene3d();
-        let g = slate.createElement(
-            E.Point.perpendicular, ["A","B","C","origin"], "FP3");
-        assert.ok(g instanceof PointElement);
-    });
+            let dx0 = Math.round(D.x), dy0 = Math.round(D.y);
+            slate._onMouseDown(dx0, dy0);
+            slate._onMouseDrag(dx0 + 20, dy0 + 15);
+            slate._onMouseUp(dx0 + 20, dy0 + 15);
 
-    it("E.Point.perpendicular with 4 points + plane should construct variant 4", () => {
-        let slate = buildScene3d();
-        let g = slate.createElement(
-            E.Point.perpendicular, ["A","B","xyplane","C","origin"], "FP4");
-        assert.ok(g instanceof PointElement);
-    });
-
-    it("PolyhedronElement.drawVertex should render face vertices when vertexColor is set", () => {
-        let slate = buildSpecializedScene();
-        let pep = slate.lookupElement("pep");  // parallelepiped
-        assert.ok(pep != null, "parallelepiped should exist");
-        pep.vertexColor = "black";
-        // Should iterate every face and call drawVertex on each vertex
-        // without throwing.
-        pep.drawVertex(createCanvas(300, 300) as any);
-    });
-
-    // CircleElement._drawCircle has a degenerate branch for edge-on
-    // rendering (minor axis < 0.5 px) that our snapshot suite never
-    // triggers. Hand-craft a CircleElement with a tilted AP to exercise it.
-    it("CircleElement.drawEdge should handle an edge-on circle without throwing", () => {
-        let canvas = createCanvas(100, 100);
-        let center = new PointElement({x: 50, y: 50, z: 0});
-        let B      = new PointElement({x: 51, y: 50, z: 0});   // radius = 1
-
-        // A plane whose S.z² + T.z² ≈ 0.99 → factor = sqrt(1-amp2) ≈ 0.1,
-        // minorR ≈ 0.1 * 1 = 0.1 (< 0.5) → takes the degenerate branch.
-        let plane = new PlaneElement({
-            A: new PointElement({x: 0, y: 0, z: 0}),
-            B: new PointElement({x: 1, y: 0, z: 0}),
-            C: new PointElement({x: 0, y: 1, z: 0}),
+            almostEqual(F.x, fInitX, 0.001);
+            almostEqual(F.y, fInitY, 0.001);
+            almostEqual(D.x, dx0 + 20, 0.5);
+            almostEqual(D.y, dy0 + 15, 0.5);
+            assert.ok(Math.hypot(A.x - aInitX, A.y - aInitY) > 1,
+                `A should have moved; went from (${aInitX},${aInitY}) to (${A.x},${A.y})`);
         });
-        plane.S = new PointElement({x: 0.1, y: 0, z: 0.995});
-        plane.T = new PointElement({x: 0,   y: 1, z: 0});
-        plane.U = new PointElement({x: 1,   y: 0, z: 0});
 
-        let circle = new CircleElement({C: center, A: center, B: B, AP: plane});
-        circle.edgeColor = "black";
-        // Should not throw even though the ellipse degenerates to a line.
-        circle.drawEdge(canvas as any);
+        it("should translate every non-preexisting element when dragging with no pivot", () => {
+            let slate = buildPivotScene();
+            // No setPivot → the drag branch becomes translateCoordinates.
+
+            let A = slate.lookupElement("A") as PointElement;
+            let D = slate.lookupElement("D") as PointElement;
+            let aInitX = A.x, aInitY = A.y;
+            let dInitX = D.x, dInitY = D.y;
+
+            let dx0 = Math.round(D.x), dy0 = Math.round(D.y);
+            slate._onMouseDown(dx0, dy0);
+            slate._onMouseDrag(dx0 + 20, dy0 + 15);
+            slate._onMouseUp(dx0 + 20, dy0 + 15);
+
+            almostEqual(A.x, aInitX + 20, 0.001);
+            almostEqual(A.y, aInitY + 15, 0.001);
+            almostEqual(D.x, dInitX + 20, 0.001);
+            almostEqual(D.y, dInitY + 15, 0.001);
+        });
+    });
+
+    describe("drag coordinates: 3D plane scene", () => {
+
+        it("should translate 3D plane elements when dragging a non-draggable point", () => {
+            let slate = buildScene3d();
+
+            let origin = slate.lookupElement("origin") as PointElement;
+            let x = slate.lookupElement("x") as PointElement;
+            let D = slate.lookupElement("D") as PointElement;
+            let A = slate.lookupElement("A") as PointElement;
+            let oInitX = origin.x, oInitY = origin.y;
+            let xInitX = x.x, xInitY = x.y;
+            let aInitX = A.x, aInitY = A.y;
+
+            // Slate derives the drag delta from the pick's actual position,
+            // not the rounded mouse-down coords — compute delta the same way.
+            let dInitX = D.x, dInitY = D.y;
+            let dx0 = Math.round(dInitX), dy0 = Math.round(dInitY);
+            let targetX = dx0 + 15, targetY = dy0 - 10;
+            let deltaX = targetX - dInitX;
+            let deltaY = targetY - dInitY;
+            slate._onMouseDown(dx0, dy0);
+            slate._onMouseDrag(targetX, targetY);
+            slate._onMouseUp(targetX, targetY);
+
+            almostEqual(origin.x, oInitX + deltaX, 0.001);
+            almostEqual(origin.y, oInitY + deltaY, 0.001);
+            almostEqual(x.x, xInitX + deltaX, 0.001);
+            almostEqual(x.y, xInitY + deltaY, 0.001);
+            almostEqual(A.x, aInitX + deltaX, 0.001);
+            almostEqual(A.y, aInitY + deltaY, 0.001);
+        });
+
+        it("should rotate 3D plane elements around a pivot on xyplane", () => {
+            let slate = buildScene3d();
+            slate.setPivot("origin,xyplane");
+
+            let origin = slate.lookupElement("origin") as PointElement;
+            let D = slate.lookupElement("D") as PointElement;
+            let A = slate.lookupElement("A") as PointElement;
+            let oInitX = origin.x, oInitY = origin.y;
+            let aInitX = A.x, aInitY = A.y;
+
+            let dx0 = Math.round(D.x), dy0 = Math.round(D.y);
+            slate._onMouseDown(dx0, dy0);
+            slate._onMouseDrag(dx0 + 20, dy0 + 12);
+            slate._onMouseUp(dx0 + 20, dy0 + 12);
+
+            almostEqual(origin.x, oInitX, 0.001);
+            almostEqual(origin.y, oInitY, 0.001);
+            assert.ok(Math.hypot(A.x - aInitX, A.y - aInitY) > 0.5,
+                `A should have rotated; went from (${aInitX},${aInitY}) to (${A.x},${A.y})`);
+        });
+
+        it("should also restore the FixedPoint from the 3D scene on reset", () => {
+            let slate = buildScene3d();
+            let x = slate.lookupElement("x") as PointElement;
+            let xInit: [number, number, number] = [x.x, x.y, x.z];
+
+            let D = slate.lookupElement("D") as PointElement;
+            slate._onMouseDown(Math.round(D.x), Math.round(D.y));
+            slate._onMouseDrag(Math.round(D.x) + 15, Math.round(D.y) - 10);
+            slate._onMouseUp(Math.round(D.x) + 15, Math.round(D.y) - 10);
+
+            assert.ok(x.x !== xInit[0] || x.y !== xInit[1],
+                "FixedPoint should have translated before reset");
+
+            slate.reset();
+
+            almostEqual(x.x, xInit[0], 0.001);
+            almostEqual(x.y, xInit[1], 0.001);
+            almostEqual(x.z, xInit[2], 0.001);
+        });
+    });
+
+    describe("drag coordinates: specialized scene", () => {
+
+        it("should translate specialized elements (RegularPolygon, Application, InvertCircle, etc.)", () => {
+            let slate = buildSpecializedScene();
+
+            let A = slate.lookupElement("A") as PointElement;
+            let M = slate.lookupElement("M") as PointElement;
+            let aInitX = A.x, aInitY = A.y;
+            let mInitX = M.x, mInitY = M.y;
+
+            let dx0 = Math.round(mInitX), dy0 = Math.round(mInitY);
+            let targetX = dx0 + 25, targetY = dy0 + 15;
+            let deltaX = targetX - mInitX;
+            let deltaY = targetY - mInitY;
+            slate._onMouseDown(dx0, dy0);
+            slate._onMouseDrag(targetX, targetY);
+            slate._onMouseUp(targetX, targetY);
+
+            almostEqual(A.x, aInitX + deltaX, 0.001);
+            almostEqual(A.y, aInitY + deltaY, 0.001);
+        });
+
+        it("should rotate specialized elements around a pivot", () => {
+            let slate = buildSpecializedScene();
+            slate.setPivot("C");
+
+            let M = slate.lookupElement("M") as PointElement;
+            let A = slate.lookupElement("A") as PointElement;
+            let C = slate.lookupElement("C") as PointElement;
+            let aInitX = A.x, aInitY = A.y;
+            let cInitX = C.x, cInitY = C.y;
+
+            let dx0 = Math.round(M.x), dy0 = Math.round(M.y);
+            slate._onMouseDown(dx0, dy0);
+            slate._onMouseDrag(dx0 + 20, dy0 + 15);
+            slate._onMouseUp(dx0 + 20, dy0 + 15);
+
+            almostEqual(C.x, cInitX, 0.001);
+            almostEqual(C.y, cInitY, 0.001);
+            assert.ok(Math.hypot(A.x - aInitX, A.y - aInitY) > 0.5,
+                `A should have rotated; stayed at (${A.x},${A.y})`);
+        });
+
+        it("should restore all slider initial positions when slate.reset() is called", () => {
+            let slate = buildSpecializedScene();
+
+            let A = slate.lookupElement("A") as PointElement;   // PlaneSlider
+            let P = slate.lookupElement("P") as PointElement;   // CircleSlider
+            let Q = slate.lookupElement("Q") as PointElement;   // SphereSlider
+            let inits = new Map<PointElement, [number, number, number]>();
+            for (let p of [A, P, Q]) inits.set(p, [p.x, p.y, p.z]);
+
+            let M = slate.lookupElement("M") as PointElement;
+            slate._onMouseDown(Math.round(M.x), Math.round(M.y));
+            slate._onMouseDrag(Math.round(M.x) + 25, Math.round(M.y) + 15);
+            slate._onMouseUp(Math.round(M.x) + 25, Math.round(M.y) + 15);
+
+            let [ax, ay] = inits.get(A)!;
+            assert.ok(A.x !== ax || A.y !== ay, "A should have moved before reset");
+
+            slate.reset();
+
+            for (let [p, [x, y, z]] of inits) {
+                almostEqual(p.x, x, 0.01);
+                almostEqual(p.y, y, 0.01);
+                almostEqual(p.z, z, 0.01);
+            }
+        });
     });
 
     // Exercises src/index.ts init() — the public entry point. Snapshot
     // tests use buildScene() directly; unit tests construct Slate without
-    // going through init(). This stubs the DOM lookup init() needs.
+    // going through init(). Stubs the DOM lookup init() needs.
     it("init() should build a slate from an IInitialization config", () => {
         let canvas: any = createCanvas(250, 250);
         canvas.clientWidth = 250;
@@ -852,1597 +314,11 @@ describe("slate", ()=> {
             assert.ok(A instanceof PlaneSlider, "A should be a PlaneSlider");
             almostEqual(A.x, 60, 0.001);
             almostEqual(A.y, 60, 0.001);
-            // Pivot applied: screen.pivot must be F.
             let F = slate.lookupElement("F") as PointElement;
             assert.ok(F != null, "F should be constructed");
         } finally {
             if (savedDoc === undefined) delete (global as any).document;
             else (global as any).document = savedDoc;
         }
-    });
-
-    // Book I, Prop 12 — chord of circle cut by a line
-    // <param name=e[1]  value="A;point;free;30,180">
-    // <param name=e[2]  value="B;point;free;290,180">
-    // <param name=e[3]  value="AB;line;connect;A,B">
-    // <param name=e[4]  value="C;point;free;160,130">
-    // <param name=e[5]  value="D;point;free;180,220">
-    // <param name=e[6]  value="EFG;circle;radius;C,D">
-    // <param name=e[7]  value="EG;line;chord;AB,EFG">
-    //
-    // Hand-computed expectations (see doc/journal.md entry for line;chord):
-    //   radius² = 20² + 90² = 8500
-    //   foot of ⊥ from C=(160,130) to line y=180 is (160,180)
-    //   d² = 50² = 2500
-    //   s  = √(8500-2500) = √6000 ≈ 77.460
-    //   factor = s / D.distance(foot) = 77.460 / 130 ≈ 0.59585
-    //   chord.A = (D-foot)*factor + foot = (82.540, 180)
-    //   chord.B = 2*foot - chord.A         = (237.460, 180)
-    let chord_propI12_data : IConstructionInfo[] = [
-        { name: "A",   construction: E.Point.free,     params: [30, 180] },
-        { name: "B",   construction: E.Point.free,     params: [290, 180] },
-        { name: "AB",  construction: E.Line.connect,   params: ["A", "B"] },
-        { name: "C",   construction: E.Point.free,     params: [160, 130] },
-        { name: "D",   construction: E.Point.free,     params: [180, 220] },
-        { name: "EFG", construction: E.Circle.radius,  params: ["C", "D"] },
-        { name: "EG",  construction: E.Line.chord,     params: ["AB", "EFG"] },
-    ];
-
-    it("should compute the chord of a circle cut by a line", () => {
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, chord_propI12_data);
-        slate.elements.forEach(e => e.update());
-        let chord = slate.lookupElement("EG") as Chord;
-        almostEqual(chord.A.x,  82.540, 0.01);
-        almostEqual(chord.A.y, 180.000, 0.01);
-        almostEqual(chord.B.x, 237.460, 0.01);
-        almostEqual(chord.B.y, 180.000, 0.01);
-        // Both endpoints must lie on the circle
-        let center = slate.lookupElement("C") as PointElement;
-        let r = Math.sqrt(8500);
-        almostEqual(chord.A.distance(center), r, 0.001);
-        almostEqual(chord.B.distance(center), r, 0.001);
-    });
-
-    it("should NaN the chord when the line misses the circle entirely", () => {
-        // Shift C far above the line so the circle can't reach it.
-        let miss_data : IConstructionInfo[] = [
-            { name: "A",   construction: E.Point.free,    params: [30, 180] },
-            { name: "B",   construction: E.Point.free,    params: [290, 180] },
-            { name: "AB",  construction: E.Line.connect,  params: ["A", "B"] },
-            { name: "C",   construction: E.Point.free,    params: [160, 10] },  // far above y=180
-            { name: "D",   construction: E.Point.free,    params: [165, 20] },  // tiny circle
-            { name: "EFG", construction: E.Circle.radius, params: ["C", "D"] },
-            { name: "EG",  construction: E.Line.chord,    params: ["AB", "EFG"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, miss_data);
-        slate.elements.forEach(e => e.update());
-        let chord = slate.lookupElement("EG") as Chord;
-        assert.ok(isNaN(chord.A.x) && isNaN(chord.A.y));
-        assert.ok(isNaN(chord.B.x) && isNaN(chord.B.y));
-    });
-
-    it("should translate only the chord endpoints, leaving inputs untouched", () => {
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, chord_propI12_data);
-        slate.elements.forEach(e => e.update());
-        let chord = slate.lookupElement("EG") as Chord;
-        let ax0 = chord.A.x, ay0 = chord.A.y;
-        let bx0 = chord.B.x, by0 = chord.B.y;
-        chord.translate(5, 7);
-        almostEqual(chord.A.x, ax0 + 5, 0.001);
-        almostEqual(chord.A.y, ay0 + 7, 0.001);
-        almostEqual(chord.B.x, bx0 + 5, 0.001);
-        almostEqual(chord.B.y, by0 + 7, 0.001);
-        // Input free points must be untouched
-        let A = slate.lookupElement("A") as PointElement;
-        let B = slate.lookupElement("B") as PointElement;
-        let C = slate.lookupElement("C") as PointElement;
-        let D = slate.lookupElement("D") as PointElement;
-        almostEqual(A.x,  30, 0.001); almostEqual(A.y, 180, 0.001);
-        almostEqual(B.x, 290, 0.001); almostEqual(B.y, 180, 0.001);
-        almostEqual(C.x, 160, 0.001); almostEqual(C.y, 130, 0.001);
-        almostEqual(D.x, 180, 0.001); almostEqual(D.y, 220, 0.001);
-    });
-
-    it("should rotate only the chord endpoints around a pivot", () => {
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, chord_propI12_data);
-        slate.elements.forEach(e => e.update());
-        let chord = slate.lookupElement("EG") as Chord;
-        let A = slate.lookupElement("A") as PointElement;
-        // 90° CCW rotation around A=(30,180): ac=cos(90°)=0, as=sin(90°)=1
-        // chord.A (82.540, 180) → dx=52.540, dy=0
-        //   new x = 30 + 0*52.540 - 1*0        = 30
-        //   new y = 180 + 1*52.540 + 0*0       = 232.540
-        // chord.B (237.460, 180) → dx=207.460, dy=0
-        //   new x = 30 + 0*207.460 - 1*0       = 30
-        //   new y = 180 + 1*207.460 + 0*0      = 387.460
-        chord.rotate(A, 0, 1);
-        almostEqual(chord.A.x,  30.000, 0.01);
-        almostEqual(chord.A.y, 232.540, 0.01);
-        almostEqual(chord.B.x,  30.000, 0.01);
-        almostEqual(chord.B.y, 387.460, 0.01);
-        // Input free points untouched (A is the pivot; B, C, D must not move)
-        let B = slate.lookupElement("B") as PointElement;
-        let C = slate.lookupElement("C") as PointElement;
-        let D = slate.lookupElement("D") as PointElement;
-        almostEqual(A.x,  30, 0.001); almostEqual(A.y, 180, 0.001);
-        almostEqual(B.x, 290, 0.001); almostEqual(B.y, 180, 0.001);
-        almostEqual(C.x, 160, 0.001); almostEqual(C.y, 130, 0.001);
-        almostEqual(D.x, 180, 0.001); almostEqual(D.y, 220, 0.001);
-    });
-
-    // line;parallel — line through A parallel and equal to BC
-    // Slate.java case 9: Layoff(A, B, C, B, C) → D = A + (C-B), then LineElement(A, D)
-    //
-    // Test fixture: A=(50,100), B=(100,100), C=(200,200)
-    //   direction BC = (100, 100)
-    //   D = A + (C-B) = (50,100) + (100,100) = (150, 200)
-    //   resulting line: (50,100) → (150,200), parallel to BC, same length
-    let parallel_data : IConstructionInfo[] = [
-        { name: "A",  construction: E.Point.free,     params: [50, 100] },
-        { name: "B",  construction: E.Point.free,     params: [100, 100] },
-        { name: "C",  construction: E.Point.free,     params: [200, 200] },
-        { name: "AD", construction: E.Line.parallel,  params: ["A", "B", "C"] },
-    ];
-
-    // polygon;parallelogram — parallelogram CABD given 3 vertices C, A, B
-    // Slate.java case 6: Layoff(C, A, B, A, B) → D = C + (B-A), then
-    // PolygonElement([C, A, B, D])
-    //
-    // propI34: C=(50,175), A=(90,50), B=(250,50)
-    //   D = C + (B-A) = (50+160, 175+0) = (210, 175)
-    //   polygon vertices: [(50,175), (90,50), (250,50), (210,175)]
-    let pgram_propI34_data : IConstructionInfo[] = [
-        { name: "A",    construction: E.Point.free,              params: [90, 50] },
-        { name: "B",    construction: E.Point.free,              params: [250, 50] },
-        { name: "C",    construction: E.Point.free,              params: [50, 175] },
-        { name: "CABD", construction: E.Polygon.parallelogram,   params: ["C", "A", "B"] },
-        { name: "D",    construction: E.Point.vertex,            params: ["CABD", 4] },
-    ];
-
-    it("should compute a parallelogram with the 4th vertex via Layoff", () => {
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, pgram_propI34_data);
-        slate.elements.forEach(e => e.update());
-        let poly = slate.lookupElement("CABD") as PolygonElement;
-        // 4 vertices
-        assert.equal(poly.V.length, 4);
-        // V[0]=C, V[1]=A, V[2]=B, V[3]=D
-        almostEqual(poly.V[0].x,  50, 0.01); almostEqual(poly.V[0].y, 175, 0.01);
-        almostEqual(poly.V[1].x,  90, 0.01); almostEqual(poly.V[1].y,  50, 0.01);
-        almostEqual(poly.V[2].x, 250, 0.01); almostEqual(poly.V[2].y,  50, 0.01);
-        almostEqual(poly.V[3].x, 210, 0.01); almostEqual(poly.V[3].y, 175, 0.01);
-        // Opposite sides should be equal length (parallelogram property)
-        let CA = poly.V[0].distance(poly.V[1]);
-        let BD = poly.V[2].distance(poly.V[3]);
-        almostEqual(CA, BD, 0.001);
-        let AB = poly.V[1].distance(poly.V[2]);
-        let CD = poly.V[0].distance(poly.V[3]);
-        almostEqual(AB, CD, 0.001);
-    });
-
-    it("should extract the 4th vertex via point;vertex", () => {
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, pgram_propI34_data);
-        slate.elements.forEach(e => e.update());
-        let D = slate.lookupElement("D") as PointElement;
-        almostEqual(D.x, 210, 0.01);
-        almostEqual(D.y, 175, 0.01);
-    });
-
-    // point;similar — point C such that △ABC ∼ △DEF
-    // Similar.java: this.toSimilar(A, B, screen, D, E, F, screen)
-    //
-    // Test 1: isosceles right triangle DEF, factor=1
-    //   D=(0,0), E=(100,0), F=(0,100) → θ = π/2, factor = 100/100 = 1
-    //   A=(50,200), B=(150,200)
-    //   C = rotate B around A by π/2 then scale by 1 → (50, 300)
-    //
-    // Test 2: non-isosceles right triangle, factor=0.5
-    //   D=(0,0), E=(200,0), F=(0,100) → θ = π/2, factor = 100/200 = 0.5
-    //   A=(50,200), B=(150,200)
-    //   C = rotate B around A by π/2 then scale by 0.5 → (50, 250)
-
-    // point;proportion — point V' on V0V1 so that |S|:|T| = |U|:|V'|
-    // S=(0,0)→(100,0) len=100; T=(0,0)→(50,0) len=50;
-    // U=(0,0)→(80,0) len=80;  V=(0,0)→(200,0) len=200
-    // factor = sqrt(50²*80² / (100²*200²)) = 4000/20000 = 0.2
-    // result = (0,0) + 0.2 * (200,0) = (40, 0)
-    // Check: S:T = 100:50 = 2:1; U:V' = 80:40 = 2:1 ✓
-    // polygon;application — parallelogram with area = input polygon's area
-    // Input triangle P: (0,0),(100,0),(0,80) → area = 100*80/2 = 4000
-    // Side AB: A=(50,200), B=(150,200) → |AB| = 100
-    // Direction C: (50,100) → angle CAB points upward
-    // area(A,B,C) = area of triangle (50,200),(150,200),(50,100) = 100*100/2 = 5000
-    // factor = |P.area()| / (2 * |area(A,B,C)|) = 4000 / (2*5000) = 0.4
-    // V[3] = A + 0.4*(C-A) = (50,200) + 0.4*(0,-100) = (50, 160)
-    // V[2] = B + V[3] - A = (150,200) + (50,160) - (50,200) = (150, 160)
-    it("should create a parallelogram with the same area as the input polygon", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.free, params: [0, 0] },
-            { name: "P2", construction: E.Point.free, params: [100, 0] },
-            { name: "P3", construction: E.Point.free, params: [0, 80] },
-            { name: "P",  construction: E.Polygon.triangle, params: ["P1", "P2", "P3"] },
-            { name: "A",  construction: E.Point.free, params: [50, 200] },
-            { name: "B",  construction: E.Point.free, params: [150, 200] },
-            { name: "C",  construction: E.Point.free, params: [50, 100] },
-            { name: "ABEF", construction: E.Polygon.application, params: ["P", "A", "B", "C"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let app = slate.lookupElement("ABEF") as ApplicationElement;
-        assert.equal(app.V.length, 4);
-        // V[0]=A, V[1]=B
-        almostEqual(app.V[0].x,  50, 0.01); almostEqual(app.V[0].y, 200, 0.01);
-        almostEqual(app.V[1].x, 150, 0.01); almostEqual(app.V[1].y, 200, 0.01);
-        // V[3] = A + factor*(C-A) = (50, 160)
-        almostEqual(app.V[3].x,  50, 0.01); almostEqual(app.V[3].y, 160, 0.01);
-        // V[2] = B + V[3] - A = (150, 160)
-        almostEqual(app.V[2].x, 150, 0.01); almostEqual(app.V[2].y, 160, 0.01);
-        // The resulting parallelogram area should equal the input triangle area (4000)
-        almostEqual(app.area(), 4000, 1);
-    });
-
-    // point;meanProportional — point U' on U0U1 so that S:U' = U':T (geometric mean)
-    // S=(0,0)→(100,0) len=100; T=(0,0)→(25,0) len=25; U=(0,0)→(200,0) len=200
-    // |U'| = sqrt(|S|*|T|) = sqrt(100*25) = 50
-    // factor = 50/200 = 0.25; result = (0,0) + 0.25*(200,0) = (50, 0)
-    // Check: S:U' = 100:50 = 2:1; U':T = 50:25 = 2:1 ✓
-    it("should compute a mean proportional point (geometric mean)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "S0", construction: E.Point.free, params: [0, 0] },
-            { name: "S1", construction: E.Point.free, params: [100, 0] },
-            { name: "T0", construction: E.Point.free, params: [0, 0] },
-            { name: "T1", construction: E.Point.free, params: [25, 0] },
-            { name: "U0", construction: E.Point.free, params: [0, 0] },
-            { name: "U1", construction: E.Point.free, params: [200, 0] },
-            { name: "P",  construction: E.Point.meanProportional, params: ["S0","S1","T0","T1","U0","U1"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let P = slate.lookupElement("P") as PointElement;
-        almostEqual(P.x, 50, 0.01);
-        almostEqual(P.y,  0, 0.01);
-        // Verify the proportion: S:U' should equal U':T
-        let S = Math.sqrt(100*100);  // 100
-        let T = Math.sqrt(25*25);    // 25
-        let Up = P.distance(slate.lookupElement("U0") as PointElement); // 50
-        almostEqual(S / Up, Up / T, 0.001);
-    });
-
-    it("should compute a fourth proportional point", () => {
-        let data : IConstructionInfo[] = [
-            { name: "S0", construction: E.Point.free, params: [0, 0] },
-            { name: "S1", construction: E.Point.free, params: [100, 0] },
-            { name: "T0", construction: E.Point.free, params: [0, 0] },
-            { name: "T1", construction: E.Point.free, params: [50, 0] },
-            { name: "U0", construction: E.Point.free, params: [0, 0] },
-            { name: "U1", construction: E.Point.free, params: [80, 0] },
-            { name: "V0", construction: E.Point.free, params: [0, 0] },
-            { name: "V1", construction: E.Point.free, params: [200, 0] },
-            { name: "P",  construction: E.Point.proportion, params: ["S0","S1","T0","T1","U0","U1","V0","V1"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let P = slate.lookupElement("P") as PointElement;
-        almostEqual(P.x, 40, 0.01);
-        almostEqual(P.y,  0, 0.01);
-    });
-
-    // polygon;similar — triangle ABH where H is the similar point so △ABH ∼ △DEF
-    // propI23: A=(40,180), G=(cutoff result), C=(190,80), E=(270,180), D=(260,40)
-    // Simpler standalone: A=(50,200), B=(150,200), D=(0,0), E=(100,0), F=(0,100)
-    //   → H = (50,300) (same as point;similar test with factor=1)
-    //   → polygon vertices = [A, B, H] = [(50,200), (150,200), (50,300)]
-    it("should create a similar triangle polygon", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.free, params: [50, 200] },
-            { name: "B", construction: E.Point.free, params: [150, 200] },
-            { name: "D", construction: E.Point.free, params: [0, 0] },
-            { name: "E", construction: E.Point.free, params: [100, 0] },
-            { name: "F", construction: E.Point.free, params: [0, 100] },
-            { name: "ABH", construction: E.Polygon.similar, params: ["A", "B", "D", "E", "F"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let poly = slate.lookupElement("ABH") as PolygonElement;
-        assert.equal(poly.V.length, 3);
-        almostEqual(poly.V[0].x,  50, 0.01); almostEqual(poly.V[0].y, 200, 0.01);
-        almostEqual(poly.V[1].x, 150, 0.01); almostEqual(poly.V[1].y, 200, 0.01);
-        almostEqual(poly.V[2].x,  50, 0.01); almostEqual(poly.V[2].y, 300, 0.01);
-    });
-
-    // line;similar — line AH where H is the similar point
-    it("should create a similar line", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.free, params: [50, 200] },
-            { name: "B", construction: E.Point.free, params: [150, 200] },
-            { name: "D", construction: E.Point.free, params: [0, 0] },
-            { name: "E", construction: E.Point.free, params: [100, 0] },
-            { name: "F", construction: E.Point.free, params: [0, 100] },
-            { name: "AH", construction: E.Line.similar, params: ["A", "B", "D", "E", "F"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let line = slate.lookupElement("AH") as LineElement;
-        // Line starts at A
-        almostEqual(line.A.x,  50, 0.01); almostEqual(line.A.y, 200, 0.01);
-        // Line ends at H = similar point = (50, 300)
-        almostEqual(line.B.x,  50, 0.01); almostEqual(line.B.y, 300, 0.01);
-    });
-
-    // circle;radius 3-point — circle at Center with radius = |A-B| (not |Center-B|)
-    // propIII26: center H=(340,115), radius-points G=(120,115), A=(75,30)
-    //   radius = |GA| = sqrt(45^2 + 85^2) = sqrt(2025+7225) = sqrt(9250) ≈ 96.177
-    it("should create a circle with center H and radius |GA| (3-point form)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "G",   construction: E.Point.free,    params: [120, 115] },
-            { name: "A",   construction: E.Point.free,    params: [75, 30] },
-            { name: "H",   construction: E.Point.free,    params: [340, 115] },
-            { name: "DEF", construction: E.Circle.radius, params: ["H", "G", "A"] },
-        ];
-        let slate = new Slate(createCanvas(500, 300));
-        toElements(slate, data);
-        let circle = slate.lookupElement("DEF") as CircleElement;
-        // Center should be H
-        almostEqual(circle.Center.x, 340, 0.01);
-        almostEqual(circle.Center.y, 115, 0.01);
-        // Radius should be |GA|, not |H-anything|
-        let expectedRadius = Math.sqrt(45*45 + 85*85); // sqrt(9250) ≈ 96.177
-        almostEqual(circle.radius, expectedRadius, 0.01);
-        // A should NOT be Center (that would be the 2-point form)
-        assert.notEqual(circle.A, circle.Center);
-    });
-
-    // line;foot (2D) — line from A to the foot of the perpendicular from A to line BC
-    // A=(100,50), B=(50,200), C=(250,200) — BC is horizontal at y=200
-    // Foot of perp from A to BC = (100, 200)
-    // Line goes from A=(100,50) to foot=(100,200)
-    it("should compute a line from A to the foot of the perpendicular on BC", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.free, params: [100, 50] },
-            { name: "B", construction: E.Point.free, params: [50, 200] },
-            { name: "C", construction: E.Point.free, params: [250, 200] },
-            { name: "AL", construction: E.Line.foot, params: ["A", "B", "C"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let line = slate.lookupElement("AL") as LineElement;
-        // Line starts at A
-        almostEqual(line.A.x, 100, 0.01);
-        almostEqual(line.A.y,  50, 0.01);
-        // Line ends at foot = (100, 200)
-        almostEqual(line.B.x, 100, 0.01);
-        almostEqual(line.B.y, 200, 0.01);
-        // Line should be perpendicular to BC (dot product of directions = 0)
-        let dx_line = line.B.x - line.A.x;  // 0
-        let dy_line = line.B.y - line.A.y;  // 150
-        let dx_bc = 250 - 50;               // 200
-        let dy_bc = 0;                       // 0
-        almostEqual(dx_line * dx_bc + dy_line * dy_bc, 0, 0.01);
-    });
-
-    // polygon;square — RegularPolygonElement with n=4
-    // propI46: A=(50,190), B=(170,190), side=120
-    //   V[2] = A rotated 90° around B: dx=50-170=-120, dy=0
-    //     x = 170 + 0*(-120) - 1*0 = 170
-    //     y = 190 + 1*(-120) + 0*0 = 70    → V[2] = (170, 70)
-    //   V[3] = B rotated 90° around V[2]: dx=170-170=0, dy=190-70=120
-    //     x = 170 + 0*0 - 1*120 = 50
-    //     y = 70 + 1*0 + 0*120 = 70         → V[3] = (50, 70)
-    it("should compute a square with 4 vertices at right angles", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.free, params: [50, 190] },
-            { name: "B", construction: E.Point.free, params: [170, 190] },
-            { name: "ABED", construction: E.Polygon.square, params: ["A", "B"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let sq = slate.lookupElement("ABED") as PolygonElement;
-        assert.equal(sq.V.length, 4);
-        almostEqual(sq.V[0].x,  50, 0.01); almostEqual(sq.V[0].y, 190, 0.01);
-        almostEqual(sq.V[1].x, 170, 0.01); almostEqual(sq.V[1].y, 190, 0.01);
-        almostEqual(sq.V[2].x, 170, 0.01); almostEqual(sq.V[2].y,  70, 0.01);
-        almostEqual(sq.V[3].x,  50, 0.01); almostEqual(sq.V[3].y,  70, 0.01);
-        // All sides equal (120)
-        let side = sq.V[0].distance(sq.V[1]);
-        almostEqual(side, 120, 0.01);
-        almostEqual(sq.V[1].distance(sq.V[2]), side, 0.01);
-        almostEqual(sq.V[2].distance(sq.V[3]), side, 0.01);
-        almostEqual(sq.V[3].distance(sq.V[0]), side, 0.01);
-    });
-
-    // line;angleBisector — bisect angle BAC, line from vertex A to bisector point on BC
-    // Right angle at B=(0,0), rays to A=(0,100) and C=(100,0)
-    // Bisector of 90° at B → 45° ray hits AC (line from (0,100) to (100,0), x+y=100)
-    // at (50, 50)
-    // point;sphereSlider — point constrained to sphere surface
-    // Sphere center (100,100,0), radius point (200,100,0) → radius=100
-    // Point starts at (150,100,50), should project onto sphere surface
-    // Distance from center = sqrt(50²+0²+50²) = sqrt(5000) ≈ 70.71
-    // factor = 100/70.71 ≈ 1.414
-    // Projected: center + factor*(P-center) = (100+1.414*50, 100, 0+1.414*50) ≈ (170.71, 100, 70.71)
-    it("should project a sphereSlider point onto the sphere surface", () => {
-        let data : IConstructionInfo[] = [
-            { name: "O", construction: E.Point.fixed, params: [100, 100, 0] },
-            { name: "R", construction: E.Point.fixed, params: [200, 100, 0] },
-            { name: "S", construction: E.Sphere.radius, params: ["O", "R"] },
-            { name: "A", construction: E.Point.sphereSlider, params: ["S", 150, 100, 50] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let A = slate.lookupElement("A") as PointElement;
-        // Distance from center should equal radius (100)
-        let O = slate.lookupElement("O") as PointElement;
-        let dist = Math.sqrt((A.x-O.x)*(A.x-O.x) + (A.y-O.y)*(A.y-O.y) + (A.z-O.z)*(A.z-O.z));
-        almostEqual(dist, 100, 0.1);
-        // Should be draggable
-        assert.ok((A as any).draggable);
-    });
-
-    // plane;parallel — plane through point A parallel to plane P
-    it("should create a parallel plane through a point", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "P", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
-            { name: "A", construction: E.Point.fixed, params: [50, 50, 100] },
-            { name: "Q", construction: E.Plane.parallel, params: ["P", "A"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let Q = slate.lookupElement("Q") as PlaneElement;
-        // Parallel plane should pass through A
-        almostEqual(Q.A.x, 50, 0.01);
-        almostEqual(Q.A.y, 50, 0.01);
-        almostEqual(Q.A.z, 100, 0.01);
-    });
-
-    // polyhedron;tetrahedron — 4 points → triangle base + pyramid
-    it("should create a tetrahedron with 4 triangular faces", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "C", construction: E.Point.fixed, params: [50, 87, 0] },
-            { name: "D", construction: E.Point.fixed, params: [50, 29, 82] },
-            { name: "T", construction: E.Polyhedra.tetrahedron, params: ["A", "B", "C", "D"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        // The tetrahedron should have 4 faces (1 base + 3 sides)
-        // Find it — it's the last PolyhedronElement in the elements list
-        let tetra = slate.lookupElement("T");
-        assert.ok(tetra != null);
-        assert.equal((tetra as any).P.length, 4);
-    });
-
-    // polyhedron;prism — base polygon + direction vector → prism
-    // Triangle base + extrusion direction (0,0,100) → 5 faces (2 triangles + 3 quads)
-    it("should create a prism with base+2 triangles and 3 side quads", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "C", construction: E.Point.fixed, params: [50, 87, 0] },
-            { name: "base", construction: E.Polygon.triangle, params: ["A", "B", "C"] },
-            { name: "D", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "E", construction: E.Point.fixed, params: [0, 0, 100] },
-            { name: "P", construction: E.Polyhedra.prism, params: ["base", "D", "E"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let prism = slate.lookupElement("P");
-        assert.ok(prism != null);
-        // 2 + base.V.length = 2 + 3 = 5 faces
-        assert.equal((prism as any).P.length, 5);
-        // Top vertices should be base + (E-D) = base + (0,0,100)
-        let top = (prism as any).P[1] as PolygonElement;
-        almostEqual(top.V[0].z, 100, 0.01);
-        almostEqual(top.V[1].z, 100, 0.01);
-        almostEqual(top.V[2].z, 100, 0.01);
-    });
-
-    // polyhedron;parallelepiped — 4 points → parallelogram base + prism
-    it("should create a parallelepiped with 6 faces", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "C", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "D", construction: E.Point.fixed, params: [0, 0, 100] },
-            { name: "PP", construction: E.Polyhedra.parallelepiped, params: ["A", "B", "C", "D"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let pp = slate.lookupElement("PP");
-        assert.ok(pp != null);
-        // parallelepiped = prism on parallelogram base = 2 + 4 = 6 faces
-        assert.equal((pp as any).P.length, 6);
-    });
-
-    // circle;intersection — intersection of two spheres
-    // Sphere S: center (0,0,0), radius 100 (edge at (100,0,0))
-    // Sphere T: center (100,0,0), radius 100 (edge at (200,0,0))
-    // Both radii = 100, centers 100 apart → intersection circle at x=50
-    // factor = 0.5 + (100²-100²)/(2*100²) = 0.5
-    // Center = S.Center + factor*(T.Center - S.Center)... wait, the formula is:
-    //   Center.to(S.Center).minus(T.Center).times(factor).plus(T.Center)
-    //   = (0-100)*0.5 + 100 = 50
-    // radius = sqrt(T.radius² - Center.distance²(T.Center)) = sqrt(10000 - 2500) = sqrt(7500) ≈ 86.6
-    it("should compute the intersection circle of two spheres", () => {
-        let data : IConstructionInfo[] = [
-            { name: "O1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "R1", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "S", construction: E.Sphere.radius, params: ["O1", "R1"] },
-            { name: "O2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "R2", construction: E.Point.fixed, params: [200, 0, 0] },
-            { name: "T", construction: E.Sphere.radius, params: ["O2", "R2"] },
-            { name: "C", construction: E.Circle.intersection, params: ["S", "T"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let circle = slate.lookupElement("C") as CircleElement;
-        // Center of intersection circle should be at (50, 0, 0)
-        almostEqual(circle.Center.x, 50, 0.1);
-        almostEqual(circle.Center.y, 0, 0.1);
-        // Radius should be sqrt(10000 - 2500) = sqrt(7500) ≈ 86.6
-        almostEqual(circle.radius, Math.sqrt(7500), 0.1);
-    });
-
-    // --- Tests for the 7 previously missing constructions ---
-
-    // point;intersection (plane-line) — PlaneIntersection
-    // Plane z=0 (xy-plane), line from (50,50,100) to (50,50,-100) → intersects at (50,50,0)
-    it("should compute plane-line intersection", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "P", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
-            { name: "A", construction: E.Point.fixed, params: [50, 50, 100] },
-            { name: "B", construction: E.Point.fixed, params: [50, 50, -100] },
-            { name: "X", construction: E.Point.intersection, params: ["P", "A", "B"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let X = slate.lookupElement("X") as PointElement;
-        almostEqual(X.x, 50, 0.1);
-        almostEqual(X.y, 50, 0.1);
-        almostEqual(X.z, 0, 0.1);
-    });
-
-    // point;center (sphere) — returns sphere center
-    it("should return the center of a sphere", () => {
-        let data : IConstructionInfo[] = [
-            { name: "O", construction: E.Point.fixed, params: [150, 150, 50] },
-            { name: "R", construction: E.Point.fixed, params: [250, 150, 50] },
-            { name: "S", construction: E.Sphere.radius, params: ["O", "R"] },
-            { name: "C", construction: E.Point.center, params: ["S"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        let C = slate.lookupElement("C") as PointElement;
-        almostEqual(C.x, 150, 0.01);
-        almostEqual(C.y, 150, 0.01);
-        almostEqual(C.z, 50, 0.01);
-    });
-
-    // --- 3D signature variant tests ---
-
-    // circle;radius 3D (2-point with explicit plane)
-    it("should create a circle with explicit plane (3D variant)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
-            { name: "A", construction: E.Point.fixed, params: [50, 50, 0] },
-            { name: "B", construction: E.Point.fixed, params: [100, 50, 0] },
-            { name: "C", construction: E.Circle.radius, params: ["A", "B", "plane"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        let circle = slate.lookupElement("C") as CircleElement;
-        almostEqual(circle.radius, 50, 0.01);
-        // AP should be the explicit plane, not screen
-        assert.ok(circle.AP != null);
-    });
-
-    // polygon;equilateralTriangle 3D (with explicit plane)
-    it("should create an equilateral triangle with explicit plane (3D variant)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
-            { name: "A", construction: E.Point.fixed, params: [50, 50, 0] },
-            { name: "B", construction: E.Point.fixed, params: [150, 50, 0] },
-            { name: "T", construction: E.Polygon.equilateralTriangle, params: ["A", "B", "plane"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let tri = slate.lookupElement("T") as PolygonElement;
-        assert.equal(tri.V.length, 3);
-        // All sides should be equal (100)
-        let side = tri.V[0].distance(tri.V[1]);
-        almostEqual(side, 100, 0.01);
-        almostEqual(tri.V[1].distance(tri.V[2]), side, 0.01);
-        almostEqual(tri.V[2].distance(tri.V[0]), side, 0.01);
-    });
-
-    // sector;arc 3D (with explicit plane)
-    it("should create an arc with explicit plane (3D variant)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
-            { name: "A", construction: E.Point.fixed, params: [50, 130, 0] },
-            { name: "M", construction: E.Point.fixed, params: [70, 210, 0] },
-            { name: "B", construction: E.Point.fixed, params: [120, 200, 0] },
-            { name: "arc", construction: E.Sector.arc, params: ["A", "M", "B", "plane"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let arc = slate.lookupElement("arc");
-        assert.ok(arc != null);
-    });
-
-    // point;similar 3D (with explicit planes)
-    it("should compute a similar point with explicit planes (3D variant)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
-            { name: "A", construction: E.Point.fixed, params: [50, 200, 0] },
-            { name: "B", construction: E.Point.fixed, params: [150, 200, 0] },
-            { name: "D", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "Ep", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "F", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "C", construction: E.Point.similar, params: ["A", "B", "plane", "D", "Ep", "F", "plane"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let C = slate.lookupElement("C") as PointElement;
-        assert.ok(!isNaN(C.x));
-        assert.ok(!isNaN(C.y));
-    });
-
-    // point;angleBisector 3D
-    it("should compute angle bisector with explicit plane (3D variant)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
-            { name: "A", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "B", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "C", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "D", construction: E.Point.angleBisector, params: ["A", "B", "C", "plane"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let D = slate.lookupElement("D") as PointElement;
-        almostEqual(D.x, 50, 0.1);
-        almostEqual(D.y, 50, 0.1);
-    });
-
-    // point;angleDivider 3D
-    it("should compute angle divider with explicit plane (3D variant)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
-            { name: "A", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "B", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "C", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "D", construction: E.Point.angleDivider, params: ["A", "B", "C", "plane", 3] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let D = slate.lookupElement("D") as PointElement;
-        assert.ok(!isNaN(D.x));
-        assert.ok(!isNaN(D.y));
-    });
-
-    // line;angleBisector 3D
-    it("should compute line angle bisector with explicit plane (3D variant)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
-            { name: "A", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "B", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "C", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "L", construction: E.Line.angleBisector, params: ["A", "B", "C", "plane"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let L = slate.lookupElement("L") as LineElement;
-        almostEqual(L.A.x, 0, 0.1);
-        almostEqual(L.A.y, 0, 0.1);
-    });
-
-    // line;angleDivider 3D
-    it("should compute line angle divider with explicit plane (3D variant)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
-            { name: "A", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "B", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "C", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "L", construction: E.Line.angleDivider, params: ["A", "B", "C", "plane", 3] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let L = slate.lookupElement("L") as LineElement;
-        assert.ok(L != null);
-        assert.ok(!isNaN(L.A.x));
-    });
-
-    // line;similar 3D
-    it("should compute a similar line with explicit planes (3D variant)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
-            { name: "A", construction: E.Point.fixed, params: [50, 200, 0] },
-            { name: "B", construction: E.Point.fixed, params: [150, 200, 0] },
-            { name: "D", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "Ep", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "F", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "L", construction: E.Line.similar, params: ["A", "B", "plane", "D", "Ep", "F", "plane"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let L = slate.lookupElement("L") as LineElement;
-        almostEqual(L.A.x, 50, 0.1);
-        assert.ok(!isNaN(L.B.x));
-    });
-
-    // circle;radius 3D (3-point with explicit plane)
-    it("should create a 3-point circle with explicit plane (3D variant)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
-            { name: "A", construction: E.Point.fixed, params: [50, 50, 0] },
-            { name: "B", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "C", construction: E.Point.fixed, params: [60, 80, 0] },
-            { name: "circ", construction: E.Circle.radius, params: ["A", "B", "C", "plane"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        let circle = slate.lookupElement("circ") as CircleElement;
-        almostEqual(circle.radius, 100, 0.01);
-    });
-
-    // polygon;square 3D
-    it("should create a square with explicit plane (3D variant)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
-            { name: "A", construction: E.Point.fixed, params: [50, 190, 0] },
-            { name: "B", construction: E.Point.fixed, params: [170, 190, 0] },
-            { name: "S", construction: E.Polygon.square, params: ["A", "B", "plane"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let sq = slate.lookupElement("S") as PolygonElement;
-        assert.equal(sq.V.length, 4);
-        let side = sq.V[0].distance(sq.V[1]);
-        almostEqual(side, 120, 0.01);
-    });
-
-    // polygon;regularPolygon 3D
-    it("should create a regular pentagon with explicit plane (3D variant)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
-            { name: "A", construction: E.Point.fixed, params: [100, 50, 0] },
-            { name: "B", construction: E.Point.fixed, params: [200, 50, 0] },
-            { name: "pent", construction: E.Polygon.regularPolygon, params: ["A", "B", "plane", 5] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let poly = slate.lookupElement("pent") as PolygonElement;
-        assert.equal(poly.V.length, 5);
-    });
-
-    // polygon;similar 3D
-    it("should create a similar polygon with explicit planes (3D variant)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
-            { name: "A", construction: E.Point.fixed, params: [50, 200, 0] },
-            { name: "B", construction: E.Point.fixed, params: [150, 200, 0] },
-            { name: "D", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "Ep", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "F", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "T", construction: E.Polygon.similar, params: ["A", "B", "plane", "D", "Ep", "F", "plane"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let tri = slate.lookupElement("T") as PolygonElement;
-        assert.equal(tri.V.length, 3);
-        assert.ok(!isNaN(tri.V[2].x));
-    });
-
-    // polygon;starPolygon — star polygon with density d
-    // {5/2} pentagram: 5 vertices, density 2
-    it("should create a star polygon (pentagram) with 5 vertices", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.free, params: [100, 50] },
-            { name: "B", construction: E.Point.free, params: [200, 50] },
-            { name: "S", construction: E.Polygon.starPolygon, params: ["A", "B", 5, 2] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let poly = slate.lookupElement("S") as PolygonElement;
-        assert.equal(poly.V.length, 5);
-        // V[0]=A and V[1]=B are the given edge
-        almostEqual(poly.V[0].x, 100, 0.01);
-        almostEqual(poly.V[1].x, 200, 0.01);
-        // V[2] should exist and not be NaN
-        assert.ok(!isNaN(poly.V[2].x));
-        assert.ok(!isNaN(poly.V[2].y));
-    });
-
-    // sphere;radius 3-point — sphere at A with radius |BC|
-    it("should create a 3-point sphere with radius |BC|", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.fixed, params: [100, 100, 0] },
-            { name: "B", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "C", construction: E.Point.fixed, params: [60, 80, 0] },
-            { name: "S", construction: E.Sphere.radius, params: ["A", "B", "C"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        let sphere = slate.lookupElement("S") as SphereElement;
-        // radius should be |BC| = sqrt(60²+80²) = 100
-        almostEqual(sphere.radius(), 100, 0.01);
-    });
-
-    // circle;invert — inversion of circle in another circle
-    // Circle C: center (100,100), radius 30 (edge at (130,100))
-    // Circle D: center (200,100), radius 50 (edge at (250,100))
-    // The inverted circle should have a computable center and radius
-    it("should compute the inversion of a circle in another circle", () => {
-        let data : IConstructionInfo[] = [
-            { name: "O1", construction: E.Point.free, params: [100, 100] },
-            { name: "R1", construction: E.Point.free, params: [130, 100] },
-            { name: "C", construction: E.Circle.radius, params: ["O1", "R1"] },
-            { name: "O2", construction: E.Point.free, params: [200, 100] },
-            { name: "R2", construction: E.Point.free, params: [250, 100] },
-            { name: "D", construction: E.Circle.radius, params: ["O2", "R2"] },
-            { name: "E", construction: E.Circle.invert, params: ["C", "D"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let inverted = slate.lookupElement("E") as CircleElement;
-        // The inverted circle should be defined (not NaN)
-        assert.ok(!isNaN(inverted.Center.x));
-        assert.ok(!isNaN(inverted.Center.y));
-        assert.ok(inverted.radius > 0);
-    });
-
-    // plane;ambient (point variant) — returns the ambient plane of a point
-    // Note: ambient returns the SAME object (name gets overwritten, like point;vertex)
-    it("should return the ambient plane of a point", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "P", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
-            { name: "A", construction: E.Point.planeSlider, params: ["P", 50, 50, 0] },
-            { name: "AP", construction: E.Plane.ambient, params: ["A"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let ambient = slate.lookupElement("AP") as PlaneElement;
-        // The ambient plane should be a valid PlaneElement with S,T,U frame
-        assert.ok(ambient != null);
-        assert.ok(ambient instanceof PlaneElement);
-        // S should be unit vector in direction P1→P2
-        almostEqual(ambient.S.x, 1, 0.01);
-        almostEqual(ambient.S.y, 0, 0.01);
-    });
-
-    // line;proportion — line GI along GH so that AB:CD = EF:GI
-    // Using same values as point;proportion test: S=100, T=50, U=80, V=200
-    // factor = (50*80)/(100*200) = 0.2, result at V0 + 0.2*(V1-V0)
-    // Line from V0=(0,200) to result=(40,200)
-    it("should compute a proportion line", () => {
-        let data : IConstructionInfo[] = [
-            { name: "S0", construction: E.Point.free, params: [0, 0] },
-            { name: "S1", construction: E.Point.free, params: [100, 0] },
-            { name: "T0", construction: E.Point.free, params: [0, 0] },
-            { name: "T1", construction: E.Point.free, params: [50, 0] },
-            { name: "U0", construction: E.Point.free, params: [0, 0] },
-            { name: "U1", construction: E.Point.free, params: [80, 0] },
-            { name: "V0", construction: E.Point.free, params: [0, 200] },
-            { name: "V1", construction: E.Point.free, params: [200, 200] },
-            { name: "L",  construction: E.Line.proportion, params: ["S0","S1","T0","T1","U0","U1","V0","V1"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let line = slate.lookupElement("L") as LineElement;
-        // Line starts at V0 = (0, 200)
-        almostEqual(line.A.x, 0, 0.01);
-        almostEqual(line.A.y, 200, 0.01);
-        // Line ends at proportional point = (40, 200)
-        almostEqual(line.B.x, 40, 0.01);
-        almostEqual(line.B.y, 200, 0.01);
-    });
-
-    // point;invert — inversion of a point in a circle
-    // Circle center (100,100), radius point (200,100) → radius=100
-    // Point A at (150,100) → distance from center = 50
-    // Inverted: factor = r²/d² = 10000/2500 = 4
-    // Result = center + 4*(A-center) = (100,100) + 4*(50,0) = (300,100)
-    it("should compute the inversion of a point in a circle", () => {
-        let data : IConstructionInfo[] = [
-            { name: "O", construction: E.Point.free, params: [100, 100] },
-            { name: "R", construction: E.Point.free, params: [200, 100] },
-            { name: "C", construction: E.Circle.radius, params: ["O", "R"] },
-            { name: "A", construction: E.Point.free, params: [150, 100] },
-            { name: "B", construction: E.Point.invert, params: ["A", "C"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let B = slate.lookupElement("B") as PointElement;
-        almostEqual(B.x, 300, 0.01);
-        almostEqual(B.y, 100, 0.01);
-    });
-
-    // point;harmonic — harmonic conjugate of B with respect to C and D
-    // Collinear case: C=(0,0), D=(100,0), B=(25,0)
-    // Complex formula: A = (C(B-D) + D(B-C)) / ((B-D) + (B-C))
-    // E=B-C=(25,0), F=B-D=(-75,0)
-    // CF=C*F=(0,0), DE=D*E=(2500,0)
-    // numx = (CF+DE)*(F+E) = 2500*(-50) = -125000
-    // den = (-50)^2 = 2500
-    // A = (-50, 0)
-    it("should compute the harmonic conjugate (2D collinear case)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "B", construction: E.Point.free, params: [25, 0] },
-            { name: "C", construction: E.Point.free, params: [0, 0] },
-            { name: "D", construction: E.Point.free, params: [100, 0] },
-            { name: "A", construction: E.Point.harmonic, params: ["B", "C", "D"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let A = slate.lookupElement("A") as PointElement;
-        almostEqual(A.x, -50, 0.01);
-        almostEqual(A.y,   0, 0.01);
-    });
-
-    // point;planeSlider — draggable point constrained to a non-screen plane
-    it("should create a planeSlider point on a 3-point plane", () => {
-        let data : IConstructionInfo[] = [
-            { name: "P1", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "P2", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "P3", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "plane", construction: E.Plane.threePoints, params: ["P1", "P2", "P3"] },
-            { name: "A", construction: E.Point.planeSlider, params: ["plane", 50, 50, 99] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let A = slate.lookupElement("A") as PointElement;
-        // The plane is the xy-plane (z=0), so the point should project to z=0
-        almostEqual(A.x, 50, 0.01);
-        almostEqual(A.y, 50, 0.01);
-        almostEqual(A.z, 0, 0.01);
-        // Should be draggable
-        assert.ok((A as any).draggable);
-    });
-
-    // plane;3points — plane through 3 non-collinear points
-    it("should create a plane through 3 points with computed S,T,U frame", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "C", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "P", construction: E.Plane.threePoints, params: ["A", "B", "C"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let plane = slate.lookupElement("P") as PlaneElement;
-        // S should be unit vector in direction A→B = (1,0,0)
-        almostEqual(plane.S.x, 1, 0.01);
-        almostEqual(plane.S.y, 0, 0.01);
-        almostEqual(plane.S.z, 0, 0.01);
-        // T should be unit vector perpendicular to S in the plane = (0,1,0)
-        almostEqual(plane.T.x, 0, 0.01);
-        almostEqual(plane.T.y, 1, 0.01);
-        almostEqual(plane.T.z, 0, 0.01);
-        // U should be normal = (0,0,1)
-        almostEqual(plane.U.x, 0, 0.01);
-        almostEqual(plane.U.y, 0, 0.01);
-        almostEqual(plane.U.z, 1, 0.01);
-    });
-
-    // polygon;octagon — 8 free vertices pass-through
-    it("should create an octagon with 8 vertices", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.free, params: [100, 50] },
-            { name: "B", construction: E.Point.free, params: [150, 50] },
-            { name: "C", construction: E.Point.free, params: [175, 100] },
-            { name: "D", construction: E.Point.free, params: [150, 150] },
-            { name: "E", construction: E.Point.free, params: [100, 150] },
-            { name: "F", construction: E.Point.free, params: [75, 100] },
-            { name: "G", construction: E.Point.free, params: [85, 70] },
-            { name: "H", construction: E.Point.free, params: [115, 70] },
-            { name: "OCT", construction: E.Polygon.octagon, params: ["A","B","C","D","E","F","G","H"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        let poly = slate.lookupElement("OCT") as PolygonElement;
-        assert.equal(poly.V.length, 8);
-        almostEqual(poly.V[0].x, 100, 0.01);
-        almostEqual(poly.V[7].x, 115, 0.01);
-    });
-
-    // line;cutoff — line AE equal to CD along line AB
-    // A=(50,100), B=(200,100), C=(0,0), D=(60,0) → |CD|=60
-    // Layoff(A,A,B,C,D): E on ray AB from A with |AE|=60 → E=(110,100)
-    // Line from A=(50,100) to E=(110,100)
-    it("should create a line cutoff equal to a given length", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.free, params: [50, 100] },
-            { name: "B", construction: E.Point.free, params: [200, 100] },
-            { name: "C", construction: E.Point.free, params: [0, 0] },
-            { name: "D", construction: E.Point.free, params: [60, 0] },
-            { name: "AE", construction: E.Line.cutoff, params: ["A", "B", "C", "D"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let line = slate.lookupElement("AE") as LineElement;
-        // Line starts at A
-        almostEqual(line.A.x, 50, 0.01);
-        almostEqual(line.A.y, 100, 0.01);
-        // Line ends at E = A + 60 along AB direction (horizontal)
-        almostEqual(line.B.x, 110, 0.01);
-        almostEqual(line.B.y, 100, 0.01);
-    });
-
-    it("should bisect a right angle and intersect the opposite side", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.free, params: [0, 100] },
-            { name: "B", construction: E.Point.free, params: [0, 0] },
-            { name: "C", construction: E.Point.free, params: [100, 0] },
-            { name: "Bbis", construction: E.Line.angleBisector, params: ["A", "B", "C"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let line = slate.lookupElement("Bbis") as LineElement;
-        // Line starts at vertex B
-        almostEqual(line.A.x, 0, 0.01);
-        almostEqual(line.A.y, 0, 0.01);
-        // Line ends at bisector point on AC = (50, 50)
-        almostEqual(line.B.x, 50, 0.01);
-        almostEqual(line.B.y, 50, 0.01);
-    });
-
-    // point;angleBisector — just the bisector point, no line
-    it("should compute the angle bisector point", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.free, params: [0, 100] },
-            { name: "B", construction: E.Point.free, params: [0, 0] },
-            { name: "C", construction: E.Point.free, params: [100, 0] },
-            { name: "D", construction: E.Point.angleBisector, params: ["A", "B", "C"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let D = slate.lookupElement("D") as PointElement;
-        almostEqual(D.x, 50, 0.01);
-        almostEqual(D.y, 50, 0.01);
-    });
-
-    // polygon;regularPolygon — variable-n regular polygon via RegularPolygonElement
-    // n=5 (pentagon): A=(100,50), B=(200,50), side=100
-    // All sides should be equal and there should be 5 vertices
-    it("should create a regular pentagon with 5 equal sides", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.free, params: [100, 50] },
-            { name: "B", construction: E.Point.free, params: [200, 50] },
-            { name: "ABCDE", construction: E.Polygon.regularPolygon, params: ["A", "B", 5] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let poly = slate.lookupElement("ABCDE") as PolygonElement;
-        assert.equal(poly.V.length, 5);
-        // All 5 sides should be equal to side AB = 100
-        let side = poly.V[0].distance(poly.V[1]);
-        almostEqual(side, 100, 0.01);
-        for (let i = 1; i < 5; i++) {
-            almostEqual(poly.V[i].distance(poly.V[(i+1) % 5]), side, 0.01);
-        }
-    });
-
-    // polygon;quadrilateral — 4 free vertices passed through to PolygonElement
-    it("should create a quadrilateral with 4 vertices", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.free, params: [80, 40] },
-            { name: "B", construction: E.Point.free, params: [40, 210] },
-            { name: "C", construction: E.Point.free, params: [210, 210] },
-            { name: "D", construction: E.Point.free, params: [250, 40] },
-            { name: "ABCD", construction: E.Polygon.quadrilateral, params: ["A", "B", "C", "D"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        let poly = slate.lookupElement("ABCD") as PolygonElement;
-        assert.equal(poly.V.length, 4);
-        almostEqual(poly.V[0].x,  80, 0.01); almostEqual(poly.V[0].y,  40, 0.01);
-        almostEqual(poly.V[1].x,  40, 0.01); almostEqual(poly.V[1].y, 210, 0.01);
-        almostEqual(poly.V[2].x, 210, 0.01); almostEqual(poly.V[2].y, 210, 0.01);
-        almostEqual(poly.V[3].x, 250, 0.01); almostEqual(poly.V[3].y,  40, 0.01);
-    });
-
-    it("should compute a similar point with factor=1 (isosceles right triangle)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.free, params: [50, 200] },
-            { name: "B", construction: E.Point.free, params: [150, 200] },
-            { name: "D", construction: E.Point.free, params: [0, 0] },
-            { name: "E", construction: E.Point.free, params: [100, 0] },
-            { name: "F", construction: E.Point.free, params: [0, 100] },
-            { name: "C", construction: E.Point.similar, params: ["A", "B", "D", "E", "F"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let C = slate.lookupElement("C") as SimilarElement;
-        almostEqual(C.x, 50, 0.01);
-        almostEqual(C.y, 300, 0.01);
-        // Verify similarity: |AC|/|AB| should equal |DF|/|DE| = 1.0
-        let A = slate.lookupElement("A") as PointElement;
-        let B = slate.lookupElement("B") as PointElement;
-        almostEqual(A.distance(C) / A.distance(B), 1.0, 0.001);
-    });
-
-    it("should compute a similar point with factor=0.5 (non-isosceles right triangle)", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.free, params: [50, 200] },
-            { name: "B", construction: E.Point.free, params: [150, 200] },
-            { name: "D", construction: E.Point.free, params: [0, 0] },
-            { name: "E", construction: E.Point.free, params: [200, 0] },
-            { name: "F", construction: E.Point.free, params: [0, 100] },
-            { name: "C", construction: E.Point.similar, params: ["A", "B", "D", "E", "F"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let C = slate.lookupElement("C") as SimilarElement;
-        almostEqual(C.x, 50, 0.01);
-        almostEqual(C.y, 250, 0.01);
-        // Verify similarity: |AC|/|AB| should equal |DF|/|DE| = 0.5
-        let A = slate.lookupElement("A") as PointElement;
-        let B = slate.lookupElement("B") as PointElement;
-        almostEqual(A.distance(C) / A.distance(B), 0.5, 0.001);
-    });
-
-    it("should compute a line through A parallel and equal to BC", () => {
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, parallel_data);
-        slate.elements.forEach(e => e.update());
-        let line = slate.lookupElement("AD") as LineElement;
-        // Line starts at A
-        almostEqual(line.A.x,  50, 0.01);
-        almostEqual(line.A.y, 100, 0.01);
-        // Line ends at D = A + (C-B) = (150, 200)
-        almostEqual(line.B.x, 150, 0.01);
-        almostEqual(line.B.y, 200, 0.01);
-        // Direction AD should equal direction BC
-        let adx = line.B.x - line.A.x;  // 100
-        let ady = line.B.y - line.A.y;  // 100
-        let bcx = 200 - 100;             // 100
-        let bcy = 200 - 100;             // 100
-        almostEqual(adx, bcx, 0.01);
-        almostEqual(ady, bcy, 0.01);
-        // Lengths should match
-        let lenAD = Math.sqrt(adx*adx + ady*ady);
-        let lenBC = Math.sqrt(bcx*bcx + bcy*bcy);
-        almostEqual(lenAD, lenBC, 0.001);
-    });
-
-    it("should recompute the parallel line when an input point moves", () => {
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, parallel_data);
-        slate.elements.forEach(e => e.update());
-        // Move C from (200,200) to (250,150)
-        let C = slate.lookupElement("C") as PointElement;
-        C.x = 250; C.y = 150;
-        slate.elements.forEach(e => e.update());
-        let line = slate.lookupElement("AD") as LineElement;
-        // D = A + (C'-B) = (50,100) + (150,50) = (200, 150)
-        almostEqual(line.A.x,  50, 0.01);
-        almostEqual(line.A.y, 100, 0.01);
-        almostEqual(line.B.x, 200, 0.01);
-        almostEqual(line.B.y, 150, 0.01);
-    });
-
-    it("should be able to find the closest visible point within a tolerance", () =>{
-        let slate : Slate = new Slate(createCanvas(200,200));
-        let elms = toElements(slate, connected_line_data);
-        let A = slate.lookupElement("A") as PointElement;
-        let B = slate.lookupElement("B") as PointElement;
-        let red = "#FF0000";
-        A.vertexColor = 'red';
-        B.vertexColor = 'red';
-
-        let P = slate.closestVisiblePoint(slate.elements,
-                                  new PointElement({x:(10+100)/2 - 1, y:100}), 100);
-        assert(P.name == "A");
-        P = slate.closestVisiblePoint(slate.elements,
-            new PointElement({x:(10+100)/2 + 1, y:100}), 100);
-        assert(P.name == "B");
-
-        P = slate.closestVisiblePoint(slate.elements,
-            new PointElement({x:(10+100)/2 - 1, y:100}), 10);
-        assert(P == null);
-
-        P = slate.closestVisiblePoint(slate.elements,
-            new PointElement({x:89, y:100}), 10);
-        assert(P == null);
-
-        P = slate.closestVisiblePoint(slate.elements,
-            new PointElement({x:91, y:100}), 10);
-        assert(P.name == "B");
-    });
-
-    // point;foot (plane variant) — foot of perpendicular from D to plane P
-    // Plane P = XY-plane through A=(0,0,0), B=(100,0,0), C=(0,100,0)
-    // D=(50,50,100) — foot should be (50,50,0)
-    it("should compute the foot of a perpendicular from a point to a plane", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "C", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "P", construction: E.Plane.threePoints, params: ["A", "B", "C"] },
-            { name: "D", construction: E.Point.fixed, params: [50, 50, 100] },
-            { name: "F", construction: E.Point.foot, params: ["D", "P"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let foot = slate.lookupElement("F") as PointElement;
-        almostEqual(foot.x, 50, 0.01);
-        almostEqual(foot.y, 50, 0.01);
-        almostEqual(foot.z, 0, 0.01);
-    });
-
-    // line;foot (plane variant) — line from D to foot of perpendicular on plane P
-    // Same setup: foot at (50,50,0), line from D=(50,50,100) to foot
-    it("should compute a line from a point to the foot on a plane", () => {
-        let data : IConstructionInfo[] = [
-            { name: "A", construction: E.Point.fixed, params: [0, 0, 0] },
-            { name: "B", construction: E.Point.fixed, params: [100, 0, 0] },
-            { name: "C", construction: E.Point.fixed, params: [0, 100, 0] },
-            { name: "P", construction: E.Plane.threePoints, params: ["A", "B", "C"] },
-            { name: "D", construction: E.Point.fixed, params: [50, 50, 100] },
-            { name: "DF", construction: E.Line.foot, params: ["D", "P"] },
-        ];
-        let slate = new Slate(createCanvas(400, 400));
-        toElements(slate, data);
-        slate.elements.forEach(e => e.update());
-        let line = slate.lookupElement("DF") as LineElement;
-        // Line starts at D
-        almostEqual(line.A.x, 50, 0.01);
-        almostEqual(line.A.y, 50, 0.01);
-        almostEqual(line.A.z, 100, 0.01);
-        // Line ends at foot = (50, 50, 0)
-        almostEqual(line.B.x, 50, 0.01);
-        almostEqual(line.B.y, 50, 0.01);
-        almostEqual(line.B.z, 0, 0.01);
-    });
-
-});
-
-describe("parseColor", () => {
-
-    let bgcolor = "rgb(255,233,205)"; // #ffe9cd — the standard proposition background
-
-    // 1. Transparent inputs → null
-    it("should return null for null input (uses default)", () => {
-        assert.equal(parseColor(null, "black", bgcolor), "black");
-    });
-    it("should return null for 'none'", () => {
-        assert.equal(parseColor("none", "black", bgcolor), null);
-    });
-    it("should return null for string '0'", () => {
-        assert.equal(parseColor("0", "black", bgcolor), null);
-    });
-    it("should return null for numeric 0", () => {
-        assert.equal(parseColor(0, "black", bgcolor), null);
-    });
-    it("should return null for empty string", () => {
-        assert.equal(parseColor("", "black", bgcolor), null);
-    });
-
-    // 2. Special keywords
-    it("should return a random color for 'random'", () => {
-        let c = parseColor("random", "black", bgcolor);
-        assert.ok(c.startsWith("rgb("));
-    });
-    it("should return bgcolor for 'background'", () => {
-        assert.equal(parseColor("background", "black", bgcolor), bgcolor);
-    });
-    it("should return a brighter color for 'brighter'", () => {
-        let c = parseColor("brighter", "black", bgcolor);
-        assert.ok(c.startsWith("rgb("));
-        assert.notEqual(c, bgcolor);
-    });
-    it("should return a darker color for 'darker'", () => {
-        let c = parseColor("darker", "black", bgcolor);
-        assert.ok(c.startsWith("rgb("));
-        assert.notEqual(c, bgcolor);
-    });
-
-    // 3. Named colors (all 13)
-    it("should resolve all 13 named colors", () => {
-        assert.equal(parseColor("black", null, bgcolor), "rgb(0,0,0)");
-        assert.equal(parseColor("blue", null, bgcolor), "rgb(0,0,255)");
-        assert.equal(parseColor("cyan", null, bgcolor), "rgb(0,255,255)");
-        assert.equal(parseColor("darkGray", null, bgcolor), "rgb(64,64,64)");
-        assert.equal(parseColor("gray", null, bgcolor), "rgb(128,128,128)");
-        assert.equal(parseColor("green", null, bgcolor), "rgb(0,255,0)");
-        assert.equal(parseColor("lightGray", null, bgcolor), "rgb(192,192,192)");
-        assert.equal(parseColor("magenta", null, bgcolor), "rgb(255,0,255)");
-        assert.equal(parseColor("orange", null, bgcolor), "rgb(255,200,0)");
-        assert.equal(parseColor("pink", null, bgcolor), "rgb(255,175,175)");
-        assert.equal(parseColor("red", null, bgcolor), "rgb(255,0,0)");
-        assert.equal(parseColor("white", null, bgcolor), "rgb(255,255,255)");
-        assert.equal(parseColor("yellow", null, bgcolor), "rgb(255,255,0)");
-    });
-
-    // 4. Hex color parsing
-    it("should parse 6-digit hex 'ff0000' as red", () => {
-        assert.equal(parseColor("ff0000", null, bgcolor), "rgb(255,0,0)");
-    });
-    it("should parse hex '0000ff' as blue", () => {
-        assert.equal(parseColor("0000ff", null, bgcolor), "rgb(0,0,255)");
-    });
-    it("should parse hex 'ffffff' as white", () => {
-        assert.equal(parseColor("ffffff", null, bgcolor), "rgb(255,255,255)");
-    });
-
-    // 5. HSB comma triple parsing
-    it("should parse '35,19,100' (standard background) as warm peach", () => {
-        // h=35/360, s=19/100, b=100/100
-        let c = parseColor("35,19,100", null, bgcolor);
-        assert.ok(c.startsWith("rgb("));
-        // Should be approximately rgb(255,233,205) — the peach background
-        let m = c.match(/rgb\((\d+),(\d+),(\d+)\)/);
-        let r = parseInt(m[1]), g = parseInt(m[2]), b = parseInt(m[3]);
-        // Java produces Color(255,233,206) for HSB(35/360, 19/100, 100/100)
-        assert.ok(r >= 250 && r <= 255, `red ${r} should be ~255`);
-        assert.ok(g >= 228 && g <= 238, `green ${g} should be ~233`);
-        assert.ok(b >= 200 && b <= 210, `blue ${b} should be ~206`);
-    });
-    it("should parse '0,0,0' as black", () => {
-        assert.equal(parseColor("0,0,0", null, bgcolor), "rgb(0,0,0)");
-    });
-    it("should parse '0,0,100' as white (full brightness, no saturation)", () => {
-        let c = parseColor("0,0,100", null, bgcolor);
-        assert.equal(c, "rgb(255,255,255)");
-    });
-    it("should parse '270,70,100' as a purple", () => {
-        let c = parseColor("270,70,100", null, bgcolor);
-        let m = c.match(/rgb\((\d+),(\d+),(\d+)\)/);
-        let r = parseInt(m[1]), b = parseInt(m[3]);
-        // Hue 270 = purple region, high saturation
-        assert.ok(b > r, `blue ${b} should exceed red ${r} for purple`);
-    });
-
-    // 6. Unrecognized → null
-    it("should return null for unrecognized input", () => {
-        assert.equal(parseColor("notacolor", null, bgcolor), null);
-    });
-});
-
-describe("brighter / darker", () => {
-
-    it("brighter should increase RGB components", () => {
-        let c = brighter("rgb(100,100,100)");
-        let m = c.match(/rgb\((\d+),(\d+),(\d+)\)/);
-        let r = parseInt(m[1]);
-        assert.ok(r > 100, `brighter(100) = ${r} should be > 100`);
-        // Java: floor(100 / 0.7) = 142
-        assert.equal(r, 142);
-    });
-
-    it("brighter should handle black (all zeros)", () => {
-        let c = brighter("rgb(0,0,0)");
-        // Java: ceil(1.0 / (1.0 - 0.7)) = ceil(3.333) = 4
-        assert.equal(c, "rgb(4,4,4)");
-    });
-
-    it("brighter should cap at 255", () => {
-        let c = brighter("rgb(200,200,200)");
-        let m = c.match(/rgb\((\d+),(\d+),(\d+)\)/);
-        let r = parseInt(m[1]);
-        assert.ok(r <= 255, `brighter(200) = ${r} should be <= 255`);
-    });
-
-    it("darker should reduce RGB components by factor 0.7", () => {
-        let c = darker("rgb(100,100,100)");
-        // Java: floor(100 * 0.7) = 70
-        assert.equal(c, "rgb(70,70,70)");
-    });
-
-    it("darker should handle black", () => {
-        let c = darker("rgb(0,0,0)");
-        assert.equal(c, "rgb(0,0,0)");
-    });
-
-    it("brighter should work with HSB triple input", () => {
-        // "35,19,100" → rgb(~255,~233,~206) → brighter clamps near 255
-        let c = brighter("35,19,100");
-        assert.ok(c.startsWith("rgb("), `expected rgb string, got: ${c}`);
-    });
-
-    it("darker should work with named color input", () => {
-        let c = darker("red");
-        // red = rgb(255,0,0) → darker = rgb(178,0,0)
-        assert.equal(c, "rgb(178,0,0)");
-    });
-});
-
-import {parseParam} from "../src/index";
-
-describe("parseParam", () => {
-
-    it("should parse a free point with coordinates", () => {
-        let p = parseParam("A;point;free;60,100");
-        assert.equal(p.name, "A");
-        assert.equal(p.construction, E.Point.free);
-        assert.deepEqual(p.params, [60, 100]);
-    });
-
-    it("should parse a midpoint with string references", () => {
-        let p = parseParam("M;point;midpoint;A,B");
-        assert.equal(p.name, "M");
-        assert.equal(p.construction, E.Point.midpoint);
-        assert.deepEqual(p.params, ["A", "B"]);
-    });
-
-    it("should parse a circle construction", () => {
-        let p = parseParam("C;circle;radius;A,B");
-        assert.equal(p.construction, E.Circle.radius);
-        assert.deepEqual(p.params, ["A", "B"]);
-    });
-
-    it("should parse a line construction", () => {
-        let p = parseParam("AB;line;connect;A,B");
-        assert.equal(p.construction, E.Line.connect);
-        assert.deepEqual(p.params, ["A", "B"]);
-    });
-
-    it("should parse a polygon construction", () => {
-        let p = parseParam("T;polygon;triangle;A,B,C");
-        assert.equal(p.construction, E.Polygon.triangle);
-        assert.deepEqual(p.params, ["A", "B", "C"]);
-    });
-
-    it("should parse a sector construction", () => {
-        let p = parseParam("S;sector;sector;A,B,C");
-        assert.equal(p.construction, E.Sector.sector);
-    });
-
-    it("should parse a plane construction", () => {
-        let p = parseParam("P;plane;3points;A,B,C");
-        assert.equal(p.construction, E.Plane.threePoints);
-    });
-
-    it("should parse a sphere construction", () => {
-        let p = parseParam("S;sphere;radius;A,B");
-        assert.equal(p.construction, E.Sphere.radius);
-    });
-
-    it("should parse a polyhedron construction", () => {
-        let p = parseParam("P;polyhedron;pyramid;base,D");
-        assert.equal(p.construction, E.Polyhedra.pyramid);
-        assert.deepEqual(p.params, ["base", "D"]);
-    });
-
-    it("should convert numeric params to numbers", () => {
-        let p = parseParam("A;point;fixed;50,100,0");
-        assert.deepEqual(p.params, [50, 100, 0]);
-        assert.equal(typeof p.params[0], "number");
-    });
-
-    it("should handle mixed string and numeric params", () => {
-        let p = parseParam("R;polygon;regularPolygon;A,B,5");
-        assert.deepEqual(p.params, ["A", "B", 5]);
-    });
-
-    it("should handle negative numeric params", () => {
-        let p = parseParam("Y;point;planeSlider;P,-90,202,90");
-        assert.deepEqual(p.params, ["P", -90, 202, 90]);
-    });
-
-    it("should parse color fields", () => {
-        let p = parseParam("T;polygon;triangle;A,B,C;0;0;black;random");
-        assert.equal(p.nameColor, "0");
-        assert.equal(p.vertexColor, "0");
-        assert.equal(p.edgeColor, "black");
-        assert.equal(p.faceColor, "random");
-    });
-
-    it("should parse partial color fields", () => {
-        let p = parseParam("D;point;fixed;50,100,0;black;green");
-        assert.equal(p.nameColor, "black");
-        assert.equal(p.vertexColor, "green");
-        assert.equal(p.edgeColor, undefined);
-        assert.equal(p.faceColor, undefined);
-    });
-
-    it("should parse a single color field", () => {
-        let p = parseParam("Z;point;lineSlider;A,B,40,40,100;0");
-        assert.equal(p.nameColor, "0");
-        assert.equal(p.vertexColor, undefined);
-    });
-
-    it("should throw on unknown element type", () => {
-        assert.throws(() => parseParam("A;bogus;free;60,100"), /unknown element type/);
-    });
-
-    it("should throw on unknown construction name", () => {
-        assert.throws(() => parseParam("A;point;bogus;60,100"), /unknown construction/);
-    });
-
-    it("should throw on too few fields", () => {
-        assert.throws(() => parseParam("A;point"), /at least 4/);
     });
 });

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -16,6 +16,7 @@ import {PolygonElement} from "../src/elements/polygon/PolygonElement";
 import {ApplicationElement} from "../src/elements/polygon/ApplicationElement";
 import {SimilarElement} from "../src/elements/point/SimilarElement";
 import {CircleElement} from "../src/elements/circle/CircleElement";
+import {HarmonicElement} from "../src/elements/point/HarmonicElement";
 import {createCanvas} from "canvas";
 import {create} from "domain";
 
@@ -483,6 +484,10 @@ describe("slate", ()=> {
         { name: "C",       construction: E.Point.planeSlider,   params: ["xyplane", 245, 190, 80] },
         { name: "BC",      construction: E.Line.connect,        params: ["B","C"] },
         { name: "D",       construction: E.Point.foot,          params: ["A","BC"] },
+        // point;perpendicular variant 5: point A, plane P, points C, D
+        // constructs a PlanePerpendicularLine internally — the line
+        // perpendicular to xyplane through B, with length |BC|.
+        { name: "Pperp",   construction: E.Point.perpendicular, params: ["B","xyplane","B","C"] },
     ];
 
     function buildScene3d(): Slate {
@@ -582,13 +587,18 @@ describe("slate", ()=> {
         { name: "M",    construction: E.Point.midpoint,          params: ["A","B"] },  // pick target
     ];
 
-    it("should translate specialized elements (RegularPolygon, Application, InvertCircle, etc.)", () => {
+    function buildSpecializedScene(): Slate {
         let slate = new Slate(createCanvas(300, 300));
         toElements(slate, specialized_data);
         for (let e of slate.elements) {
             if (e instanceof PointElement) e.vertexColor = "black";
         }
         slate.elements.forEach(e => e.update());
+        return slate;
+    }
+
+    it("should translate specialized elements (RegularPolygon, Application, InvertCircle, etc.)", () => {
+        let slate = buildSpecializedScene();
 
         let A = slate.lookupElement("A") as PointElement;
         let M = slate.lookupElement("M") as PointElement;
@@ -610,6 +620,77 @@ describe("slate", ()=> {
 
         almostEqual(A.x, aInitX + deltaX, 0.001);
         almostEqual(A.y, aInitY + deltaY, 0.001);
+    });
+
+    it("should restore all slider initial positions when slate.reset() is called", () => {
+        let slate = buildSpecializedScene();
+
+        // Snapshot initial positions of each slider type.
+        let A    = slate.lookupElement("A") as PointElement;   // PlaneSlider
+        let P    = slate.lookupElement("P") as PointElement;   // CircleSlider
+        let Q    = slate.lookupElement("Q") as PointElement;   // SphereSlider
+        let inits = new Map<PointElement, [number,number,number]>();
+        for (let p of [A, P, Q]) inits.set(p, [p.x, p.y, p.z]);
+
+        // Translate everything, then reset — every slider's reset() runs.
+        let M = slate.lookupElement("M") as PointElement;
+        slate._onMouseDown(Math.round(M.x), Math.round(M.y));
+        slate._onMouseDrag(Math.round(M.x) + 25, Math.round(M.y) + 15);
+        slate._onMouseUp(Math.round(M.x) + 25, Math.round(M.y) + 15);
+
+        // Sanity: A actually moved.
+        let [ax, ay] = inits.get(A)!;
+        assert.ok(A.x !== ax || A.y !== ay, "A should have moved before reset");
+
+        slate.reset();
+
+        for (let [p, [x, y, z]] of inits) {
+            almostEqual(p.x, x, 0.01);
+            almostEqual(p.y, y, 0.01);
+            almostEqual(p.z, z, 0.01);
+        }
+    });
+
+    it("should compute the harmonic conjugate in the 3D branch when any z != 0", () => {
+        // The 2D branch is hit when B.z === C.z === D.z === 0; lines 46-59.
+        // Lines 61-72 are the 3D branch — exercised as soon as any point
+        // has a non-zero z. Picks three collinear points on z=5.
+        let B = new PointElement({x: 10, y: 10, z: 5});
+        let C = new PointElement({x: 30, y: 10, z: 5});
+        let D = new PointElement({x: 50, y: 10, z: 5});
+        let H = new HarmonicElement(B, C, D);
+        H.update();
+
+        // Harmonic conjugate of B w.r.t. collinear C,D satisfies
+        // cross-ratio (A,B;C,D) = -1 → A = (B*C + B*D - 2*C*D) / (2B - C - D)
+        // along the line. With B=10, C=30, D=50: A = (10*30 + 10*50 - 2*30*50) / (20 - 30 - 50)
+        //                                          = (300 + 500 - 3000) / -60
+        //                                          = -2200 / -60 = 36.667
+        // (Same line → same y, same z.)
+        almostEqual(H.x, 110 / 3, 0.01);
+        almostEqual(H.y, 10, 0.01);
+        almostEqual(H.z, 5, 0.01);
+    });
+
+    it("should also restore the FixedPoint from the 3D scene on reset", () => {
+        let slate = buildScene3d();
+        let x = slate.lookupElement("x") as PointElement;   // FixedPoint
+        let xInit: [number,number,number] = [x.x, x.y, x.z];
+
+        // Translate then reset.
+        let D = slate.lookupElement("D") as PointElement;
+        slate._onMouseDown(Math.round(D.x), Math.round(D.y));
+        slate._onMouseDrag(Math.round(D.x) + 15, Math.round(D.y) - 10);
+        slate._onMouseUp(Math.round(D.x) + 15, Math.round(D.y) - 10);
+
+        assert.ok(x.x !== xInit[0] || x.y !== xInit[1],
+            "FixedPoint should have translated before reset");
+
+        slate.reset();
+
+        almostEqual(x.x, xInit[0], 0.001);
+        almostEqual(x.y, xInit[1], 0.001);
+        almostEqual(x.z, xInit[2], 0.001);
     });
 
     // Exercises src/index.ts init() — the public entry point. Snapshot

--- a/tests/SnapshotHelper.ts
+++ b/tests/SnapshotHelper.ts
@@ -504,7 +504,7 @@ details { margin: 5px 0; }
     <p class="modal-subtitle" id="modalSubtitle"></p>
     <div class="strip" id="modalStrip"></div>
     <div class="live-area">
-      <canvas id="liveCanvas"></canvas>
+      <div id="liveSlateHost"></div>
       <p class="live-hint">Drag any orange/red point to interact.</p>
     </div>
   </div>
@@ -577,15 +577,18 @@ function openModal(slateKey) {
         modalStrip.appendChild(fig);
     }
 
-    // Rebuild the live canvas with a fresh id (so geomlib.init finds it).
-    // Replacing the node drops any old Slate's event listeners.
+    // Tear down any previous live slate: geomlib.init wraps the canvas
+    // in a controls div, so we can't just replaceChild on the host.
+    // Wiping the host and dropping the slate reference is the safe path.
+    destroyLiveSlate();
+
     const fresh = document.createElement("canvas");
     fresh.id = "liveCanvas";
     fresh.width = config.width;
     fresh.height = config.height;
     fresh.style.width = config.width + "px";
     fresh.style.height = config.height + "px";
-    liveCanvasContainer().replaceChild(fresh, document.getElementById("liveCanvas"));
+    document.getElementById("liveSlateHost").appendChild(fresh);
 
     modal.classList.add("open");
 
@@ -602,12 +605,20 @@ function openModal(slateKey) {
     }
 }
 
-function liveCanvasContainer() {
-    return document.querySelector(".live-area");
+function destroyLiveSlate() {
+    const host = document.getElementById("liveSlateHost");
+    if (host) host.innerHTML = "";
+    // geomlib.slates is the module-level registry that init() pushes into.
+    // Drop the most recent entry so the old Slate (and its event closures)
+    // can be garbage-collected.
+    if (typeof geomlib !== "undefined" && Array.isArray(geomlib.slates)) {
+        geomlib.slates.pop();
+    }
 }
 
 function closeModal() {
     modal.classList.remove("open");
+    destroyLiveSlate();
 }
 
 function openLightbox(src, alt) {

--- a/tests/SnapshotHelper.ts
+++ b/tests/SnapshotHelper.ts
@@ -1,0 +1,363 @@
+/*----------------------------------------------------------------------+
+|    Snapshot test helper — render, compare, drag, and report.          |
+|    Renders Slate scenes from SlateConfig, simulates drag interactions,|
+|    compares against golden PNG baselines via pixelmatch, and generates |
+|    an HTML report with before/after/verify images.                    |
++----------------------------------------------------------------------*/
+
+import * as fs from "fs";
+import * as path from "path";
+import {PNG} from "pngjs";
+const pixelmatch = require("pixelmatch");
+import {createCanvas, Canvas} from "canvas";
+import {Slate} from "../src/Slate";
+import {PointElement} from "../src/elements/point/PointElement";
+import {PlaneSlider} from "../src/elements/point/PlaneSlider";
+import {parseColor, lighten} from "../src/Colors";
+import {parseParam, IConstructionInfo} from "../src/index";
+import {Align as align} from "../src/elements/GeomElement";
+import {GeomElement} from "../src/elements/GeomElement";
+import {SlateConfig} from "./HtmlParamParser";
+
+const SNAPSHOT_DIR = path.join(__dirname, "snapshots");
+const THRESHOLD = 0.1;
+const FAIL_PERCENT = 0.5;
+
+// -----------------------------------------------------------------
+// Build a Slate from a SlateConfig (parsed from HTML)
+// -----------------------------------------------------------------
+export function buildScene(config: SlateConfig): Slate {
+    let canvas = createCanvas(config.width, config.height);
+    let slate = new Slate(canvas as unknown as HTMLCanvasElement);
+
+    // Parse background
+    let bgcolor = parseColor(config.background, "#ffffff", "#ffffff");
+    slate.bgcolor = bgcolor;
+
+    // Set font to match Java default
+    GeomElement.setFont("Times New Roman", 18);
+
+    for (let paramStr of config.elements) {
+        let param: IConstructionInfo;
+        try {
+            param = parseParam(paramStr);
+        } catch (e) {
+            // Skip unparseable elements (e.g., unknown constructions)
+            continue;
+        }
+
+        let element: GeomElement;
+        try {
+            element = slate.createElement(param.construction, param.params, param.name);
+        } catch (e) {
+            // Skip elements that fail to construct
+            continue;
+        }
+
+        element.align = align.CENTRAL;
+
+        let defaultNameColor = element instanceof PointElement ? "black" : null;
+        element.nameColor = parseColor(param.nameColor, defaultNameColor, bgcolor);
+
+        let defaultVertexColor = element.draggable ?
+            ((element instanceof PlaneSlider) ? "red" : "orange") : "black";
+        element.vertexColor = parseColor(param.vertexColor, defaultVertexColor, bgcolor);
+        element.edgeColor = parseColor(param.edgeColor, "black", bgcolor);
+
+        let lighterColor = lighten(bgcolor);
+        let defaultFaceColor = element.dimension == 2 ? lighterColor : null;
+        element.faceColor = parseColor(param.faceColor, defaultFaceColor, bgcolor);
+    }
+
+    // Set pivot if specified
+    if (config.pivot) {
+        try {
+            slate.setPivot(config.pivot);
+        } catch (e) {
+            // Ignore pivot errors (element may not exist)
+        }
+    }
+
+    slate.update();
+    return slate;
+}
+
+// -----------------------------------------------------------------
+// Render the scene to its canvas
+// -----------------------------------------------------------------
+export function renderScene(slate: Slate): Canvas {
+    let canvas = (slate as any)._canvas as Canvas;
+    let ctx = canvas.getContext("2d");
+    let w = canvas.width;
+    let h = canvas.height;
+    ctx.clearRect(0, 0, w, h);
+    ctx.fillStyle = slate.bgcolor;
+    ctx.fillRect(0, 0, w, h);
+    for (let element of slate.elements) element.drawFace(canvas as any);
+    for (let element of slate.elements) element.drawEdge(canvas as any);
+    for (let element of slate.elements) element.drawVertex(canvas as any);
+    for (let element of slate.elements) element.drawName(canvas as any);
+    return canvas;
+}
+
+// -----------------------------------------------------------------
+// Find draggable points (up to maxCount)
+// -----------------------------------------------------------------
+export function findDraggablePoints(slate: Slate, maxCount: number = 5): PointElement[] {
+    let draggables: PointElement[] = [];
+    for (let elem of slate.elements) {
+        if (elem instanceof PointElement && elem.draggable && elem.name) {
+            draggables.push(elem);
+            if (draggables.length >= maxCount) break;
+        }
+    }
+    return draggables;
+}
+
+// -----------------------------------------------------------------
+// Simulate a drag: mousedown → mousemove → mouseup
+// -----------------------------------------------------------------
+export function simulateDrag(
+    slate: Slate,
+    from: [number, number],
+    to: [number, number]
+): void {
+    (slate as any)._onMouseDown(from[0], from[1]);
+    (slate as any)._onMouseDrag(to[0], to[1]);
+    (slate as any)._onMouseUp(to[0], to[1]);
+}
+
+// -----------------------------------------------------------------
+// Draw a verification image: the scene with a drag arrow overlaid
+// -----------------------------------------------------------------
+export function drawVerificationImage(
+    canvas: Canvas,
+    from: [number, number],
+    to: [number, number],
+    label: string
+): Canvas {
+    let w = canvas.width;
+    let h = canvas.height;
+    let verifyCanvas = createCanvas(w, h);
+    let ctx = verifyCanvas.getContext("2d");
+
+    ctx.drawImage(canvas, 0, 0);
+
+    let [x1, y1] = from;
+    let [x2, y2] = to;
+
+    ctx.strokeStyle = "rgba(255, 0, 0, 0.8)";
+    ctx.fillStyle = "rgba(255, 0, 0, 0.8)";
+    ctx.lineWidth = 2;
+
+    // Arrow shaft
+    ctx.beginPath();
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(x2, y2);
+    ctx.stroke();
+
+    // Arrowhead
+    let angle = Math.atan2(y2 - y1, x2 - x1);
+    let headLen = 10;
+    ctx.beginPath();
+    ctx.moveTo(x2, y2);
+    ctx.lineTo(x2 - headLen * Math.cos(angle - Math.PI / 6),
+               y2 - headLen * Math.sin(angle - Math.PI / 6));
+    ctx.lineTo(x2 - headLen * Math.cos(angle + Math.PI / 6),
+               y2 - headLen * Math.sin(angle + Math.PI / 6));
+    ctx.closePath();
+    ctx.fill();
+
+    // Start dot
+    ctx.beginPath();
+    ctx.arc(x1, y1, 4, 0, 2 * Math.PI);
+    ctx.fill();
+
+    // Label
+    ctx.font = "12px sans-serif";
+    ctx.fillText(label, x1 + 8, y1 - 8);
+
+    return verifyCanvas;
+}
+
+// -----------------------------------------------------------------
+// Canvas → PNG conversion
+// -----------------------------------------------------------------
+function canvasToPNG(canvas: Canvas): PNG {
+    let ctx = canvas.getContext("2d");
+    let imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    let png = new PNG({width: canvas.width, height: canvas.height});
+    png.data = Buffer.from(imageData.data);
+    return png;
+}
+
+function savePNG(png: PNG, filePath: string): void {
+    fs.mkdirSync(path.dirname(filePath), {recursive: true});
+    fs.writeFileSync(filePath, PNG.sync.write(png));
+}
+
+function loadPNG(filePath: string): PNG | null {
+    if (!fs.existsSync(filePath)) return null;
+    return PNG.sync.read(fs.readFileSync(filePath));
+}
+
+// -----------------------------------------------------------------
+// Snapshot comparison
+// -----------------------------------------------------------------
+export interface SnapshotResult {
+    passed: boolean;
+    isNew: boolean;
+    diffPixels?: number;
+    totalPixels?: number;
+    diffPercent?: number;
+}
+
+export function assertSnapshot(
+    canvas: Canvas,
+    snapshotPath: string
+): SnapshotResult {
+    let actual = canvasToPNG(canvas);
+    let golden = loadPNG(snapshotPath);
+
+    if (golden == null) {
+        savePNG(actual, snapshotPath);
+        return {passed: true, isNew: true};
+    }
+
+    if (golden.width !== actual.width || golden.height !== actual.height) {
+        savePNG(actual, snapshotPath.replace(".png", "-actual.png"));
+        return {
+            passed: false, isNew: false,
+            diffPixels: golden.width * golden.height,
+            totalPixels: golden.width * golden.height,
+            diffPercent: 100
+        };
+    }
+
+    let diffPng = new PNG({width: golden.width, height: golden.height});
+    let diffPixels = pixelmatch(
+        golden.data, actual.data, diffPng.data,
+        golden.width, golden.height,
+        {threshold: THRESHOLD}
+    );
+
+    let totalPixels = golden.width * golden.height;
+    let diffPercent = (diffPixels / totalPixels) * 100;
+
+    if (diffPercent > FAIL_PERCENT) {
+        savePNG(actual, snapshotPath.replace(".png", "-actual.png"));
+        savePNG(diffPng, snapshotPath.replace(".png", "-diff.png"));
+        return {passed: false, isNew: false, diffPixels, totalPixels, diffPercent};
+    }
+
+    return {passed: true, isNew: false, diffPixels, totalPixels, diffPercent};
+}
+
+export function saveVerificationImage(canvas: Canvas, filePath: string): void {
+    savePNG(canvasToPNG(canvas), filePath);
+}
+
+// -----------------------------------------------------------------
+// HTML report generation
+// -----------------------------------------------------------------
+export interface ReportEntry {
+    category: string;
+    fileName: string;
+    slateIndex: number;
+    snapshotDir: string;     // relative to SNAPSHOT_DIR
+    beforeResult: SnapshotResult;
+    dragResults: {
+        pointName: string;
+        result: SnapshotResult;
+    }[];
+    error?: string;
+}
+
+export function generateReport(entries: ReportEntry[]): void {
+    // Group by category
+    let categories: {[key: string]: ReportEntry[]} = {};
+    for (let entry of entries) {
+        if (!categories[entry.category]) categories[entry.category] = [];
+        categories[entry.category].push(entry);
+    }
+
+    let html = `<!DOCTYPE html>
+<html><head>
+<meta charset="UTF-8">
+<title>Snapshot Verification Report</title>
+<style>
+body { font-family: sans-serif; margin: 20px; background: #f5f5f5; }
+h1 { color: #333; }
+h2 { color: #555; cursor: pointer; }
+h2:hover { text-decoration: underline; }
+table { border-collapse: collapse; margin: 10px 0 20px; }
+th, td { border: 1px solid #ccc; padding: 4px 8px; text-align: center; font-size: 13px; }
+th { background: #e8e8e8; }
+img { max-width: 150px; max-height: 120px; border: 1px solid #ddd; }
+.pass { background: #d4edda; }
+.fail { background: #f8d7da; }
+.new { background: #fff3cd; }
+.error { background: #f8d7da; color: #721c24; }
+.section { margin-bottom: 30px; }
+details { margin: 5px 0; }
+</style>
+</head><body>
+<h1>Snapshot Verification Report</h1>
+<p>Generated: ${new Date().toISOString()}</p>
+<p>Total slates: ${entries.length} |
+   Passed: ${entries.filter(e => !e.error && e.beforeResult.passed).length} |
+   New baselines: ${entries.filter(e => e.beforeResult.isNew).length} |
+   Failed: ${entries.filter(e => !e.error && !e.beforeResult.passed).length} |
+   Errors: ${entries.filter(e => e.error).length}</p>
+`;
+
+    for (let [cat, catEntries] of Object.entries(categories).sort()) {
+        html += `<div class="section"><details open>
+<summary><h2>${cat} (${catEntries.length} slates)</h2></summary>
+<table>
+<tr><th>Name</th><th>Slate</th><th>Before</th>`;
+        // Add drag columns
+        for (let i = 1; i <= 5; i++) html += `<th>Drag ${i}</th>`;
+        html += `<th>Status</th></tr>\n`;
+
+        for (let entry of catEntries) {
+            let statusClass = entry.error ? "error" :
+                entry.beforeResult.isNew ? "new" :
+                entry.beforeResult.passed ? "pass" : "fail";
+            let statusText = entry.error ? "ERROR" :
+                entry.beforeResult.isNew ? "NEW" :
+                entry.beforeResult.passed ? "PASS" : "FAIL";
+
+            let relDir = entry.snapshotDir;
+            html += `<tr class="${statusClass}">`;
+            html += `<td>${entry.fileName}</td>`;
+            html += `<td>slate${entry.slateIndex}</td>`;
+
+            if (entry.error) {
+                html += `<td colspan="7">${entry.error}</td>`;
+            } else {
+                // Before image
+                html += `<td><img src="${relDir}/before.png" loading="lazy"></td>`;
+                // Drag verify images
+                for (let i = 0; i < 5; i++) {
+                    if (i < entry.dragResults.length) {
+                        let dr = entry.dragResults[i];
+                        html += `<td><img src="${relDir}/drag${i+1}-verify.png" loading="lazy" title="${dr.pointName}"></td>`;
+                    } else {
+                        html += `<td>—</td>`;
+                    }
+                }
+                html += `<td>${statusText}</td>`;
+            }
+            html += `</tr>\n`;
+        }
+
+        html += `</table></details></div>\n`;
+    }
+
+    html += `</body></html>`;
+
+    let reportPath = path.join(SNAPSHOT_DIR, "report.html");
+    fs.mkdirSync(path.dirname(reportPath), {recursive: true});
+    fs.writeFileSync(reportPath, html);
+}

--- a/tests/SnapshotHelper.ts
+++ b/tests/SnapshotHelper.ts
@@ -481,7 +481,9 @@ details { margin: 5px 0; }
                 for (let i = 0; i < MAX_DRAG_PAIRS; i++) {
                     if (i < entry.dragResults.length) {
                         let dr = entry.dragResults[i];
-                        html += `<td><img class="thumb" data-slate="${slateKey}" src="${relDir}/drag${i+1}-after.png" loading="lazy" title="${dr.pointName} (move)" alt="drag${i+1} move"></td>`;
+                        // Move image = with red arrow (shows the drag).
+                        // Verify image = clean post-drag state (baseline).
+                        html += `<td><img class="thumb" data-slate="${slateKey}" src="${relDir}/drag${i+1}-move.png" loading="lazy" title="${dr.pointName} (move)" alt="drag${i+1} move"></td>`;
                         html += `<td><img class="thumb" data-slate="${slateKey}" src="${relDir}/drag${i+1}-verify.png" loading="lazy" title="${dr.pointName} (verify)" alt="drag${i+1} verify"></td>`;
                     } else {
                         html += `<td>—</td><td>—</td>`;
@@ -555,8 +557,11 @@ function openModal(slateKey) {
     for (let i = 0; i < entry.dragPoints.length; i++) {
         const n = i + 1;
         const name = entry.dragPoints[i];
+        // Move image (with arrow) shows the drag action; verify image is
+        // the clean post-drag state used as the regression baseline.
+        // Sequence reads: before → move → verify → move → verify.
         images.push({
-            src: relDir + "/drag" + n + "-after.png",
+            src: relDir + "/drag" + n + "-move.png",
             label: "drag " + n + " move (" + name + ")"
         });
         images.push({

--- a/tests/SnapshotHelper.ts
+++ b/tests/SnapshotHelper.ts
@@ -101,17 +101,45 @@ export function renderScene(slate: Slate): Canvas {
 }
 
 // -----------------------------------------------------------------
-// Find draggable points (up to maxCount)
+// Find draggable points worth exercising in the snapshot report.
+//
+// We only pick points that can meaningfully change the proportions of
+// the drawing when dragged. In practice that means:
+//   - has a name and is marked draggable (PlaneSlider / LineSlider /
+//     CircleSlider / SphereSlider — free points become PlaneSliders)
+//   - is rendered inside the visible canvas bounds
+//
+// The second rule filters out "helper anchors" like the ±1000-x points
+// used in Book IX to define a number-line axis: dragging them either
+// hit-tests to nothing (off-canvas) or just translates the frame,
+// neither of which exercises the construction's geometry.
 // -----------------------------------------------------------------
-export function findDraggablePoints(slate: Slate, maxCount: number = 5): PointElement[] {
+export function findDraggablePoints(
+    slate: Slate,
+    maxCount: number = 5,
+    canvasWidth?: number,
+    canvasHeight?: number
+): PointElement[] {
     let draggables: PointElement[] = [];
     for (let elem of slate.elements) {
-        if (elem instanceof PointElement && elem.draggable && elem.name) {
-            draggables.push(elem);
-            if (draggables.length >= maxCount) break;
+        if (!(elem instanceof PointElement)) continue;
+        if (!elem.draggable || !elem.name) continue;
+        if (canvasWidth != null && canvasHeight != null) {
+            if (elem.x < 0 || elem.x > canvasWidth) continue;
+            if (elem.y < 0 || elem.y > canvasHeight) continue;
         }
+        draggables.push(elem);
+        if (draggables.length >= maxCount) break;
     }
     return draggables;
+}
+
+// Snapshot a canvas's raw pixel bytes so we can compare them later
+// without aliasing the live canvas buffer (renderScene mutates in place).
+export function capturePixels(canvas: Canvas): Buffer {
+    let ctx = canvas.getContext("2d");
+    let imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    return Buffer.from(imageData.data);
 }
 
 // -----------------------------------------------------------------
@@ -257,6 +285,24 @@ export function saveVerificationImage(canvas: Canvas, filePath: string): void {
     savePNG(canvasToPNG(canvas), filePath);
 }
 
+// Count differing pixels between two pre-captured pixel buffers.
+// Uses pixelmatch's perceptual threshold (same as assertSnapshot) so
+// antialiasing noise around a small shift doesn't swamp the count.
+export function countDiffPixels(
+    priorBytes: Buffer,
+    currentCanvas: Canvas
+): number {
+    let expectedLen = currentCanvas.width * currentCanvas.height * 4;
+    if (priorBytes.length !== expectedLen) return Infinity;
+    let currentBytes = capturePixels(currentCanvas);
+    let diffBuf = Buffer.alloc(expectedLen);
+    return pixelmatch(
+        priorBytes, currentBytes, diffBuf,
+        currentCanvas.width, currentCanvas.height,
+        {threshold: THRESHOLD}
+    );
+}
+
 // -----------------------------------------------------------------
 // HTML report generation
 // -----------------------------------------------------------------
@@ -265,6 +311,7 @@ export interface ReportEntry {
     fileName: string;
     slateIndex: number;
     snapshotDir: string;     // relative to SNAPSHOT_DIR
+    config: SlateConfig;     // used to rebuild a live slate in the browser
     beforeResult: SnapshotResult;
     dragResults: {
         pointName: string;
@@ -281,6 +328,14 @@ export function generateReport(entries: ReportEntry[]): void {
         categories[entry.category].push(entry);
     }
 
+    // Build a map of slateKey -> SlateConfig for in-browser instantiation.
+    // Key format matches the data-slate attribute we put on each image.
+    let configMap: {[key: string]: SlateConfig} = {};
+    for (let entry of entries) {
+        let key = `${entry.category}/${entry.fileName}/slate${entry.slateIndex}`;
+        configMap[key] = entry.config;
+    }
+
     let html = `<!DOCTYPE html>
 <html><head>
 <meta charset="UTF-8">
@@ -288,18 +343,94 @@ export function generateReport(entries: ReportEntry[]): void {
 <style>
 body { font-family: sans-serif; margin: 20px; background: #f5f5f5; }
 h1 { color: #333; }
-h2 { color: #555; cursor: pointer; }
+h2 { color: #555; cursor: pointer; display: inline; font-size: 1.2em; }
 h2:hover { text-decoration: underline; }
 table { border-collapse: collapse; margin: 10px 0 20px; }
 th, td { border: 1px solid #ccc; padding: 4px 8px; text-align: center; font-size: 13px; }
 th { background: #e8e8e8; }
 img { max-width: 150px; max-height: 120px; border: 1px solid #ddd; }
+.thumb { cursor: zoom-in; }
+.thumb:hover { outline: 2px solid #3a80c4; }
 .pass { background: #d4edda; }
 .fail { background: #f8d7da; }
 .new { background: #fff3cd; }
 .error { background: #f8d7da; color: #721c24; }
 .section { margin-bottom: 30px; }
 details { margin: 5px 0; }
+
+/* Modal backdrop */
+.modal-backdrop {
+    position: fixed; inset: 0;
+    background: rgba(0, 0, 0, 0.65);
+    display: none;
+    align-items: center; justify-content: center;
+    z-index: 1000;
+    overflow: auto; padding: 20px;
+}
+.modal-backdrop.open { display: flex; }
+
+/* Modal window */
+.modal {
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 10px 40px rgba(0,0,0,0.3);
+    max-width: 95vw;
+    padding: 16px 20px;
+    position: relative;
+}
+.modal-close {
+    position: absolute; top: 6px; right: 10px;
+    background: none; border: none;
+    font-size: 24px; line-height: 1;
+    cursor: pointer; color: #888;
+}
+.modal-close:hover { color: #222; }
+.modal-title { margin: 0 30px 12px 0; font-size: 16px; color: #333; }
+.modal-subtitle { margin: 0 0 12px; font-size: 12px; color: #666; font-family: monospace; }
+
+/* Image strip */
+.strip {
+    display: flex; gap: 8px;
+    overflow-x: auto;
+    padding-bottom: 8px;
+    margin-bottom: 16px;
+    border-bottom: 1px solid #ddd;
+}
+.strip figure { margin: 0; text-align: center; flex-shrink: 0; }
+.strip img {
+    max-height: 180px; max-width: 240px;
+    border: 1px solid #bbb; cursor: zoom-in;
+    display: block;
+}
+.strip img:hover { outline: 2px solid #3a80c4; }
+.strip figcaption { font-size: 11px; color: #555; margin-top: 2px; }
+
+/* Live canvas area */
+.live-area { text-align: center; }
+.live-area canvas {
+    border: 1px solid #bbb;
+    background: #fff;
+    max-width: 100%;
+}
+.live-hint {
+    font-size: 11px; color: #666; margin: 8px 0 0;
+}
+
+/* Expanded image overlay (layer above modal) */
+.lightbox-backdrop {
+    position: fixed; inset: 0;
+    background: rgba(0, 0, 0, 0.85);
+    display: none;
+    align-items: center; justify-content: center;
+    z-index: 2000;
+    cursor: zoom-out;
+    padding: 20px;
+}
+.lightbox-backdrop.open { display: flex; }
+.lightbox-backdrop img {
+    max-width: 98vw; max-height: 98vh;
+    border: 2px solid #fff;
+}
 </style>
 </head><body>
 <h1>Snapshot Verification Report</h1>
@@ -309,16 +440,25 @@ details { margin: 5px 0; }
    New baselines: ${entries.filter(e => e.beforeResult.isNew).length} |
    Failed: ${entries.filter(e => !e.error && !e.beforeResult.passed).length} |
    Errors: ${entries.filter(e => e.error).length}</p>
+<p style="color:#555;font-size:13px">Click any image to open a live slate + image sequence. Click a strip image again to enlarge.</p>
 `;
+
+    // Each drag is rendered as a (move, verify) pair — clean after-state
+    // plus the same state with the drag arrow overlaid for verification.
+    const MAX_DRAG_PAIRS = 2;
 
     for (let [cat, catEntries] of Object.entries(categories).sort()) {
         html += `<div class="section"><details open>
 <summary><h2>${cat} (${catEntries.length} slates)</h2></summary>
 <table>
 <tr><th>Name</th><th>Slate</th><th>Before</th>`;
-        // Add drag columns
-        for (let i = 1; i <= 5; i++) html += `<th>Drag ${i}</th>`;
+        for (let i = 1; i <= MAX_DRAG_PAIRS; i++) {
+            html += `<th>Drag ${i} Move</th><th>Drag ${i} Verify</th>`;
+        }
         html += `<th>Status</th></tr>\n`;
+
+        let dragColCount = MAX_DRAG_PAIRS * 2;
+        let errorColspan = dragColCount + 2;  // +before +status
 
         for (let entry of catEntries) {
             let statusClass = entry.error ? "error" :
@@ -329,22 +469,22 @@ details { margin: 5px 0; }
                 entry.beforeResult.passed ? "PASS" : "FAIL";
 
             let relDir = entry.snapshotDir;
+            let slateKey = `${entry.category}/${entry.fileName}/slate${entry.slateIndex}`;
             html += `<tr class="${statusClass}">`;
             html += `<td>${entry.fileName}</td>`;
             html += `<td>slate${entry.slateIndex}</td>`;
 
             if (entry.error) {
-                html += `<td colspan="7">${entry.error}</td>`;
+                html += `<td colspan="${errorColspan}">${entry.error}</td>`;
             } else {
-                // Before image
-                html += `<td><img src="${relDir}/before.png" loading="lazy"></td>`;
-                // Drag verify images
-                for (let i = 0; i < 5; i++) {
+                html += `<td><img class="thumb" data-slate="${slateKey}" src="${relDir}/before.png" loading="lazy" alt="before"></td>`;
+                for (let i = 0; i < MAX_DRAG_PAIRS; i++) {
                     if (i < entry.dragResults.length) {
                         let dr = entry.dragResults[i];
-                        html += `<td><img src="${relDir}/drag${i+1}-verify.png" loading="lazy" title="${dr.pointName}"></td>`;
+                        html += `<td><img class="thumb" data-slate="${slateKey}" src="${relDir}/drag${i+1}-after.png" loading="lazy" title="${dr.pointName} (move)" alt="drag${i+1} move"></td>`;
+                        html += `<td><img class="thumb" data-slate="${slateKey}" src="${relDir}/drag${i+1}-verify.png" loading="lazy" title="${dr.pointName} (verify)" alt="drag${i+1} verify"></td>`;
                     } else {
-                        html += `<td>—</td>`;
+                        html += `<td>—</td><td>—</td>`;
                     }
                 }
                 html += `<td>${statusText}</td>`;
@@ -355,7 +495,151 @@ details { margin: 5px 0; }
         html += `</table></details></div>\n`;
     }
 
-    html += `</body></html>`;
+    // Modal + lightbox markup
+    html += `
+<div class="modal-backdrop" id="modal">
+  <div class="modal">
+    <button class="modal-close" id="modalClose" title="Close">&times;</button>
+    <h3 class="modal-title" id="modalTitle"></h3>
+    <p class="modal-subtitle" id="modalSubtitle"></p>
+    <div class="strip" id="modalStrip"></div>
+    <div class="live-area">
+      <canvas id="liveCanvas"></canvas>
+      <p class="live-hint">Drag any orange/red point to interact.</p>
+    </div>
+  </div>
+</div>
+
+<div class="lightbox-backdrop" id="lightbox">
+  <img id="lightboxImg" alt="">
+</div>
+
+<script src="../../dist/bundle.js"></script>
+<script>
+const CONFIGS = ${JSON.stringify(configMap)};
+const ENTRIES = ${JSON.stringify(entries.map(e => ({
+    category: e.category,
+    fileName: e.fileName,
+    slateIndex: e.slateIndex,
+    snapshotDir: e.snapshotDir,
+    dragPoints: e.dragResults.map(d => d.pointName),
+})))};
+const ENTRY_BY_KEY = {};
+for (const e of ENTRIES) {
+    ENTRY_BY_KEY[e.category + "/" + e.fileName + "/slate" + e.slateIndex] = e;
+}
+
+const modal = document.getElementById("modal");
+const modalClose = document.getElementById("modalClose");
+const modalTitle = document.getElementById("modalTitle");
+const modalSubtitle = document.getElementById("modalSubtitle");
+const modalStrip = document.getElementById("modalStrip");
+const liveCanvas = document.getElementById("liveCanvas");
+
+const lightbox = document.getElementById("lightbox");
+const lightboxImg = document.getElementById("lightboxImg");
+
+function openModal(slateKey) {
+    const config = CONFIGS[slateKey];
+    const entry = ENTRY_BY_KEY[slateKey];
+    if (!config || !entry) return;
+
+    modalTitle.textContent = entry.category + " / " + entry.fileName + " / slate" + entry.slateIndex;
+    modalSubtitle.textContent = config.title || "";
+
+    // Build image strip: before + for each drag, both the clean "move"
+    // image and the with-arrow "verify" image (= a complete pair).
+    modalStrip.innerHTML = "";
+    const relDir = entry.snapshotDir;
+    const images = [{src: relDir + "/before.png", label: "before"}];
+    for (let i = 0; i < entry.dragPoints.length; i++) {
+        const n = i + 1;
+        const name = entry.dragPoints[i];
+        images.push({
+            src: relDir + "/drag" + n + "-after.png",
+            label: "drag " + n + " move (" + name + ")"
+        });
+        images.push({
+            src: relDir + "/drag" + n + "-verify.png",
+            label: "drag " + n + " verify"
+        });
+    }
+    for (const im of images) {
+        const fig = document.createElement("figure");
+        const img = document.createElement("img");
+        img.src = im.src;
+        img.alt = im.label;
+        img.addEventListener("click", () => openLightbox(im.src, im.label));
+        const cap = document.createElement("figcaption");
+        cap.textContent = im.label;
+        fig.appendChild(img);
+        fig.appendChild(cap);
+        modalStrip.appendChild(fig);
+    }
+
+    // Rebuild the live canvas with a fresh id (so geomlib.init finds it).
+    // Replacing the node drops any old Slate's event listeners.
+    const fresh = document.createElement("canvas");
+    fresh.id = "liveCanvas";
+    fresh.width = config.width;
+    fresh.height = config.height;
+    fresh.style.width = config.width + "px";
+    fresh.style.height = config.height + "px";
+    liveCanvasContainer().replaceChild(fresh, document.getElementById("liveCanvas"));
+
+    modal.classList.add("open");
+
+    try {
+        geomlib.init({
+            canvasid: "liveCanvas",
+            background: config.background,
+            title: config.title || "",
+            pivot: config.pivot,
+            elements: config.elements,
+        });
+    } catch (err) {
+        console.error("Failed to instantiate live slate:", err);
+    }
+}
+
+function liveCanvasContainer() {
+    return document.querySelector(".live-area");
+}
+
+function closeModal() {
+    modal.classList.remove("open");
+}
+
+function openLightbox(src, alt) {
+    lightboxImg.src = src;
+    lightboxImg.alt = alt || "";
+    lightbox.classList.add("open");
+}
+
+function closeLightbox() {
+    lightbox.classList.remove("open");
+    lightboxImg.src = "";
+}
+
+modalClose.addEventListener("click", closeModal);
+modal.addEventListener("click", (e) => { if (e.target === modal) closeModal(); });
+lightbox.addEventListener("click", closeLightbox);
+document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") {
+        if (lightbox.classList.contains("open")) closeLightbox();
+        else if (modal.classList.contains("open")) closeModal();
+    }
+});
+
+// Wire thumbnails in the report table
+document.querySelectorAll("img.thumb").forEach(img => {
+    img.addEventListener("click", () => {
+        const key = img.getAttribute("data-slate");
+        if (key) openModal(key);
+    });
+});
+</script>
+</body></html>`;
 
     let reportPath = path.join(SNAPSHOT_DIR, "report.html");
     fs.mkdirSync(path.dirname(reportPath), {recursive: true});

--- a/tests/SnapshotTest.ts
+++ b/tests/SnapshotTest.ts
@@ -1,0 +1,140 @@
+/*----------------------------------------------------------------------+
+|    Snapshot verification test suite                                   |
+|    Auto-discovers all Java HTML files across euclid propositions,     |
+|    definitions, compass geometry, and round geometry. For each        |
+|    applet (slate), renders the scene, drags up to 5 points, and      |
+|    compares against golden PNG baselines.                             |
++----------------------------------------------------------------------*/
+
+import "mocha";
+import * as assert from "assert";
+import * as path from "path";
+import {discoverAllHtmlFiles, HtmlFileResult} from "./HtmlParamParser";
+import {
+    buildScene, renderScene, findDraggablePoints, simulateDrag,
+    drawVerificationImage, assertSnapshot, saveVerificationImage,
+    generateReport, ReportEntry
+} from "./SnapshotHelper";
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const SNAPSHOT_DIR = path.join(__dirname, "snapshots");
+
+// Collect report entries across all tests
+let reportEntries: ReportEntry[] = [];
+
+// Discover all HTML files
+let allFiles: HtmlFileResult[];
+try {
+    allFiles = discoverAllHtmlFiles(REPO_ROOT);
+} catch (e) {
+    allFiles = [];
+}
+
+describe("snapshot verification", function() {
+    // Increase timeout — rendering 671 slates takes time
+    this.timeout(300000);
+
+    for (let fileResult of allFiles) {
+        for (let slateIdx = 0; slateIdx < fileResult.slates.length; slateIdx++) {
+            let config = fileResult.slates[slateIdx];
+            let slateNum = slateIdx + 1;
+            let testName = `${fileResult.category}/${fileResult.fileName}/slate${slateNum}`;
+            let snapshotDir = path.join(
+                fileResult.category,
+                fileResult.fileName,
+                `slate${slateNum}`
+            );
+            let fullSnapshotDir = path.join(SNAPSHOT_DIR, snapshotDir);
+
+            it(`should render ${testName}`, function() {
+                let entry: ReportEntry = {
+                    category: fileResult.category,
+                    fileName: fileResult.fileName,
+                    slateIndex: slateNum,
+                    snapshotDir: snapshotDir,
+                    beforeResult: {passed: false, isNew: false},
+                    dragResults: [],
+                };
+
+                try {
+                    // Build and render the scene
+                    let slate = buildScene(config);
+                    let canvas = renderScene(slate);
+
+                    // Snapshot the initial state
+                    let beforePath = path.join(fullSnapshotDir, "before.png");
+                    let beforeResult = assertSnapshot(canvas, beforePath);
+                    entry.beforeResult = beforeResult;
+
+                    assert.ok(beforeResult.passed,
+                        `Before snapshot failed: ${beforeResult.diffPercent?.toFixed(2)}% pixels differ`);
+
+                    // Find draggable points (up to 5)
+                    let draggables = findDraggablePoints(slate, 5);
+
+                    // Drag each point and verify
+                    for (let i = 0; i < draggables.length; i++) {
+                        let point = draggables[i];
+                        let fromX = Math.round(point.x);
+                        let fromY = Math.round(point.y);
+                        let toX = fromX + 50;
+                        let toY = fromY + 30;
+
+                        // Clamp to canvas bounds
+                        toX = Math.max(0, Math.min(toX, config.width));
+                        toY = Math.max(0, Math.min(toY, config.height));
+
+                        // Simulate drag
+                        simulateDrag(slate, [fromX, fromY], [toX, toY]);
+
+                        // Render after drag
+                        let afterCanvas = renderScene(slate);
+
+                        // Save after snapshot
+                        let afterPath = path.join(fullSnapshotDir, `drag${i+1}-after.png`);
+                        let afterResult = assertSnapshot(afterCanvas, afterPath);
+
+                        // Generate verification image with arrow
+                        let verifyCanvas = drawVerificationImage(
+                            afterCanvas, [fromX, fromY], [toX, toY],
+                            point.name || `point${i+1}`
+                        );
+                        let verifyPath = path.join(fullSnapshotDir, `drag${i+1}-verify.png`);
+                        saveVerificationImage(verifyCanvas, verifyPath);
+
+                        entry.dragResults.push({
+                            pointName: point.name || `point${i+1}`,
+                            result: afterResult,
+                        });
+
+                        assert.ok(afterResult.passed,
+                            `Drag ${i+1} (${point.name}) snapshot failed: ${afterResult.diffPercent?.toFixed(2)}% pixels differ`);
+                    }
+                } catch (e) {
+                    entry.error = (e as Error).message;
+                    // Don't re-throw — record the error in the report
+                    // but still mark the test as failed
+                    if (!entry.error.includes("snapshot failed")) {
+                        // Construction/rendering error, not a snapshot diff
+                        // Still fail the test
+                    }
+                    throw e;
+                } finally {
+                    reportEntries.push(entry);
+                }
+            });
+        }
+    }
+
+    // Generate the HTML report after all tests complete
+    after(function() {
+        if (reportEntries.length > 0) {
+            generateReport(reportEntries);
+            console.log(`\n  Report generated: tests/snapshots/report.html`);
+            console.log(`  Total slates: ${reportEntries.length}`);
+            console.log(`  Passed: ${reportEntries.filter(e => !e.error && e.beforeResult.passed).length}`);
+            console.log(`  New baselines: ${reportEntries.filter(e => e.beforeResult.isNew).length}`);
+            console.log(`  Errors: ${reportEntries.filter(e => e.error).length}`);
+        }
+    });
+});

--- a/tests/SnapshotTest.ts
+++ b/tests/SnapshotTest.ts
@@ -125,25 +125,30 @@ describe("snapshot verification", function() {
                         recorded++;
                         let dragNum = recorded;
 
-                        let afterPath = path.join(fullSnapshotDir, `drag${dragNum}-after.png`);
-                        let afterResult = assertSnapshot(afterCanvas, afterPath);
+                        // The clean post-drag canvas is the verification
+                        // baseline — that's what we compare against in
+                        // future runs. The arrow-annotated version is the
+                        // "move" image, a visual showing which drag was
+                        // performed (not compared, just displayed).
+                        let verifyPath = path.join(fullSnapshotDir, `drag${dragNum}-verify.png`);
+                        let verifyResult = assertSnapshot(afterCanvas, verifyPath);
 
-                        let verifyCanvas = drawVerificationImage(
+                        let moveCanvas = drawVerificationImage(
                             afterCanvas, [fromX, fromY], [toX, toY],
                             point.name || `point${dragNum}`
                         );
-                        let verifyPath = path.join(fullSnapshotDir, `drag${dragNum}-verify.png`);
-                        saveVerificationImage(verifyCanvas, verifyPath);
+                        let movePath = path.join(fullSnapshotDir, `drag${dragNum}-move.png`);
+                        saveVerificationImage(moveCanvas, movePath);
 
                         entry.dragResults.push({
                             pointName: point.name || `point${dragNum}`,
-                            result: afterResult,
+                            result: verifyResult,
                         });
 
                         priorBytes = capturePixels(afterCanvas);
 
-                        assert.ok(afterResult.passed,
-                            `Drag ${dragNum} (${point.name}) snapshot failed: ${afterResult.diffPercent?.toFixed(2)}% pixels differ`);
+                        assert.ok(verifyResult.passed,
+                            `Drag ${dragNum} (${point.name}) snapshot failed: ${verifyResult.diffPercent?.toFixed(2)}% pixels differ`);
                     }
                 } catch (e) {
                     entry.error = (e as Error).message;

--- a/tests/SnapshotTest.ts
+++ b/tests/SnapshotTest.ts
@@ -13,7 +13,7 @@ import {discoverAllHtmlFiles, HtmlFileResult} from "./HtmlParamParser";
 import {
     buildScene, renderScene, findDraggablePoints, simulateDrag,
     drawVerificationImage, assertSnapshot, saveVerificationImage,
-    generateReport, ReportEntry
+    generateReport, ReportEntry, countDiffPixels, capturePixels
 } from "./SnapshotHelper";
 
 const REPO_ROOT = path.resolve(__dirname, "..");
@@ -52,6 +52,7 @@ describe("snapshot verification", function() {
                     fileName: fileResult.fileName,
                     slateIndex: slateNum,
                     snapshotDir: snapshotDir,
+                    config: config,
                     beforeResult: {passed: false, isNew: false},
                     dragResults: [],
                 };
@@ -69,46 +70,80 @@ describe("snapshot verification", function() {
                     assert.ok(beforeResult.passed,
                         `Before snapshot failed: ${beforeResult.diffPercent?.toFixed(2)}% pixels differ`);
 
-                    // Find draggable points (up to 5)
-                    let draggables = findDraggablePoints(slate, 5);
+                    // Only drag on-canvas draggable points — off-canvas
+                    // anchors like the ±1000-x helpers in Book IX are either
+                    // invisible (unpickable) or just translate the frame.
+                    // Pool 10 candidates so we can keep trying when early
+                    // ones fail the visual-significance check below.
+                    let candidates = findDraggablePoints(slate, 10, config.width, config.height);
 
-                    // Drag each point and verify
-                    for (let i = 0; i < draggables.length; i++) {
-                        let point = draggables[i];
+                    // A drag is "worth recording" only if it visibly changes
+                    // the rendering by at least this much. Sliders that only
+                    // move their own endpoint, or that propagate to a distant
+                    // proportion-point shifting a handful of pixels, fall
+                    // below this floor — dragging them produces near-identical
+                    // thumbnails and is noise for this report. 2% is roughly
+                    // the visible threshold at 150-px thumbnail size.
+                    let totalPixels = config.width * config.height;
+                    let minDiffPixels = Math.max(200, Math.floor(totalPixels * 0.02));
+
+                    let priorBytes = capturePixels(canvas);  // snapshot initial pixels
+                    let recorded = 0;                         // count of meaningful drags
+
+                    // Cap at 2 meaningful drags so every drag is shown as a
+                    // complete (move, verify) pair in the report — total of
+                    // 5 images per slate (1 before + 2 pairs), always ending
+                    // on a verify image.
+                    for (let point of candidates) {
+                        if (recorded >= 2) break;
+
                         let fromX = Math.round(point.x);
                         let fromY = Math.round(point.y);
                         let toX = fromX + 50;
                         let toY = fromY + 30;
 
-                        // Clamp to canvas bounds
                         toX = Math.max(0, Math.min(toX, config.width));
                         toY = Math.max(0, Math.min(toY, config.height));
 
-                        // Simulate drag
-                        simulateDrag(slate, [fromX, fromY], [toX, toY]);
+                        let origX = point.x;
+                        let origY = point.y;
 
-                        // Render after drag
+                        simulateDrag(slate, [fromX, fromY], [toX, toY]);
                         let afterCanvas = renderScene(slate);
 
-                        // Save after snapshot
-                        let afterPath = path.join(fullSnapshotDir, `drag${i+1}-after.png`);
+                        if (countDiffPixels(priorBytes, afterCanvas) < minDiffPixels) {
+                            // Visually insignificant change — revert this
+                            // drag so subsequent candidates see the original
+                            // scene state, then move on.
+                            let nowX = Math.round(point.x);
+                            let nowY = Math.round(point.y);
+                            simulateDrag(slate, [nowX, nowY], [Math.round(origX), Math.round(origY)]);
+                            renderScene(slate);
+                            continue;
+                        }
+
+                        recorded++;
+                        let dragNum = recorded;
+
+                        let afterPath = path.join(fullSnapshotDir, `drag${dragNum}-after.png`);
                         let afterResult = assertSnapshot(afterCanvas, afterPath);
 
-                        // Generate verification image with arrow
                         let verifyCanvas = drawVerificationImage(
                             afterCanvas, [fromX, fromY], [toX, toY],
-                            point.name || `point${i+1}`
+                            point.name || `point${dragNum}`
                         );
-                        let verifyPath = path.join(fullSnapshotDir, `drag${i+1}-verify.png`);
+                        let verifyPath = path.join(fullSnapshotDir, `drag${dragNum}-verify.png`);
                         saveVerificationImage(verifyCanvas, verifyPath);
 
                         entry.dragResults.push({
-                            pointName: point.name || `point${i+1}`,
+                            pointName: point.name || `point${dragNum}`,
                             result: afterResult,
                         });
 
+                        priorBytes = capturePixels(afterCanvas);
+
                         assert.ok(afterResult.passed,
-                            `Drag ${i+1} (${point.name}) snapshot failed: ${afterResult.diffPercent?.toFixed(2)}% pixels differ`);
+                            `Drag ${dragNum} (${point.name}) snapshot failed: ${afterResult.diffPercent?.toFixed(2)}% pixels differ`);
                     }
                 } catch (e) {
                     entry.error = (e as Error).message;

--- a/tests/SphereTest.ts
+++ b/tests/SphereTest.ts
@@ -1,0 +1,56 @@
+import "mocha";
+import * as assert from "assert";
+import {Slate} from "../src/Slate";
+import {E, IConstructionInfo} from "../src/index";
+import {PointElement} from "../src/elements/point/PointElement";
+import {SphereElement} from "../src/elements/sphere/SphereElement";
+import {createCanvas} from "canvas";
+import {almostEqual, toElements} from "./shared/testHelpers";
+
+describe("sphere", () => {
+
+    let sphere_data: IConstructionInfo[] = [
+        { construction: E.Point.free,    name: "A",       params: [60, 30] },
+        { construction: E.Point.free,    name: "B",       params: [60, 200] },
+        { construction: E.Sphere.radius, name: "Asphere", params: ["A", "B"] },
+    ];
+
+    it("should create a sphere", () => {
+        let slate: Slate = new Slate(createCanvas(200, 200));
+        toElements(slate, sphere_data);
+        slate.elements.forEach(e => e.update());
+        // Mirrors the original smoke test — just ensures the construction
+        // pipeline doesn't throw for sphere;radius + free points.
+        assert.ok(slate.lookupElement("Asphere") != null);
+    });
+
+    // point;center (sphere) — returns sphere center
+    it("should return the center of a sphere", () => {
+        let data: IConstructionInfo[] = [
+            { name: "O", construction: E.Point.fixed, params: [150, 150, 50] },
+            { name: "R", construction: E.Point.fixed, params: [250, 150, 50] },
+            { name: "S", construction: E.Sphere.radius, params: ["O", "R"] },
+            { name: "C", construction: E.Point.center, params: ["S"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        let C = slate.lookupElement("C") as PointElement;
+        almostEqual(C.x, 150, 0.01);
+        almostEqual(C.y, 150, 0.01);
+        almostEqual(C.z, 50, 0.01);
+    });
+
+    // sphere;radius 3-point — sphere at A with radius |BC|
+    it("should create a 3-point sphere with radius |BC|", () => {
+        let data: IConstructionInfo[] = [
+            { name: "A", construction: E.Point.fixed, params: [100, 100, 0] },
+            { name: "B", construction: E.Point.fixed, params: [0, 0, 0] },
+            { name: "C", construction: E.Point.fixed, params: [60, 80, 0] },
+            { name: "S", construction: E.Sphere.radius, params: ["A", "B", "C"] },
+        ];
+        let slate = new Slate(createCanvas(400, 400));
+        toElements(slate, data);
+        let sphere = slate.lookupElement("S") as SphereElement;
+        almostEqual(sphere.radius(), 100, 0.01);
+    });
+});

--- a/tests/shared/dragScenes.ts
+++ b/tests/shared/dragScenes.ts
@@ -1,0 +1,106 @@
+/*----------------------------------------------------------------------+
+|    Shared scenes for slate drag-coordinate tests                       |
+|    (translateCoordinates / rotateCoordinates via simulated drags).     |
++----------------------------------------------------------------------*/
+
+import {createCanvas} from "canvas";
+import {Slate} from "../../src/Slate";
+import {E, IConstructionInfo} from "../../src/index";
+import {PointElement} from "../../src/elements/point/PointElement";
+import {toElements} from "./testHelpers";
+
+// propIV5a-style 2D scene: triangle ABC with circumcenter F.
+// Dragging the midpoint D (non-draggable) exercises Slate.movePick's
+// rotate branch (with pivot F) or translate branch (without pivot),
+// propagating rotate()/translate() onto every element type in the scene.
+export let pivotScene_data: IConstructionInfo[] = [
+    { name: "A",       construction: E.Point.free,         params: [140, 40] },
+    { name: "B",       construction: E.Point.free,         params: [50, 180] },
+    { name: "C",       construction: E.Point.free,         params: [200, 180] },
+    { name: "circABC", construction: E.Circle.circumcircle,params: ["A","B","C"] },
+    { name: "triABC",  construction: E.Polygon.triangle,   params: ["A","B","C"] },
+    { name: "D",       construction: E.Point.midpoint,     params: ["A","B"] },
+    { name: "F",       construction: E.Point.center,       params: ["circABC"] },
+    { name: "AF",      construction: E.Line.connect,       params: ["A","F"] },
+];
+
+export function buildPivotScene(): Slate {
+    let slate = new Slate(createCanvas(250, 250));
+    toElements(slate, pivotScene_data);
+    // Picks use closestVisiblePoint which filters on vertexColor; buildScene
+    // sets this in the snapshot path — do it here too.
+    for (let e of slate.elements) {
+        if (e instanceof PointElement) e.vertexColor = "black";
+    }
+    slate.elements.forEach(e => e.update());
+    return slate;
+}
+
+// propXI11-style 3D scene: exercises FixedPoint, PerpendicularPlane,
+// ParallelPlane, Perpendicular (point), LineSlider, PlaneSlider on a
+// non-screen plane, and the 3D foot-of-perpendicular Foot element.
+export let scene3d_data: IConstructionInfo[] = [
+    { name: "origin",  construction: E.Point.free,          params: [120, 160] },
+    { name: "x",       construction: E.Point.fixed,         params: [280, 160, 100] },
+    { name: "yzplane", construction: E.Plane.perpendicular, params: ["origin","x"] },
+    { name: "y",       construction: E.Point.planeSlider,   params: ["yzplane", -90, 260, 40] },
+    { name: "xyplane", construction: E.Plane.threePoints,   params: ["origin","x","y"] },
+    { name: "z1",      construction: E.Point.perpendicular, params: ["origin","y","yzplane"] },
+    { name: "z",       construction: E.Point.lineSlider,    params: ["origin","z1",50,50,100] },
+    { name: "Oz",      construction: E.Line.connect,        params: ["origin","z"] },
+    { name: "ceiling", construction: E.Plane.parallel,      params: ["xyplane","z"] },
+    { name: "A",       construction: E.Point.planeSlider,   params: ["ceiling", 140, 100, 180] },
+    { name: "B",       construction: E.Point.planeSlider,   params: ["xyplane", 208, 270, 140] },
+    { name: "C",       construction: E.Point.planeSlider,   params: ["xyplane", 245, 190, 80] },
+    { name: "BC",      construction: E.Line.connect,        params: ["B","C"] },
+    { name: "D",       construction: E.Point.foot,          params: ["A","BC"] },
+    // point;perpendicular variant 5: point A, plane P, points C, D.
+    // Constructs a PlanePerpendicularLine internally.
+    { name: "Pperp",   construction: E.Point.perpendicular, params: ["B","xyplane","B","C"] },
+];
+
+export function buildScene3d(): Slate {
+    let slate = new Slate(createCanvas(330, 330));
+    toElements(slate, scene3d_data);
+    for (let e of slate.elements) {
+        if (e instanceof PointElement) e.vertexColor = "black";
+    }
+    slate.elements.forEach(e => e.update());
+    return slate;
+}
+
+// Grab-bag scene covering the construction types whose translate() /
+// rotate() methods were the long tail in the coverage report: RegularPolygon,
+// Application, InvertCircle, SphereIntersection, CircleSlider, SphereSlider,
+// Sector, Prism, Parallelepiped, Bichord.
+export let specialized_data: IConstructionInfo[] = [
+    { name: "A",    construction: E.Point.free,              params: [50, 50] },
+    { name: "B",    construction: E.Point.free,              params: [140, 50] },
+    { name: "C",    construction: E.Point.free,              params: [100, 140] },
+    { name: "D",    construction: E.Point.free,              params: [50, 180] },
+    { name: "c1",   construction: E.Circle.radius,           params: ["A","B"] },
+    { name: "c2",   construction: E.Circle.radius,           params: ["B","A"] },
+    { name: "bich", construction: E.Line.bichord,            params: ["c1","c2"] },
+    { name: "P",    construction: E.Point.circleSlider,      params: ["c1", 120, 30] },
+    { name: "inv",  construction: E.Circle.invert,           params: ["c1","c2"] },
+    { name: "s1",   construction: E.Sphere.radius,           params: ["A","B"] },
+    { name: "s2",   construction: E.Sphere.radius,           params: ["B","A"] },
+    { name: "sInt", construction: E.Circle.intersection,     params: ["s1","s2"] },
+    { name: "Q",    construction: E.Point.sphereSlider,      params: ["s1", 90, 70, 50] },
+    { name: "reg",  construction: E.Polygon.regularPolygon,  params: ["A","B", 5] },
+    { name: "poly", construction: E.Polygon.triangle,        params: ["A","B","C"] },
+    { name: "app",  construction: E.Polygon.application,     params: ["poly", "A", "B", "C"] },
+    { name: "sec",  construction: E.Sector.sector,           params: ["A","B","C"] },
+    { name: "pep",  construction: E.Polyhedra.parallelepiped,params: ["A","B","C","D"] },
+    { name: "M",    construction: E.Point.midpoint,          params: ["A","B"] },  // pick target
+];
+
+export function buildSpecializedScene(): Slate {
+    let slate = new Slate(createCanvas(300, 300));
+    toElements(slate, specialized_data);
+    for (let e of slate.elements) {
+        if (e instanceof PointElement) e.vertexColor = "black";
+    }
+    slate.elements.forEach(e => e.update());
+    return slate;
+}

--- a/tests/shared/testHelpers.ts
+++ b/tests/shared/testHelpers.ts
@@ -1,0 +1,20 @@
+/*----------------------------------------------------------------------+
+|    Shared helpers for the per-element test suites.                    |
++----------------------------------------------------------------------*/
+
+import * as assert from "assert";
+import {Slate} from "../../src/Slate";
+import {IConstructionInfo} from "../../src/index";
+
+export let almostEqual = function (actual: number, expected: number, precision: number) {
+    return assert.equal(
+        Math.abs(actual - expected) < precision,
+        true,
+        "expected: " + expected + " actual: " + actual + " tolerance: " + precision);
+};
+
+export function toElements(slate: Slate, data: IConstructionInfo[]) {
+    return data.map(
+        cld => slate.createElement(cld.construction, cld.params, cld.name)
+    );
+}


### PR DESCRIPTION
## Summary

Adds a full snapshot-verification suite that auto-discovers every Java applet
occurrence across books I–XIII + compass/round geometry (671 slates from 545
HTML files) and rebuilds them in the TS port; an interactive HTML report
with a click-to-open modal showing the image sequence and a live
`geomlib.init()` canvas; and a coverage-driven expansion of unit tests that
takes the project from 88.4% / 82.9% statements/functions to **92.2% /
92.4%**.

Also splits the formerly-2448-line `SlateTest.ts` into per-element test
files mirroring `src/elements/`.

## What's new

### Snapshot suite (`tests/SnapshotTest.ts` + helpers)

- **`HtmlParamParser.ts`** auto-discovers all `<applet>` blocks across
  `view/euclid-html/`, `geom_applet/compass_geometry/`, and
  `geom_applet/round_geometry/`. Handles multi-applet pages, quoted and
  unquoted param values, `random` → fixed HSB palette for reproducibility.
- **`SnapshotHelper.ts`** builds a `Slate` from each parsed config, renders
  to a node-canvas, compares PNGs with pixelmatch (0.1 threshold, 0.5% fail
  budget), and writes a `before.png` + `drag{N}-move.png` (arrow overlay)
  / `drag{N}-verify.png` (clean baseline) per slate. Smart drag filtering:
  - prefers on-canvas draggable points (off-canvas helper anchors in
    Book IX no longer waste slots)
  - skips drags that don't change the rendering by ≥2% of pixels
    (reverts and tries the next candidate)
  - caps at 2 meaningful drags per slate so every sequence is a complete
    `(move, verify)` pair and ends on a verify
- **`report.html`**: table of thumbnails per category; clicking any
  thumbnail opens a modal that shows the sequence above a live
  `geomlib.init()` canvas (full teardown between opens so the DOM and
  `geomlib.slates` stay clean). Thumbnails inside the modal expand to
  a full-screen lightbox.

671 slates render and pass; disk footprint ~42 MB.

### Unit test expansion

19 new tests target `Slate.rotateCoordinates` / `translateCoordinates`
(exercised via simulated drags on non-draggable points, with and without
pivots) and the long tail of 50%-function files (PerpendicularPlane,
ParallelPlane, InvertCircleElement, SphereIntersectionElement,
ApplicationElement, RegularPolygonElement, PrismElement, FixedPoint,
CircleSlider, SphereSliderElement, HarmonicElement 3D branch,
PlanePerpendicularLine). Plus a direct `init()` test that stubs the DOM
lookup the public entry point needs.

### Cleanup

Removed confirmed-unused helpers (`PointElement.toString`/`hitTest`/static
`sum`, `GeomElement.hitTest`, `CircleElement.toString`, `SectorElement.
toString`/`radius2`) and a dead `if (majorR < 0.5)` branch
(`minorR = factor * majorR` with factor in [0,1] so the earlier
`minorR < 0.5` branch always fires first).

### Test organization

`SlateTest.ts` (was 2448 lines) split into 11 element-specific files
that match `src/elements/`:

- `PointTest.ts`, `LineTest.ts`, `CircleTest.ts`, `PlaneTest.ts`,
  `PolygonTest.ts`, `SectorTest.ts`, `SphereTest.ts`, `PolyhedronTest.ts`
- `ColorsTest.ts`, `ParseParamTest.ts`
- `SlateTest.ts` retains slate-level only (construct/update/drag/init/
  error paths/closestVisiblePoint)
- `tests/shared/testHelpers.ts` + `tests/shared/dragScenes.ts` for
  cross-file helpers

All 135 unit tests preserved verbatim — organizational only.

### npm scripts

- `npm test` — snapshot (min reporter, quiet) then unit (spec reporter)
- `npm run test:snapshot`, `npm run test:unit`
- `npm run coverage`, `npm run coverage:unit` (skip snapshots, ~2s)
- `npm run snapshots:clean` — wipe `tests/snapshots/` to `.gitkeep`

## Coverage

|                | Before | After  |
| -------------- | ------ | ------ |
| Statements     | 88.4%  | 92.18% |
| Functions      | 82.9%  | 92.37% |
| Branches       | 91.8%  | 93.11% |
| Lines          | 88.4%  | 92.18% |
| Tests          | 116    | 806    |

Files remaining below 90% are either DOM-event-listener code in
`Slate.ts`/`index.ts` that requires jsdom, or the `SlateControls.ts`
UI overlay (conscious skip — DOM glue, not algorithmic logic).

## Test plan

- [x] `npm test` — 806 passing (671 snapshot + 135 unit)
- [x] `npm run coverage` — matches the table above
- [x] `npm run snapshots:clean && npm run test:snapshot` — regenerates
      all 671 baselines from scratch, all pass on the second run
- [x] Open `tests/snapshots/report.html`, click a thumbnail — modal
      opens with the image sequence on top and an interactive canvas
      below; dragging an orange/red point updates the canvas; close
      and open another slate — no DOM errors
- [x] Click a sequence thumbnail inside the modal — expands to lightbox
- [x] `npm run test:unit` uses spec reporter, `test:snapshot` uses min

🤖 Generated with [Claude Code](https://claude.com/claude-code)
