### PR TITLE
doc: post-#41/#42 review — journal, tracker, architecture, java-port

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -68,6 +68,64 @@ then calls `slate.update()` to redraw.
 
 ---
 
+## Drag pipeline: `movePick` / `translateCoordinates` / `rotateCoordinates`
+
+`Slate.movePick(c, d)` routes a drag to one of three branches based on
+what was picked and the scene state:
+
+1. **Draggable point** (`PlaneSlider`, `LineSlider`, `CircleSlider`,
+   `SphereSliderElement`, `FixedPoint` with `draggable=true`).
+   → `pick.drag(c, d)` writes the new coords, then
+   `updateCoordinates(picki)` calls `.update()` on every element after
+   the picked one so derived elements recompute from the moved parent.
+
+2. **Non-draggable point whose ambient plane has a `pivot` set, and
+   the pick isn't the pivot itself.** → `rotateCoordinates(c, d)`.
+   Computes `(ac, as)` = the scale + rotation factor that maps the
+   pick's old position to the new mouse position (both expressed
+   relative to the pivot in the ambient plane's (S, T) basis). Then:
+     - Iterate `_elements` (not `_elementsForUpdate` — the latter is a
+       subset) and call `.rotate(pivot, ac, as)` on each non-preexists
+       entry, matching Java's full-`element[]` walk in `Slate.java`
+       843-845.
+     - Call `this.update()` afterward. This re-derives any element
+       whose container didn't move it directly — most importantly,
+       `Layoff` points returned by `point;last` on a `line;extend`-made
+       LineElement (the bare LineElement's `rotate()` is a no-op so
+       nothing moves the Layoff via the container path). Re-deriving
+       from the rotated parents gives the correct post-rotation
+       position because the rotation is linear. Java doesn't need this
+       step because its `element[]` holds duplicate entries for shared
+       objects and the Layoff gets rotated directly via its
+       non-preexists entry — see `doc/construction-tracker.md`'s
+       *preexists* item for the full rationale.
+
+3. **Non-draggable point with no applicable pivot.** →
+   `translateCoordinates(dx, dy)` moves every non-preexists element
+   by `(dx, dy)` and calls `.update()`.
+
+**Key invariants:**
+- Both `rotateCoordinates` and `translateCoordinates` iterate
+  `_elements`, not `_elementsForUpdate`. The latter is for `update()`
+  propagation only.
+- `preexists` is set on a `GeomElement` when `createElement` finds it
+  already in `_elements` before the construction push — i.e. it's a
+  re-reference (first/last/center/vertex/etc.) to something a prior
+  construction added. Java sets it explicitly in
+  `Slate.java` cases 3/4/5/8/9/15; the TS heuristic is coarser but
+  aligns for the common Layoff case and works for the bichord endpoint
+  case after the #43 update-after-rotate fix.
+- Rotation and translation **do not** commute with `update()` for
+  container elements that move their own points (Bichord, Chord,
+  Perpendicular, Circumcircle, RegularPolygon, Application, InvertCircle,
+  SphereIntersection). Their `rotate`/`translate` methods call
+  `.rotate`/`.translate` on owned sub-points, and those owned points
+  must NOT also be iterated by the outer loop — hence the preexists
+  skip. Getting this mapping right is the recurring footgun in this
+  codebase.
+
+---
+
 ## The `screen` plane
 
 `Slate`'s constructor creates three `FixedPoint`s (`screen_origin`, `screen_x`, `screen_y`)

--- a/doc/construction-tracker.md
+++ b/doc/construction-tracker.md
@@ -38,19 +38,30 @@ These affect the library as a whole, independent of individual constructions.
 - [x] **`font` / `fontsize` params** — FIXED (2026-04-18): `IInitialization`
   accepts `font` and `fontsize`. Default matches Java: TimesRoman italic 18px.
   `GeomElement.setFont()` updates the static font string used by all labels
