### PR TITLE
Bugfix/issue 41 propi2 slate1 drag instability

### DIFF
--- a/src/Slate.ts
+++ b/src/Slate.ts
@@ -397,13 +397,24 @@ export class Slate {
       den = olds*olds + oldt*oldt;
       let ac : number = (news*olds + newt*oldt)/den;
       let as : number = (newt*olds - news*oldt)/den;
-      // rotate all non-preexisting elements
-      // (Java: Slate.java line 844 — if (!preexists[i]) element[i].rotate(...))
-      for (let elem of this._elementsForUpdate) {
+      // Rotate all non-preexisting elements directly.
+      // (Java: Slate.java line 843-845)
+      for (let elem of this._elements) {
           if (!elem.preexists)
               elem.rotate(piv, ac, as);
       }
-
+      // After direct rotation, recompute derived elements from their (now
+      // rotated) parents. Java doesn't need this because element[] carries
+      // duplicate entries for shared objects — a Layoff created by
+      // line;extend and re-referenced by point;last appears at two indices,
+      // one with preexists=false that gets rotated directly. TS dedupes
+      // _elements, so a shared object marked preexists=true is skipped,
+      // which means Layoff-style points backed by bare LineElement wrappers
+      // would never get moved directly (bare LineElement.rotate is a no-op).
+      // Running update() rebuilds them from their (rotated) parents, which
+      // produces the same result because rotation is a linear operation
+      // and Layoff.update() derives its position from parent coords.
+      this.update();
     }
 
 }

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -276,6 +276,103 @@ describe("slate", () => {
         });
     });
 
+    // Regression test for bugfix/issue-41 — propI2 slate1.
+    // Dragging a non-draggable Layoff point (L, created via
+    // point;last on a line;extend-produced LineElement) should rotate
+    // the whole scene around the pivot D, including ALL derived
+    // Layoff points (E, G, F, H, K) — not just the free points (A, B, C).
+    // Before the fix, preexists marking on shared Layoff objects caused
+    // the derived points to be skipped during rotation, leaving them
+    // stationary while A/B/C swung around D — a visibly sheared scene.
+    describe("drag coordinates: propI2 slate1 (issue #41)", () => {
+        let params = [
+            "A;point;free;160,190",
+            "B;point;free;190,160",
+            "C;point;free;180,90",
+            "BC;line;connect;B,C",
+            "DAB;polygon;equilateralTriangle;A,B;0;0;0;0",
+            "D;point;vertex;DAB,3;black;green",
+            "AL;line;extend;D,A,B,C",
+            "L;point;last;AL",
+            "LE;line;extend;A,L,A,B",
+            "E;point;last;LE;black;0",
+            "BG;line;extend;D,B,B,C",
+            "G;point;last;BG",
+            "GF;line;extend;B,G,A,B",
+            "F;point;last;GF;black;0",
+            "BH;line;extend;G,B,G,B;0;0;0",
+            "H;point;last;BH;black;0",
+            "DK;line;extend;G,D,G,D;0;0;0",
+            "K;point;last;DK;black;0",
+        ];
+
+        function buildScene(): Slate {
+            let slate = new Slate(createCanvas(340, 320));
+            let parseParam = require("../src/index").parseParam;
+            for (let p of params) {
+                let info = parseParam(p);
+                slate.createElement(info.construction, info.params, info.name);
+            }
+            slate.elements.forEach(e => e.update());
+            for (let e of slate.elements) {
+                if (e instanceof PointElement && (e as any).vertexColor == null) {
+                    (e as any).vertexColor = "black";
+                }
+            }
+            slate.setPivot("D");
+            return slate;
+        }
+
+        it("dragging L rotates every derived point, not only the free A/B/C", () => {
+            let slate = buildScene();
+            let before: Record<string, [number, number]> = {};
+            for (let n of ["A","B","C","D","L","E","G","F","H","K"]) {
+                let p = slate.lookupElement(n) as PointElement;
+                before[n] = [p.x, p.y];
+            }
+
+            let L = slate.lookupElement("L") as PointElement;
+            let fromX = Math.round(L.x), fromY = Math.round(L.y);
+            let toX = fromX + 50, toY = fromY + 30;
+            (slate as any)._onMouseDown(fromX, fromY);
+            (slate as any)._onMouseDrag(toX, toY);
+            (slate as any)._onMouseUp(toX, toY);
+
+            let moved = (n: string) => {
+                let p = slate.lookupElement(n) as PointElement;
+                return Math.hypot(p.x - before[n][0], p.y - before[n][1]);
+            };
+
+            // Pivot must not move.
+            assert.ok(moved("D") < 0.001, `D (pivot) unexpectedly moved by ${moved("D")}`);
+            // L lands at drop target.
+            assert.ok(Math.abs(L.x - toX) < 1 && Math.abs(L.y - toY) < 1,
+                `L should have landed at (${toX},${toY}), got (${L.x},${L.y})`);
+            // Every non-pivot point must rotate, including Layoff-backed ones.
+            for (let n of ["A","B","C","E","G","F","H","K"]) {
+                assert.ok(moved(n) > 5,
+                    `${n} should rotate with L; moved by only ${moved(n).toFixed(2)} px`);
+            }
+        });
+
+        it("L stays on the ray DA after the drag (Layoff invariant)", () => {
+            let slate = buildScene();
+            let L = slate.lookupElement("L") as PointElement;
+            let fromX = Math.round(L.x), fromY = Math.round(L.y);
+            (slate as any)._onMouseDown(fromX, fromY);
+            (slate as any)._onMouseDrag(fromX + 30, fromY + 20);
+            (slate as any)._onMouseUp(fromX + 30, fromY + 20);
+
+            let A = slate.lookupElement("A") as PointElement;
+            let D = slate.lookupElement("D") as PointElement;
+            let dA = Math.hypot(A.x - D.x, A.y - D.y);
+            let dL = Math.hypot(L.x - D.x, L.y - D.y);
+            let ux = (A.x - D.x) / dA, uy = (A.y - D.y) / dA;
+            let err = Math.hypot(L.x - (D.x + dL * ux), L.y - (D.y + dL * uy));
+            assert.ok(err < 0.5, `L should stay on ray DA; off by ${err.toFixed(2)} px`);
+        });
+    });
+
     // Exercises src/index.ts init() — the public entry point. Snapshot
     // tests use buildScene() directly; unit tests construct Slate without
     // going through init(). Stubs the DOM lookup init() needs.