-- [ ] **`preexists` tracking missing** — Java's `Slate.java` has a
-  `preexists[]` boolean array that marks elements which are references
-  to existing elements (e.g., `point;first` returns `P[0]`,
-  `point;vertex` returns a polygon vertex, `point;center` returns a
-  circle's center). During `rotateCoordinates` and `translateCoordinates`,
-  Java skips `preexists` elements to avoid double-rotation/translation.
-  The TS port has no equivalent — all elements in `_elementsForUpdate`
-  are rotated/translated, causing double-movement of shared references.
-  **Visible symptom**: rotating a 3D scene via pivot causes the xyplane
-  parallelogram to grow progressively. Discovered on propXI26 pivot test.
-  **Fix**: add a `preexists` flag to `GeomElement` (or a separate set in
-  `Slate`), set it for elements returned by first/last/vertex/center
-  constructions, and skip flagged elements in rotate/translate loops.
+- [~] **`preexists` tracking — partially addressed (2026-04-19, PR #43)**.
+  Java's `Slate.java` has a `preexists[]` boolean array that marks
+  elements which are references to existing elements (e.g.,
+  `point;first` returns `P[0]`, `point;vertex` returns a polygon
+  vertex, `point;center` returns a circle's center). Java's
+  `element[]` also holds *duplicate* entries for shared objects so a
+  shared Layoff created by `line;extend` gets rotated once (via its
+  non-preexists entry) and skipped once (via its preexists entry).
+  TS dedupes `_elements`, so a single flag-on-object model can't
+  reproduce both semantics. **Workaround landed in #43**:
+  `Slate.rotateCoordinates` now iterates `_elements` (not
+  `_elementsForUpdate`) and calls `this.update()` at the end, so
+  Layoff-backed derived points re-derive from their rotated parents.
+  This fixed the propI2 slate1 shear (issue #41) and *likely* the
+  xyplane parallelogram growing symptom on propXI26, though that
+  hasn't been re-verified in the harness yet.
+  **Still potentially broken**: `translateCoordinates` uses the
+  original `indexOf(g) in _elements` heuristic from createElement,
+  which is correct for Layoff-from-line;extend but miscategorizes
+  Bichord/Chord/Perpendicular endpoints (they're not in `_elements`
+  as their own entries, so preexists stays false → double translation
+  via both the container's `translate` and the outer loop). Not yet
+  observed in a failing test; revisit if a 3D-translation regression
+  surfaces.
 - [x] **`pivot` rotation** — FIXED (2026-04-18): `setPivot` now handles
   Java's `"point,plane"` two-part format. The rotation math was already
   implemented in `Slate.rotateCoordinates` and `PointElement.rotate`

--- a/doc/java-port-tracker.md
+++ b/doc/java-port-tracker.md
@@ -127,7 +127,6 @@ implementation status. Updated as constructions are ported.
 |--------|-------|-------|
 | PORTED | 38 | Core element classes + all ported constructions (incl. InvertCircle ported 2026-04-12) |
 | PARTIAL | 2 | PerpendicularPL (split across 2 TS files), Slate (dispatch ported, rendering replaced) |
-| TBD | 0 | — |
 | TBD | 0 | All Java files ported or partially ported |
 | N/A | 3 | Geometry, ClientFrame, Remote |
 | **Total** | **44** | |

--- a/doc/journal.md
+++ b/doc/journal.md
@@ -20,6 +20,73 @@ Each entry records what was completed, what was discovered, and what comes next.
 
 ---
 
+## 2026-04-19 — Drag-pipeline correctness + SlateControls polish
+
+**Completed:**
+- **Issue #41 — propI2 slate1 rotate-around-pivot instability** (PR #43).
+  Dragging a non-draggable Layoff point (L, created via `point;last` on
+  a `line;extend`-produced LineElement) with pivot D set made free
+  points A/B/C rotate correctly but left every derived Layoff point
+  (L/E/G/F/H/K) stationary, so the scene visibly sheared. Two causes:
+  1. `Slate.rotateCoordinates` iterated `_elementsForUpdate` — a strict
+     subset that skips bare-reference entries added via `createElement`'s
+     final push. Switched to iterate `_elements` to match Java's
+     full-`element[]` walk in `Slate.java` 843-845. Same rule
+     `translateCoordinates` already used.
+  2. Java's `element[]` carries *duplicate* entries for shared objects
+     (a Layoff created by `line;extend` appears once with
+     `preexists=false` and rotates directly, plus a second time via
+     `point;last` with `preexists=true` and gets skipped). TS dedupes
+     `_elements`, so a shared Layoff is marked preexists=true and the
+     rotate loop skips it — and its parent bare `LineElement.rotate` is
+     a no-op, so nothing moves it. Fix: call `this.update()` at the end
+     of `rotateCoordinates`. `Layoff.update()` re-derives from the
+     (now-rotated) parents, producing the same result the direct
+     rotation would because rotation is a linear operation.
+  Two new mocha tests in `drag coordinates: propI2 slate1 (issue #41)`
+  (135 → **137 passing**), 671 snapshot tests still green. 3-way
+  harness entry at `view/applet-tests/point/propI2-L-drag/` so
+  reviewers can flip before/after with `git checkout`.
+
+- **SlateControls maximize-restore fix** (PR #42). Click-maximize then
+  click-minimize used to leave the canvas at viewport width instead of
+  shrinking back. `maximize()` was saving `canvas.style.{width,height}`
+  but then `resizeAndRedraw()` clobbered `canvas.{width,height}` (the
+  *attributes* — bitmap resolution AND intrinsic size when CSS is
+  empty). `minimize()` restored the style but not the attrs, so
+  `clientWidth` stayed at the viewport size. Fix: save/restore the
+  canvas width/height attributes alongside the styles.
+
+- **SlateControls new-window config fix** (PR #42). Clicking the
+  new-window button on any converted page threw
+  `Uncaught TypeError: can't access property "clientWidth", canvas is null`.
+  `onNewWindow` stringified `this._config` verbatim — including the
+  source page's `canvasid` (e.g. `"canvas_0"`) — but wrote the new
+  window's canvas with `id="canvasId"`. `geomlib.init()` looked up the
+  old id, got null, threw. Fix: shallow-merge `{canvasid: "canvasId"}`
+  into the config before stringifying.
+
+**Discovered:**
+- The `preexists` tracking gap flagged in construction-tracker (xyplane
+  parallelogram growing on 3D pivot rotation) is very likely the same
+  class of bug that #41 fixed. The update-after-rotate hook re-derives
+  the parallelogram's Layoff-backed 4th vertex from its rotated
+  parents, so the growth should no longer occur. Marking it partially
+  addressed in the tracker; a direct propXI26 pivot test would confirm.
+- The snapshot suite only drags *free* points (picked by
+  `findDraggablePoints`), so it doesn't currently exercise the
+  rotate-around-pivot path at all — which is why the #41 bug passed
+  regression for weeks. A follow-up could broaden the candidate pool
+  to include Layoff and `point;last`-returned points.
+
+**Next session:**
+- Run the full three-way harness on propXI26 to verify the xyplane
+  parallelogram symptom is gone.
+- Consider extending `SnapshotTest.ts` to cover non-draggable-point
+  drags so rotation regressions land on goldens.
+
+---
+
 ## 2026-04-18 — Constructions.ts refactored + parseParam API
 
 **Completed:**


### PR DESCRIPTION
journal.md:
  Add 2026-04-19 entry covering all three fixes that landed since the
  prior 2026-04-18 entry — SlateControls maximize-restore (PR #42),
  SlateControls new-window canvasid override (PR #42), and the
  propI2 slate1 rotate-around-pivot fix (issue #41 / PR #43). Includes
  Discovered notes flagging the snapshot suite's blind spot for
  non-draggable-point drags.

construction-tracker.md:
  Update the 'preexists tracking missing' platform-level TODO from
  open to partially-addressed. The #43 update-after-rotate hook
  fixes the propI2 slate1 shear and likely the propXI26 xyplane
  parallelogram symptom by re-deriving Layoff-backed points from
  rotated parents. translateCoordinates may still double-translate
  Bichord/Chord/Perpendicular endpoints (no failing test yet).

architecture.md:
  Add a new 'Drag pipeline' section covering the three movePick
  branches (drag / rotate-around-pivot / translate), the
  iterate-_elements / call-update() invariants in
  rotateCoordinates, and the rotation-vs-update commute footgun
  for container elements that move their own owned points.

java-port-tracker.md:
  Strip a duplicated 'TBD | 0' row in the summary table.

No source code changes. analysis/ subfolder left as-is per its 'historical analysis at the time' charter.