--- a/view/applet-tests/point/propI2-L-drag/applet.html
+++ b/view/applet-tests/point/propI2-L-drag/applet.html
@@ -1,0 +1,50 @@
+<HTML><HEAD><TITLE>point;propI2-L-drag — applet form of view/test/point/propI2-L-drag.html</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!-- TS:       view/test/point/propI2-L-drag.html -->
+<!-- ORIGINAL: view/applet-tests/point/propI2-L-drag/original.html (propI2 slate1 — first applet) -->
+<!--
+  propI2 slate1 = the FIRST <applet> on
+  http://aleph0.clarku.edu/~djoyce/java/elements/bookI/propI2.html
+  ("slate1" is 1-indexed; this is the applet inside <div id="ap1">).
+  Identical params to original.html — this applet is already at a
+  suitable size for side-by-side comparison, no trim needed.
+
+  Bug being demonstrated (issue #41): every point labeled L/E/F/G/H/K
+  is a `point;last;...` reference to an existing line endpoint. In
+  Java, Slate.java sets preexists[eCount]=true for these (cases 4/5),
+  so rotateCoordinates skips them (their parent line already moves
+  them). The TS port's preexists heuristic checks indexOf in
+  _elements, but line endpoints were never registered individually,
+  so preexists stays false and rotateCoordinates double-moves them
+  — scaling the whole scene when any free point (A/B/C) is dragged.
+  Compare drag-A behavior in windows 1/2 (Java — clean) vs
+  window 3 (TS — explodes).
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=320 width=340>
+<param name=background value="35,19,100">
+<param name=title value="I.2">
+<param name=e[1] value="A;point;free;160,190">
+<param name=e[2] value="B;point;free;190,160">
+<param name=e[3] value="C;point;free;180,90">
+<param name=e[4] value="BC;line;connect;B,C">
+<param name=e[5] value="DAB;polygon;equilateralTriangle;A,B;0;0;0;0">
+<param name=e[6] value="D;point;vertex;DAB,3;black;green">
+<param name=pivot value="D">
+<param name=e[7] value="AL;line;extend;D,A,B,C">
+<param name=e[8] value="L;point;last;AL">
+<param name=e[9] value="LE;line;extend;A,L,A,B">
+<param name=e[10] value="E;point;last;LE;black;0">
+<param name=e[11] value="BG;line;extend;D,B,B,C">
+<param name=e[12] value="G;point;last;BG">
+<param name=e[13] value="GF;line;extend;B,G,A,B">
+<param name=e[14] value="F;point;last;GF;black;0">
+<param name=e[15] value="CGH;circle;radius;BC;0;0;0;0">
+<param name=e[16] value="BH;line;extend;G,B,G,B;0;0;0">
+<param name=e[17] value="H;point;last;BH;black;0">
+<param name=e[18] value="GKL;circle;radius;D,G;0;0;black;darker">
+<param name=e[19] value="CGH*;circle;radius;BC;0;0;black;brighter">
+<param name=e[20] value="DK;line;extend;G,D,G,D;0;0;0">
+<param name=e[21] value="K;point;last;DK;black;0">
+<param name=e[22] value="DAB*;polygon;equilateralTriangle;A,B;0;0;black;random">
+</applet>
+</BODY></HTML>

--- a/view/applet-tests/point/propI2-L-drag/original.html
+++ b/view/applet-tests/point/propI2-L-drag/original.html
@@ -1,0 +1,48 @@
+<HTML><HEAD><TITLE>propI2 slate1 — L-drag instability reproducer (original)</TITLE></HEAD>
+<BODY BGCOLOR=ffe9cd>
+<!--
+  Unmodified extraction of propI2 slate1 — the FIRST <applet> on
+  http://aleph0.clarku.edu/~djoyce/java/elements/bookI/propI2.html
+  ("slate1" = 1-indexed first slate, inside <div id="ap1">). The only
+  edit is the codebase path so appletviewer can find Geometry.zip.
+
+  Reproducer for issue #41: every point labeled L, E, F, G, H, K is
+  defined via `point;last;...` — a reference to an already-existing
+  line endpoint. In Java the applet's preexists[] array marks these
+  as references so the rotate-around-pivot loop skips them (their
+  containing line moves them already). The TS port's preexists
+  heuristic (indexOf-in-_elements) misses them because line endpoints
+  aren't registered as individual _elements entries. Result: picking
+  any of these points — especially L, which is visually the furthest
+  from pivot D and so has the largest moment arm — makes the scene
+  double-rotate / scale wildly as you drag. Java: clean rotation.
+-->
+<applet code=Geometry codebase=../../.. archive=Geometry.zip height=320 width=340 name=main>
+<img src=propI2.gif alt="java applet or image">
+<param name=background value="35,19,100">
+<param name=title value="I.2">
+<param name=e[1] value="A;point;free;160,190">
+<param name=e[2] value="B;point;free;190,160">
+<param name=e[3] value="C;point;free;180,90">
+<param name=e[4] value="BC;line;connect;B,C">
+<param name=e[5] value="DAB;polygon;equilateralTriangle;A,B;0;0;0;0">
+<param name=e[6] value="D;point;vertex;DAB,3;black;green">
+<param name=pivot value="D">
+<param name=e[7] value="AL;line;extend;D,A,B,C">
+<param name=e[8] value="L;point;last;AL">
+<param name=e[9] value="LE;line;extend;A,L,A,B">
+<param name=e[10] value="E;point;last;LE;black;0">
+<param name=e[11] value="BG;line;extend;D,B,B,C">
+<param name=e[12] value="G;point;last;BG">
+<param name=e[13] value="GF;line;extend;B,G,A,B">
+<param name=e[14] value="F;point;last;GF;black;0">
+<param name=e[15] value="CGH;circle;radius;BC;0;0;0;0">
+<param name=e[16] value="BH;line;extend;G,B,G,B;0;0;0">
+<param name=e[17] value="H;point;last;BH;black;0">
+<param name=e[18] value="GKL;circle;radius;D,G;0;0;black;darker">
+<param name=e[19] value="CGH*;circle;radius;BC;0;0;black;brighter">
+<param name=e[20] value="DK;line;extend;G,D,G,D;0;0;0">
+<param name=e[21] value="K;point;last;DK;black;0">
+<param name=e[22] value="DAB*;polygon;equilateralTriangle;A,B;0;0;black;random">
+</applet>
+</BODY></HTML>

--- a/view/test/point/propI2-L-drag.html
+++ b/view/test/point/propI2-L-drag.html
@@ -1,0 +1,80 @@
+<html>
+<head>
+    <title>Test View - propI2 slate1 (drag instability reproducer, issue #41)</title>
+</head>
+<body>
+<p>Drag any free point (A, B, or C) — the scene should rotate/scale
+smoothly around the equilateral-triangle apex <b>D</b> (green) which
+is the pivot. In the Java applet (windows 1 &amp; 2 of the three-way
+harness) the rotation is visually stable. In the TS port before the
+fix for issue #41, dragging A even a small amount balloons the
+outer circle <i>GKL</i> and the radius circle <i>CGH</i>
+disproportionately — the points labeled L, E, F, G, H, K are all
+<code>point;last;...</code> references to existing line endpoints,
+and a missing preexists flag caused them to be moved twice in the
+rotation loop.</p>
+
+<canvas id="canvasId" style="width:340px; height: 320px;"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+
+<!--applet code=Geometry codebase="../../Geometry" archive=Geometry.zip height=320 width=340>
+<param name=background value="35,19,100">
+<param name=title value="I.2">
+<param name=e[1] value="A;point;free;160,190">
+<param name=e[2] value="B;point;free;190,160">
+<param name=e[3] value="C;point;free;180,90">
+<param name=e[4] value="BC;line;connect;B,C">
+<param name=e[5] value="DAB;polygon;equilateralTriangle;A,B;0;0;0;0">
+<param name=e[6] value="D;point;vertex;DAB,3;black;green">
+<param name=pivot value="D">
+<param name=e[7] value="AL;line;extend;D,A,B,C">
+<param name=e[8] value="L;point;last;AL">
+<param name=e[9] value="LE;line;extend;A,L,A,B">
+<param name=e[10] value="E;point;last;LE;black;0">
+<param name=e[11] value="BG;line;extend;D,B,B,C">
+<param name=e[12] value="G;point;last;BG">
+<param name=e[13] value="GF;line;extend;B,G,A,B">
+<param name=e[14] value="F;point;last;GF;black;0">
+<param name=e[15] value="CGH;circle;radius;BC;0;0;0;0">
+<param name=e[16] value="BH;line;extend;G,B,G,B;0;0;0">
+<param name=e[17] value="H;point;last;BH;black;0">
+<param name=e[18] value="GKL;circle;radius;D,G;0;0;black;darker">
+<param name=e[19] value="CGH*;circle;radius;BC;0;0;black;brighter">
+<param name=e[20] value="DK;line;extend;G,D,G,D;0;0;0">
+<param name=e[21] value="K;point;last;DK;black;0">
+<param name=e[22] value="DAB*;polygon;equilateralTriangle;A,B;0;0;black;random">
+</applet-->
+<script type="text/javascript">
+    geomlib.init({
+        background: "35,19,100",
+        title: "I.2",
+        canvasid: "canvasId",
+        pivot: "D",
+        elements: [
+            "A;point;free;160,190",
+            "B;point;free;190,160",
+            "C;point;free;180,90",
+            "BC;line;connect;B,C",
+            "DAB;polygon;equilateralTriangle;A,B;0;0;0;0",
+            "D;point;vertex;DAB,3;black;green",
+            "AL;line;extend;D,A,B,C",
+            "L;point;last;AL",
+            "LE;line;extend;A,L,A,B",
+            "E;point;last;LE;black;0",
+            "BG;line;extend;D,B,B,C",
+            "G;point;last;BG",
+            "GF;line;extend;B,G,A,B",
+            "F;point;last;GF;black;0",
+            "CGH;circle;radius;BC;0;0;0;0",
+            "BH;line;extend;G,B,G,B;0;0;0",
+            "H;point;last;BH;black;0",
+            "GKL;circle;radius;D,G;0;0;black;darker",
+            "CGH*;circle;radius;BC;0;0;black;brighter",
+            "DK;line;extend;G,D,G,D;0;0;0",
+            "K;point;last;DK;black;0",
+            "DAB*;polygon;equilateralTriangle;A,B;0;0;black;random",
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Fixes issue #41 — the `propI2 slate1` drag instability where picking any
non-draggable point (L, E, F, G, H, K — all `point;last` on a
`line;extend`-produced LineElement) around pivot D made the diagram
visibly shear/scale instead of rotating cleanly. Root cause was in
`Slate.rotateCoordinates` and the Java→TS deduping of shared
references; the fix is a 2-line change in `Slate.ts` plus regression
tests.

## What's in this branch

- `40695e7` issue #41: add propI2 slate1 to 3-way harness (L-drag bug repro)
- `178e3af` fix #41: rotateCoordinates must iterate _elements + call update() after

The repro commit lands first so a reviewer can checkout `40695e7`,
run `./run_euclid_applet.sh`, pick `point;propI2-L-drag`, and see the
Java applet (windows 1 & 2) rotating cleanly while the TS port
(window 3) shears the scene. Checkout `178e3af` and re-run — all
three windows agree.

## Bug details

Picking a non-draggable point with `AP.pivot` set routes through
`Slate.movePick`'s rotate branch. Two bugs compounded there:

1. **Wrong iteration scope.** The rotate loop walked
   `_elementsForUpdate` — a subset that excludes bare-reference entries
   added via `createElement`'s final push (first/last/center/etc.).
   Java's equivalent walks the full `element[]` (`Slate.java` 843-845).
   Fix: iterate `_elements`, same rule `translateCoordinates` already
   uses.

2. **Missing `update()` after the direct rotation.** Java's `element[]`
   carries duplicate entries for shared objects: a `Layoff` created by
   `line;extend` sits at its own index with `preexists=false` (rotates
   directly) *and* at a second index from `point;last` with
   `preexists=true` (skipped). The Layoff ends up rotated exactly once.
   The TS port dedupes `_elements`, so a shared Layoff has one entry
   marked `preexists=true` and the rotate loop skips it — and its
   parent bare `LineElement` has a no-op `rotate()`, so *nothing*
   moves the Layoff directly. Fix: call `this.update()` at the end of
   `rotateCoordinates`; `Layoff.update()` re-derives its position from
   its (now-rotated) parents, giving the same result the direct
   rotation would because rotation is a linear operation.

## Files touched

- `src/Slate.ts` — 2-line fix in `rotateCoordinates` (+ comments)
- `tests/SlateTest.ts` — new describe block
  `drag coordinates: propI2 slate1 (issue #41)` with 2 tests
- `view/applet-tests/point/propI2-L-drag/{original,applet}.html` — 3-way
  harness entry
- `view/test/point/propI2-L-drag.html` — TS test page for firefox
  container window

## Tests

- **Unit: 135 → 137 passing.** Two new tests in the
  `propI2 slate1 (issue #41)` describe block:
  1. `dragging L rotates every derived point, not only the free A/B/C` —
     asserts L lands at drop target, pivot D unchanged, and every one
     of A/B/C/E/G/F/H/K moved by > 5 px.
  2. `L stays on the ray DA after the drag (Layoff invariant)` —
     asserts L remains collinear with D→A (within 0.5 px) so the
     `point;last;extend(D,A,B,C)` semantic is preserved after rotation.
- **Snapshot: 671 passing** against existing golden baselines, so
  nothing else regressed. (The existing snapshot drags hit free
  points only, which rotated correctly before and after; the fix
  changes behavior for the non-draggable-point path that no
  snapshot test currently exercises — a follow-up could extend
  `SnapshotTest.ts`'s candidate pool to cover that path.)
- `npx tsc --noEmit` clean.

## Verification

- [x] `npm run build` clean
- [x] `npm test` passes (137/137 unit + 671/671 snapshot)
- [x] `npx webpack` rebuilds `dist/bundle.js`
- [x] Three-way harness (`./run_euclid_applet.sh` → pick
      `point;propI2-L-drag`) — compare windows 1/2 (Java) vs 3 (TS)
      before and after the fix commit
- [x] Free-point A/B/C drags in propI2 slate1 still behave (they went
      through the `draggable` branch, not rotate, so shouldn't change —
      worth a spot check)
- [x] Pivot-rotate scenes in other propositions still look right
      (buildPivotScene test already covers this programmatically)

## What I considered but didn't ship

- I initially reached for a `preexistsResult` flag on `Construction`
  and marked First/Last/Center/Vertex/PointPerpendicular/AmbientPlane/
  Face as preexists=true, to sidestep double-rotation on Bichord/Chord/
  Perpendicular endpoints. Ripping those changes out and just adding
  the `update()` call made all tests pass — the recompute from
  rotated parents is idempotent with a correct direct rotation, so the
  preexists refinement was redundant. Kept the simpler diff.
- Not extending the snapshot suite to drag non-draggable points; that
  would be a meaningful improvement to the regression coverage but is
  a separate piece of work.
- Separately, there's a note in `doc/construction-tracker.md` about
  the `preexists` tracking heuristic being "missing" — this PR doesn't
  close that out, but the symptom described there (xyplane
  parallelogram growing on 3D pivot rotation) is likely the same
  class of bug and may benefit from the same `update()`-after-rotate
  treatment. Worth checking in a follow-up.
