### PR TITLE
Doc/architecture refresh

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -1,0 +1,537 @@
+# Public API Reference
+
+This document is the reference for the public surface of `geomlib` — the
+TypeScript port of David Joyce's Geometry Applet (1996, version 2.2). It
+maps every accepted parameter, every construction enum value, and every
+helper to its source location in `src/`, with the original Java applet
+contract in `geom_applet/source/Geometry.html` and `tables.html` as the
+authoritative behavior reference.
+
+For "how the pieces fit together" see [architecture.md](architecture.md).
+For "how to add a new construction" see
+[creating-constructions.md](creating-constructions.md).
+
+---
+
+## Quick start
+
+```html
+<canvas id="myCanvas" style="width:340px; height:320px;"></canvas>
+<script src="dist/bundle.js"></script>
+<script>
+let E = geomlib.E;
+geomlib.init({
+    background: "35,19,100",
+    title: "I.1",
+    canvasid: "myCanvas",
+    pivot: "C",
+    elements: [
+        { name: "A",   construction: E.Point.free,   params: [125, 130] },
+        { name: "B",   construction: E.Point.free,   params: [215, 130] },
+        { name: "AB",  construction: E.Line.connect, params: ["A", "B"] },
+        { name: "Ac",  construction: E.Circle.radius, params: ["A", "B"] },
+        { name: "Bc",  construction: E.Circle.radius, params: ["B", "A"] },
+        { name: "CD",  construction: E.Line.bichord, params: ["Bc", "Ac"] },
+        { name: "C",   construction: E.Point.first,  params: ["CD"] },
+        { name: "ABC", construction: E.Polygon.triangle, params: ["A","B","C"] },
+    ],
+});
+</script>
+```
+
+The canvas can be any size. `init()` matches `canvas.width/height`
+attributes to its `clientWidth/clientHeight` once at startup so the bitmap
+resolution is sharp at the CSS size you set.
+
+`elements:` accepts either object form (above) or Joyce's original Java
+`<param>` strings — see [`parseParam()`](#parseparam) below.
+
+---
+
+## Top-level exports — `dist/bundle.js`
+
+When loaded via the webpack UMD bundle, everything is on the global
+`geomlib`. When imported via TypeScript:
+
+```typescript
+import { init, parseParam, E, Align, slates, Color,
+         IInitialization, IConstructionInfo } from "geomlib";
+```
+
+| Export | File | Description |
+|---|---|---|
+| `init(config)` | `src/index.ts` | Build a slate from an `IInitialization` config. Reads the canvas by `canvasid`, sets up the screen plane, instantiates each element in order, and injects the SlateControls UI overlay. |
+| `parseParam(s)` | `src/index.ts` | Convert a Java applet `<param value="…">` string into an `IConstructionInfo` object. |
+| `E` | `src/elements/Constructions.ts` | Construction enum accessor: `E.Point.free`, `E.Line.connect`, `E.Circle.radius`, … See the [construction tables](#construction-tables) below. |
+| `Align` | `src/elements/GeomElement.ts` | Label-placement enum: `ABOVE`, `BELOW`, `LEFT`, `RIGHT`, `CENTRAL`. |
+| `Color` | `src/Colors.ts` | Color helpers (`parseColor`, `lighten`, `darken`, `randomColor`). |
+| `slates: Slate[]` | `src/index.ts` | Mutable array of every Slate instance `init()` has created. Each call to `init()` appends one. Multiple canvases on the same page get one entry each. |
+| `IInitialization` | `src/index.ts` | TypeScript type of `init()`'s argument. |
+| `IConstructionInfo` | `src/index.ts` | TypeScript type of one element entry inside `elements:`. |
+
+---
+
+## `init(config: IInitialization)`
+
+Defined at [src/index.ts:97](../src/index.ts#L97). Builds one
+`Slate` per call.
+
+### `IInitialization` fields
+
+```typescript
+interface IInitialization {
+    background : string;
+    title : string;
+    align? : Align;
+    canvasid? : string;
+    pivot?: string;
+    font?: string;
+    fontsize?: number;
+    elements: (IConstructionInfo | string)[];
+}
+```
+
+| Field | Java applet param | Default | Description |
+|---|---|---|---|
+| `background` | `background` | `"#ffffff"` | Canvas fill. Same string grammar as element colors — see [Colors](#colors). HSB triples like `"35,19,100"` are valid. |
+| `title` | `title` | `""` | Title shown when the diagram is opened in a separate window via the new-window button. Stored on the Slate; not currently rendered on the canvas itself (open platform TODO). |
+| `align` | `align` | `Align.CENTRAL` | Default label placement applied to every element. CENTRAL chooses ABOVE/BELOW/LEFT/RIGHT dynamically based on the label's quadrant relative to the canvas center. |
+| `canvasid` | (none — applet's host element) | `"canvasid"` | DOM `id` of the `<canvas>` to draw into. |
+| `pivot` | `pivot` | (no pivot) | Name of a point used as the rotation/scale center when the user drags a non-draggable point. Two-part form `"P,plane"` pivots on a non-screen plane (3D). See [Drag pipeline](architecture.md#drag-pipeline-movepick--translatecoordinates--rotatecoordinates). |
+| `font` | `font` | `"Times New Roman"` | Font family for element labels. Set globally on `GeomElement` via `GeomElement.setFont()`. Java default is `"TimesRoman"`. |
+| `fontsize` | `fontsize` | `18` | Pixel size for the label font. |
+| `elements` | `e[1]`, `e[2]`, … | (required) | Ordered list of element specs. May mix `IConstructionInfo` objects and Java param strings. |
+
+`debug` from the Java applet is not implemented in the TS port.
+
+### `IConstructionInfo` (one element)
+
+```typescript
+interface IConstructionInfo {
+    name: string;
+    construction: AllConstructions;     // E.Point.free, E.Line.connect, …
+    params: any[];
+    nameColor?: string | number;
+    vertexColor?: string | number;
+    edgeColor?: string | number;
+    faceColor?: string | number;
+}
+```
+
+| Field | Java field | Description |
+|---|---|---|
+| `name` | the leading `Name` in `"Name;type;cons;…"` | Identifier used to reference this element from later constructions. Must be unique per slate. |
+| `construction` | the `type;construction` pair | A value from the `E` enum. Selects the dispatcher. |
+| `params` | the comma-separated `arg1,arg2,…` field | Mixed array of strings (element names) and numbers. Strings are looked up on the slate; if they resolve to a `LineElement`, that line is auto-expanded into its two endpoint `PointElement`s in the parameter list. See [convertParams](architecture.md#convertparams--the-type-sort-step). |
+| `nameColor` | 1st color field | Color of the rendered name label. |
+| `vertexColor` | 2nd color field | Color of the vertex dot (point) or vertices (polygon corners). |
+| `edgeColor` | 3rd color field | Color of the line/arc/edge layer. |
+| `faceColor` | 4th color field | Fill color for filled shapes (polygon, sector, filled circle). |
+
+If a color field is omitted, a sensible default is chosen at
+[src/index.ts:122-136](../src/index.ts#L122) based on the element type
+(see [Colors](#colors) below).
+
+### Defaults applied per element
+
+After each element is constructed, `init()` sets:
+
+- `element.align = config.align` (default `Align.CENTRAL`).
+- `element.nameColor` — `"black"` for points, `null` for everything else,
+  unless overridden by the `nameColor` field.
+- `element.vertexColor` — `"red"` for free `PlaneSlider` points,
+  `"orange"` for other draggable points, `"black"` for non-draggable,
+  unless overridden.
+- `element.edgeColor` — `"black"` unless overridden.
+- `element.faceColor` — a `lighten(background)` shade for 2D-dimension
+  elements (polygons, sectors, filled circles), `null` for 0D/1D, unless
+  overridden.
+
+Numeric `0` in a color field means "transparent / don't draw this layer"
+— the corresponding `draw…()` call short-circuits.
+
+---
+
+## `parseParam(s: string)`
+
+Defined at [src/index.ts:46](../src/index.ts#L46). Converts a Java applet
+`<param value="…">` string into one `IConstructionInfo`.
+
+### Format
+
+```
+"Name;type;construction;arg1,arg2,…[;nameColor[;vertexColor[;edgeColor[;faceColor]]]]"
+```
+
+Fields are separated by `;`. The fourth field uses `,` to separate args.
+
+| Position | Field | Example |
+|---|---|---|
+| 0 | `Name` | `M` |
+| 1 | `type` | `point` (mapped to enum class `Point`) |
+| 2 | `construction` | `midpoint` (mapped to enum value `E.Point.midpoint`) |
+| 3 | `args` (CSV) | `A,B` (each piece becomes an entry in `params[]`) |
+| 4 | `nameColor` | `0` or `"black"` or `"#ff00ff"` |
+| 5 | `vertexColor` | as above |
+| 6 | `edgeColor` | as above |
+| 7 | `faceColor` | as above |
+
+### Type → enum mapping
+
+```typescript
+"point"      → E.Point
+"line"       → E.Line
+"circle"     → E.Circle
+"polygon"    → E.Polygon
+"sector"     → E.Sector
+"plane"      → E.Plane
+"sphere"     → E.Sphere
+"polyhedron" → E.Polyhedra        // note: Java says "polyhedron",
+                                  //       TS enum is "Polyhedra"
+```
+
+Construction names match Java exactly **except** Java's `3points`
+(plane construction) maps to `E.Plane.threePoints` — JavaScript
+identifiers can't start with a digit.
+
+### Args parsing
+
+Each CSV entry in field 3 is converted: numeric strings (per
+`Number()`) become `number`s, everything else stays a `string`. So
+`"A,B,150,140"` becomes `["A","B",150,140]`.
+
+### Mixing object and string forms
+
+`init({ elements: [...] })` accepts both at once:
+
+```javascript
+geomlib.init({
+    background: "35,19,100",
+    canvasid: "myCanvas",
+    elements: [
+        "A;point;free;125,130",                                 // string
+        { name: "B", construction: E.Point.free, params: [215, 130] },  // object
+        "AB;line;connect;A,B",                                  // string
+    ],
+});
+```
+
+The string form is convenient when porting a Java HTML page — copy
+each `<param value="…">` value directly into the elements array.
+
+---
+
+## `E` — construction enum accessor
+
+`E` is a fixed object (not a function) exporting the eight construction
+enums:
+
+```typescript
+E.Point      // PointConstructions
+E.Line       // LineConstructions
+E.Circle     // CircleConstructions
+E.Polygon    // PolygonConstructions
+E.Sector     // SectorConstructions
+E.Plane      // PlaneConstructions
+E.Sphere     // SphereConstructions
+E.Polyhedra  // PolyhedraConstructions     (note: not "Polyhedron")
+```
+
+Each is a string-keyed numeric enum. `E.Point.free === 1`,
+`E.Line.connect === 101`, `E.Circle.radius === 201`, etc. The numeric
+ranges are 1-99 (point), 101-199 (line), 201-299 (circle), 301-399
+(polygon), 401-499 (sector), 501-599 (plane), 601-699 (sphere),
+701-799 (polyhedron), so the type can be recovered from the value.
+
+The construction tables below list every legal `E.{Type}.{name}`.
+
+---
+
+## `Align`
+
+```typescript
+enum Align {
+    ABOVE  = 0,
+    RIGHT  = 1,
+    BELOW  = 2,
+    LEFT   = 3,
+    CENTRAL = 4,   // default
+}
+```
+
+`init({ align: Align.CENTRAL })` is the Java applet's default. CENTRAL
+places each label dynamically away from the canvas center based on the
+quadrant the element occupies. ABOVE/RIGHT/BELOW/LEFT are static.
+
+Per-element align overrides are not yet supported (`IConstructionInfo`
+has no `align` field). Tracked under platform TODOs in
+[construction-tracker.md](construction-tracker.md).
+
+---
+
+## Colors
+
+`parseColor(s, defaultColor, bgcolor)` at
+[src/Colors.ts](../src/Colors.ts) accepts every form Java's
+`Geometry.html` documents:
+
+| Input | Result |
+|---|---|
+| Named CSS color (`"black"`, `"red"`, `"darkGray"`, …) | Java's color table values, exact RGB. Includes the Java additions `"darkGray"`, `"lightGray"`, `"gray"`. |
+| 6-hex-digit `#rrggbb` or `rrggbb` | The exact RGB. |
+| Comma-triple `"H,S,B"` (e.g. `"35,19,100"`) | HSB; H ∈ 0–360, S/B ∈ 0–100. Matches the Java applet's `Color.getHSBColor()` semantics. |
+| `"random"` | Random pastel each call. |
+| `"background"` | `bgcolor`. |
+| `"brighter"` | `lighten(bgcolor)` — Java's `Color.brighter()`, factor 0.7. |
+| `"darker"` | `darken(bgcolor)` — Java's `Color.darker()`, factor 0.7. |
+| `"none"` | `null` (the corresponding draw layer is skipped). |
+| Number `0` | `null` (the Java applet's "transparent" sentinel). |
+| `null` / `undefined` | `defaultColor`. |
+
+Each element has four color slots: name, vertex, edge, face. A `null`
+value means "skip drawing this layer." The default for face on
+non-2D-dimension elements is `null` — points and lines have no fill.
+
+---
+
+## Construction tables
+
+Eight tables, one per element class. Each row shows the TypeScript API
+form, the Java `<param>` form, what arguments the construction takes
+(post-`LineElement` expansion — see
+[convertParams](architecture.md#convertparams--the-type-sort-step)), and
+what it produces.
+
+Conventions:
+
+- Lowercase italic `a`/`b`/`c` denote points; uppercase italic letters
+  match Joyce's `tables.html`.
+- `[plane X]` means the plane is optional — when omitted, the screen
+  plane is used and the construction is 2D. When present, the
+  construction is 3D.
+- Constructions marked **3D-only** can only be used in solid geometry.
+- `LineElement` references in `params` auto-expand to two
+  `PointElement`s. So `params: ["AB", "C"]` where `AB` is a line is
+  equivalent to `params: ["A", "B", "C"]`.
+
+### Point — `E.Point.{name}`
+
+| TS API | Java construction | Construction data | Description |
+|---|---|---|---|
+| `E.Point.free` | `point;free` | integers `x, y` | Freely draggable point in the screen plane at `(x, y, 0)`. |
+| `E.Point.fixed` | `point;fixed` | integers `x, y, [z]` | Fixed (non-draggable) point at `(x, y, z)`. |
+| `E.Point.midpoint` | `point;midpoint` | points `A, B` | Midpoint of segment AB. |
+| `E.Point.intersection` | `point;intersection` | points `A, B, C, D, [plane E]` | Intersection of lines AB and CD in plane E. |
+| `E.Point.intersection` | `point;intersection` (3D-only) | plane `A`, points `B, C` | Intersection of plane A and line BC. |
+| `E.Point.first` | `point;first` | points `A, B` (or one line) | The first endpoint A. Returns an existing point reference (preexists). |
+| `E.Point.last` | `point;last` | points `A, B` (or one line) | The last endpoint B. Returns an existing point reference (preexists). |
+| `E.Point.center` | `point;center` | circle `A` | Center of circle A (preexists). |
+| `E.Point.center` | `point;center` (3D-only) | sphere `A` | Center of sphere A (preexists). |
+| `E.Point.lineSlider` | `point;lineSlider` | points `A, B`, ints `x, y, [z]` | Point that slides along line AB. |
+| `E.Point.circleSlider` | `point;circleSlider` | circle `A`, ints `x, y, [z]` | Point that slides along circle A. |
+| `E.Point.circumcenter` | `point;circumcenter` | points `A, B, C, [plane D]` | Center of the circle through A, B, C. |
+| `E.Point.vertex` | `point;vertex` | polygon `A`, integer `i` | i-th vertex of polygon A (1-indexed; preexists). |
+| `E.Point.foot` | `point;foot` | points `A, B, C` | Foot of perpendicular from A to line BC. |
+| `E.Point.foot` | `point;foot` (3D-only) | point `A`, plane `B` | Foot of perpendicular from A to plane B. |
+| `E.Point.cutoff` | `point;cutoff` | points `A, B, C, D` | Point E on AB so that AE = CD. |
+| `E.Point.extend` | `point;extend` | points `A, B, C, D` | Point E on AB so that BE = CD (extends past B by length CD). |
+| `E.Point.parallelogram` | `point;parallelogram` | points `A, B, C` | 4th vertex D of parallelogram ABCD; D = A + (C − B). |
+| `E.Point.similar` | `point;similar` | points `A, B, D, E, F, [planes C, G]` | Point H so that △ABH (in C) is similar to △DEF (in G). |
+| `E.Point.perpendicular` | `point;perpendicular` | points `A, B, [plane C]` | Point D so AD ⊥ AB and \|AD\| = \|AB\|. |
+| `E.Point.perpendicular` | `point;perpendicular` | points `A, B, D, E, [plane C]` | Point F so AF ⊥ AB and \|AF\| = \|DE\|. |
+| `E.Point.perpendicular` | `point;perpendicular` (3D-only) | points `A, C, D`, plane `B` | Point E on the line ⊥ B through A so dist(E, B) = \|CD\|. |
+| `E.Point.proportion` | `point;proportion` | 8 points `A…H` | Point I on GH so AB:CD = EF:GI. |
+| `E.Point.invert` | `point;invert` | point `A`, circle `B` | Image of A inverted in B. |
+| `E.Point.meanProportional` | `point;meanProportional` | 6 points `A…F` | Point G on EF so AB:CD = CD:EG. |
+| `E.Point.planeSlider` | `point;planeSlider` (3D-only) | plane `A`, ints `x, y, z` | Point that slides on plane A. |
+| `E.Point.sphereSlider` | `point;sphereSlider` (3D-only) | sphere `A`, ints `x, y, z` | Point that slides on sphere A. |
+| `E.Point.angleBisector` | `point;angleBisector` | points `A, B, C, [plane D]` | Intersection of the bisector of ∠BAC with line BC. |
+| `E.Point.angleDivider` | `point;angleDivider` | points `A, B, C, [plane D]`, integer `n` | Point E on BC so ∠BAE = ∠BAC/n. |
+| `E.Point.lineSegmentSlider` | `point;lineSegmentSlider` | points `A, B`, ints `x, y, [z]` | Sliding point clamped to segment AB. |
+| `E.Point.harmonic` | `point;harmonic` | points `B, C, D` | Harmonic conjugate of B w.r.t. C and D. |
+
+### Line — `E.Line.{name}`
+
+| TS API | Java construction | Construction data | Description |
+|---|---|---|---|
+| `E.Line.connect` | `line;connect` | points `A, B` | Line through A and B. |
+| `E.Line.angleBisector` | `line;angleBisector` | points `A, B, C, [plane D]` | Line AE bisecting ∠BAC with E on BC. |
+| `E.Line.angleDivider` | `line;angleDivider` | points `A, B, C, [plane D]`, integer `n` | Line AE so ∠BAE = ∠BAC/n. |
+| `E.Line.foot` | `line;foot` | points `A, B, C` | Line AD ⊥ BC in the screen plane. |
+| `E.Line.foot` | `line;foot` (3D-only) | point `A`, plane `B` | Line AD ⊥ plane B with D on B. |
+| `E.Line.chord` | `line;chord` | points `A, B`, circle `C` | Chord of circle C cut by line AB. |
+| `E.Line.bichord` | `line;bichord` | circles `A, B` | Common chord through the two intersection points of A and B. |
+| `E.Line.perpendicular` | `line;perpendicular` | points `A, B, [plane C]` | Line AD ⊥ AB with \|AD\| = \|AB\|. |
+| `E.Line.perpendicular` | `line;perpendicular` | points `A, B, D, E, [plane C]` | Line AF ⊥ AB with \|AF\| = \|DE\|. |
+| `E.Line.perpendicular` | `line;perpendicular` (3D-only) | points `A, C, D`, plane `B` | Line EF ⊥ plane B through A, length \|CD\|, E on B. |
+| `E.Line.cutoff` | `line;cutoff` | points `A, B, C, D` | Line AE = CD along AB. |
+| `E.Line.extend` | `line;extend` | points `A, B, C, D` | Line BE = CD extending past B; A, B, E collinear. |
+| `E.Line.parallel` | `line;parallel` | points `A, B, C` | Line AD parallel and equal to BC. |
+| `E.Line.similar` | `line;similar` | points `A, B, D, E, F, [planes C, G]` | Line AH where △ABH ∼ △DEF. |
+| `E.Line.proportion` | `line;proportion` | 8 points | Line GI along GH so AB:CD = EF:GI. |
+| `E.Line.meanProportional` | `line;meanProportional` | 6 points | Line EG along EF so AB:CD = CD:EG. |
+
+### Circle — `E.Circle.{name}`
+
+| TS API | Java construction | Construction data | Description |
+|---|---|---|---|
+| `E.Circle.radius` | `circle;radius` | points `A, B, [plane C]` | Circle, center A, radius \|AB\|. |
+| `E.Circle.radius` | `circle;radius` | points `A, B, C, [plane D]` | Circle, center A, radius \|BC\|. |
+| `E.Circle.circumcircle` | `circle;circumcircle` | points `A, B, C, [plane D]` | Circle through A, B, C. |
+| `E.Circle.invert` | `circle;invert` | circles `A, B` | Image of A inverted in B. |
+| `E.Circle.intersection` | `circle;intersection` (3D-only) | spheres `A, B` | Circle at intersection of A and B. |
+
+### Polygon — `E.Polygon.{name}`
+
+| TS API | Java construction | Construction data | Description |
+|---|---|---|---|
+| `E.Polygon.square` | `polygon;square` | points `A, B, [plane C]` | Square on side AB. |
+| `E.Polygon.triangle` | `polygon;triangle` | points `A, B, C` | Triangle ABC. |
+| `E.Polygon.quadrilateral` | `polygon;quadrilateral` | points `A, B, C, D` | Quadrilateral ABCD. |
+| `E.Polygon.pentagon` | `polygon;pentagon` | 5 points | Pentagon (free vertices). |
+| `E.Polygon.hexagon` | `polygon;hexagon` | 6 points | Hexagon (free vertices). |
+| `E.Polygon.equilateralTriangle` | `polygon;equilateralTriangle` | points `A, B, [plane C]` | Equilateral triangle on side AB. |
+| `E.Polygon.parallelogram` | `polygon;parallelogram` | points `A, B, C` | Parallelogram ABCD with D = A + (C − B). |
+| `E.Polygon.regularPolygon` | `polygon;regularPolygon` | points `A, B`, integer `n`, `[plane C]` | Regular n-gon on side AB. |
+| `E.Polygon.starPolygon` | `polygon;starPolygon` | points `A, B`, integers `n, d` | Star polygon {n/d} on side AB. |
+| `E.Polygon.similar` | `polygon;similar` | points `A, B, D, E, F, [planes C, G]` | Triangle ABH ∼ DEF. |
+| `E.Polygon.application` | `polygon;application` | polygon `A`, points `B, C, D` | Parallelogram of equal area to A, with side BC and angle BCD. |
+| `E.Polygon.octagon` | `polygon;octagon` | 8 points | Octagon (free vertices). |
+| `E.Polygon.face` | `polygon;face` (3D-only) | polyhedron `A`, integer `n` | n-th face of polyhedron A (preexists). |
+
+### Sector — `E.Sector.{name}`
+
+| TS API | Java construction | Construction data | Description |
+|---|---|---|---|
+| `E.Sector.sector` | `sector;sector` | points `A, B, C, [plane D]` | Sector with center A, radial points B and C. |
+| `E.Sector.arc` | `sector;arc` | points `A, B, C, [plane D]` | Arc through A, B, C — the circumcircle's arc, drawn as a sector. |
+
+### Plane — `E.Plane.{name}` (all 3D-only)
+
+| TS API | Java construction | Construction data | Description |
+|---|---|---|---|
+| `E.Plane.threePoints` | `plane;3points` | points `A, B, C` | Plane through A, B, C. |
+| `E.Plane.perpendicular` | `plane;perpendicular` | points `A, B` | Plane through A perpendicular to AB. |
+| `E.Plane.parallel` | `plane;parallel` | plane `A`, point `B` | Plane through B parallel to A. |
+| `E.Plane.ambient` | `plane;ambient` | point `A` (or circle `A`) | Ambient plane of A (preexists). |
+
+> **Naming gotcha:** Java says `plane;3points`, the TS enum key is
+> `threePoints` (JavaScript identifiers can't start with a digit).
+> `parseParam` rewrites `"3points"` to `"threePoints"` internally so the
+> string form still works.
+
+### Sphere — `E.Sphere.{name}` (3D-only)
+
+| TS API | Java construction | Construction data | Description |
+|---|---|---|---|
+| `E.Sphere.radius` | `sphere;radius` | points `A, B` | Sphere, center A, radius \|AB\|. |
+| `E.Sphere.radius` | `sphere;radius` | points `A, B, C` | Sphere, center A, radius \|BC\|. |
+
+### Polyhedron — `E.Polyhedra.{name}` (all 3D-only)
+
+| TS API | Java construction | Construction data | Description |
+|---|---|---|---|
+| `E.Polyhedra.tetrahedron` | `polyhedron;tetrahedron` | points `A, B, C, D` | Tetrahedron with the four vertices. |
+| `E.Polyhedra.parallelepiped` | `polyhedron;parallelepiped` | points `A, B, C, D` | Parallelepiped with edges AB, AC, AD. |
+| `E.Polyhedra.prism` | `polyhedron;prism` | polygon `A`, points `B, C` | Prism with base A and side edges parallel and equal to BC. |
+| `E.Polyhedra.pyramid` | `polyhedron;pyramid` | polygon `A`, point `B` | Pyramid with base A and apex B. |
+
+> **Enum-key gotcha:** Java says `polyhedron;…`, the TS enum is
+> `Polyhedra` (no `n`). `parseParam` handles the mapping
+> automatically; if you're constructing `IConstructionInfo` objects by
+> hand, use `E.Polyhedra.…`.
+
+---
+
+## `Slate` — runtime methods
+
+`init()` returns nothing; the constructed `Slate` is appended to
+`geomlib.slates`. To call methods on it post-init:
+
+```javascript
+let slate = geomlib.slates[geomlib.slates.length - 1];
+```
+
+The publicly-useful methods, all defined in
+[src/Slate.ts](../src/Slate.ts):
+
+| Method | Description |
+|---|---|
+| `slate.lookupElement(name)` | Return the `GeomElement` named `name`, or `null`. |
+| `slate.elements` | Read-only view of all elements (in construction order). |
+| `slate.elementsForUpdate` | Read-only view of elements whose `update()` recomputes from parents each frame. Subset of `elements`. |
+| `slate.update()` | Walk `_elementsForUpdate` calling `update()`, then redraw. Use after directly mutating an element's coords. |
+| `slate.reset()` | Restore every element to its construction-time position (sliders rewind to their initial coords) and redraw. Same action as the SlateControls reset button (`r` / `space`). |
+| `slate.setPivot(name)` | Set the rotation pivot. `"P"` for screen-plane pivot, `"P,plane"` for a 3D pivot on a non-screen plane. See [Drag pipeline](architecture.md#drag-pipeline-movepick--translatecoordinates--rotatecoordinates). |
+| `slate.bgcolor` | Get or set the canvas background color. |
+
+Lower-level methods (`createElement`, `convertParams`, `findConstruction`,
+`movePick`, `translateCoordinates`, `rotateCoordinates`,
+`updateCoordinates`) are described in
+[architecture.md](architecture.md).
+
+---
+
+## SlateControls (UI overlay)
+
+`init()` automatically calls `createControls(slate, canvas, config)`
+from [src/SlateControls.ts](../src/SlateControls.ts), which wraps the
+canvas in a relative-positioned `<div>` and overlays three icon
+buttons at the top-right:
+
+| Button | Keyboard | Action |
+|---|---|---|
+| Reset (circular arrow) | `r` or `space` | `slate.reset()`. |
+| Maximize (expand arrows) | `m` | Toggle: fill the viewport (position fixed, 100vw / 100vh, z-index 9999) or restore. |
+| New window (box-with-arrow) | `u` or `return` | Open a new browser window with the same scene maximized. |
+
+Keyboard shortcuts only fire when the canvas itself has focus. The
+overlay can be skipped (e.g. for headless rendering) by passing a
+canvas whose `parentElement` is `null`.
+
+---
+
+## Example: porting a Joyce HTML page
+
+Joyce's `<applet>` block:
+
+```html
+<applet code=Geometry archive=Geometry.zip width=340 height=320>
+<param name=background value="35,19,100">
+<param name=title value="I.2">
+<param name=e[1] value="A;point;free;160,190">
+<param name=e[2] value="B;point;free;190,160">
+<param name=e[3] value="C;point;free;180,90">
+<param name=e[4] value="BC;line;connect;B,C">
+<param name=e[5] value="DAB;polygon;equilateralTriangle;A,B;0;0;0;0">
+<param name=e[6] value="D;point;vertex;DAB,3;black;green">
+<param name=pivot value="D">
+</applet>
+```
+
+Becomes:
+
+```html
+<canvas id="myCanvas" width="340" height="320"></canvas>
+<script src="dist/bundle.js"></script>
+<script>
+geomlib.init({
+    background: "35,19,100",
+    title: "I.2",
+    canvasid: "myCanvas",
+    pivot: "D",
+    elements: [
+        "A;point;free;160,190",
+        "B;point;free;190,160",
+        "C;point;free;180,90",
+        "BC;line;connect;B,C",
+        "DAB;polygon;equilateralTriangle;A,B;0;0;0;0",
+        "D;point;vertex;DAB,3;black;green",
+    ],
+});
+</script>
+```
+
+The sibling `djoyce/convert.py` automates this transformation across
+all of Joyce's published Elements pages. See `djoyce/README.md` for
+the conversion harness.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,5 +1,98 @@
 # Architecture
 
+> **Companion docs:**
+> [api.md](api.md) is the reference for the public surface (every
+> `init()` field, every `E.{Type}.{name}`, every color/align value).
+> [creating-constructions.md](creating-constructions.md) is the
+> step-by-step recipe for adding a new construction. This document is
+> the implementation-level "how the pieces fit together."
+
+## What this library is
+
+`geomlib` is a TypeScript port of David E. Joyce's *Geometry Applet*
+(Clark University, 1996, Java version 2.2). Joyce wrote it to
+illustrate Euclid's *Elements* on the web; it renders interactive
+Euclidean diagrams where the user can drag points and watch all
+derived constructions follow. The original Java applet's overview
+page is mirrored at
+`geom_applet/source/Geometry.html` and its construction reference at
+`geom_applet/source/tables.html`. We aim to be a faithful reimplementation
+of those two contracts on top of the HTML5 `<canvas>` element.
+
+A diagram is described by an ordered list of *elements*. Each element
+belongs to one of **eight classes** — `point`, `line`, `circle`,
+`polygon`, `sector`, `plane`, `sphere`, `polyhedron` — and is built
+by one of that class's *construction methods*. Plane geometry uses the
+first five classes; all eight are needed for solid geometry. Joyce's
+`<param name=e[N] value="…">` schema and our
+`elements: [{...}]` API are two surfaces over the same model.
+
+### Interaction model
+
+Three kinds of points exist on a slate, distinguished by how the user
+can drag them (matching the Java applet's behavior):
+
+- **Free points** (red by default, drawn via `PlaneSlider`). Freely
+  draggable in their ambient plane. The rest of the diagram tracks.
+- **Sliding points** (orange by default — `LineSlider`, `CircleSlider`,
+  `PlaneSlider` on a non-screen plane, `SphereSliderElement`). Draggable,
+  but motion is constrained to a parent line/circle/plane/sphere.
+- **Computed / fixed points** (black by default, or green when used as
+  a *pivot*). Not directly draggable — but grabbing one fires the
+  drag pipeline's *translate* or *rotate-around-pivot* branch instead
+  of moving the point itself, so the whole scene shifts or rotates.
+
+The `r` / `space` keyboard shortcut (also exposed as a SlateControls
+button) calls `Slate.reset()` to restore every element to its
+construction-time position. `m` toggles maximize, `u` / `return`
+opens the same scene in a new window.
+
+### Element schema (one HTML param ↔ one `IConstructionInfo`)
+
+```
+"Name;type;construction;arg1,arg2,…[;nameColor[;vertexColor[;edgeColor[;faceColor]]]]"
+```
+
+- **Name** — slate-unique identifier for later references.
+- **type** — one of the eight element classes.
+- **construction** — the construction method within that class
+  (`free`, `midpoint`, `bichord`, …). The full catalog is
+  [api.md § Construction tables](api.md#construction-tables).
+- **args** — comma-separated. Strings reference earlier elements by
+  name; numbers are integer coordinates or counts. A `LineElement`
+  named in args auto-expands to its two endpoint `PointElement`s
+  (Joyce's "Special note 1": any time two points are needed, one line
+  may be given instead).
+- **colors** (all optional, in order): name, vertex, edge, face. Up to
+  four layers per element. See [Colors](#colors) for the parser rules.
+
+Slate-level params (set on `init()`, not per element):
+`background`, `title`, `align`, `pivot`, `font`, `fontsize`. The
+applet's `debug` flag is not implemented in the TS port.
+
+### Source-file mapping (Java → TypeScript)
+
+| Java class (Geometry.html §Source files) | TS file |
+|---|---|
+| `Geometry.java` (applet entry) | `src/index.ts` |
+| `Slate.java` (canvas + dispatch + drag) | `src/Slate.ts` (rendering on `<canvas>`) + `src/elements/Constructions.ts` (dispatch) |
+| `Element.java` | `src/elements/GeomElement.ts` |
+| `PointElement.java` (+ 17 subclasses) | `src/elements/point/*.ts` |
+| `LineElement.java` (+ Bichord, Chord, Perpendicular, PlanePerpendicular) | `src/elements/line/*.ts` |
+| `CircleElement.java` (+ Circumcircle, InvertCircle, IntersectionSS) | `src/elements/circle/*.ts` |
+| `PolygonElement.java` (+ Application, RegularPolygon) | `src/elements/polygon/*.ts` |
+| `SectorElement.java` (+ Arc) | `src/elements/sector/*.ts` |
+| `PlaneElement.java` (+ ParallelP, PerpendicularPL) | `src/elements/plane/*.ts` |
+| `SphereElement.java` | `src/elements/sphere/SphereElement.ts` |
+| `PolyhedronElement.java` (+ Prism, Pyramid) | `src/elements/polyhedron/*.ts` |
+| `ClientFrame.java` (Java AWT detached frame) | replaced by SlateControls' "new window" button (`src/SlateControls.ts`) |
+| `Remote.java` (applet remote-control) | not ported |
+
+The full porting status is tracked in
+[java-port-tracker.md](java-port-tracker.md).
+
+---
+
 ## Repository layout
 
 ```
@@ -299,18 +392,14 @@ section above.
 
 ---
 
-## Adding a new construction — the four-file checklist
+## Adding a new construction
 
-1. **Element class**: `src/elements/{type}/FooElement.ts`
-2. **Construction class**: new subclass in `src/elements/{type}/{Type}Constructions.ts`;
-   append `new FooConstruction()` to that file's `{type}Constructions` array
-3. **Test**: new `it(...)` block in `tests/{Type}Test.ts` (the suite is now
-   split per element type — point tests in `PointTest.ts`, line tests in
-   `LineTest.ts`, etc.). Slate-level integration tests stay in `SlateTest.ts`.
-4. **Demo page**: `view/test/{super_type}/{sub_type}.html`
-
-The enum entry for the construction (e.g. `PointConstructions.foo = N`) already exists
-for all documented constructions — check the enum definitions in `Constructions.ts`.
+The four files (element class, construction class, test, demo page),
+the contracts each must satisfy, and the common pitfalls to watch
+for live in [creating-constructions.md](creating-constructions.md).
+The enum entries (`PointConstructions.foo = N`, etc.) already exist
+for every construction Joyce documents in `tables.html`; the slot for
+your work is in `src/elements/{type}/{Type}Constructions.ts`.
 
 ---
 
@@ -328,56 +417,33 @@ Null color for a draw layer means `draw{Edge,Face,Vertex,Name}` is skipped entir
 
 ---
 
-## Public API (`src/index.ts`)
+## Public API — see [api.md](api.md)
+
+The full reference for every `init()` field, every `E.{Type}.{name}`,
+every accepted color/align value, and every public `Slate` method is
+in **[api.md](api.md)**. That doc is the canonical mapping back to
+Joyce's `Geometry.html` parameter contract and `tables.html`
+construction catalog.
+
+The high-level shape: `init()` takes an `IInitialization` object with
+slate-level params (`background`, `title`, `pivot`, `font`, `fontsize`,
+`align`, `canvasid`) and an `elements: (IConstructionInfo | string)[]`
+ordered list. Each element entry can be a structured object —
 
 ```typescript
-// Object form (structured)
-geomlib.init({
-    canvasid: "myCanvas",
-    background: "#ffe9cd",
-    title: "Proposition I.1",
-    elements: [
-        { name: "A", construction: E.Point.free, params: [125, 130] },
-        { name: "B", construction: E.Point.free, params: [215, 130] },
-        { name: "AB", construction: E.Line.connect, params: ["A", "B"] },
-    ]
-})
-
-// String form (Java param format — can be mixed with object form)
-geomlib.init({
-    background: "35,19,100",
-    title: "I.1",
-    canvasid: "myCanvas",
-    elements: [
-        "A;point;free;125,130",
-        "B;point;free;215,130",
-        "AB;line;connect;A,B",
-    ]
-})
+{ name: "A", construction: E.Point.free, params: [125, 130] }
 ```
 
-`E` is the construction enum accessor: `E.Point.free`, `E.Line.connect`, `E.Circle.radius`, etc.
-`Align` is `{ ABOVE, BELOW, LEFT, RIGHT, CENTRAL }`.
-`parseParam(s)` converts a Java param string to `IConstructionInfo`.
-
-`init()` accepts an optional `pivot` setting that fixes the rotation
-center for the drag pipeline (see "Drag pipeline" above):
+— or a raw Java `<param value=…>` string —
 
 ```typescript
-geomlib.init({ … , pivot: "C"            }) // pivot on screen plane
-geomlib.init({ … , pivot: "origin,xyplane" }) // 3D pivot on a non-screen plane
+"A;point;free;125,130"
 ```
 
-`Slate.setPivot(name)` accepts the same string format and can be called
-post-init.
+— and the two forms can be mixed in the same `elements` array.
+`parseParam(s)` is the public converter.
 
-`init()` appends each constructed `Slate` to the exported `slates` array
-(`geomlib.slates`), so multiple canvases on the same page each get their
-own slate instance.
-
-UI controls (reset, maximize, new window) are injected by `init()` via
-`createControls(slate, canvas, config)` from `src/SlateControls.ts`. The
-overlay draws three icon buttons at the canvas's top-right and binds
-keyboard shortcuts when the canvas is focused: `r`/`space` = reset,
-`u`/`return` = open a new window with this scene maximized, `m` =
-maximize/minimize. See the file header for the icon and shortcut catalog.
+`init()` also calls `createControls()` from `src/SlateControls.ts`,
+which wraps the canvas and adds the reset / maximize / new-window
+button overlay plus keyboard shortcuts (`r`/`space`, `u`/`return`,
+`m`). See [api.md § SlateControls](api.md#slatecontrols-ui-overlay).

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -21,18 +21,22 @@ euclid/
 │       ├── sphere/               # SphereElement + SphereConstructions.ts
 │       └── polyhedron/           # PolyhedronElement, Prism, Pyramid + PolyhedronConstructions.ts
 ├── tests/
-│   └── SlateTest.ts              # Mocha test suite
+│   ├── {Circle,Line,Plane,Point,Polygon,Polyhedron,Sector,Sphere,Slate}Test.ts
+│   │                              # Per-element-type unit suites (split 2026-04-18)
+│   ├── ColorsTest.ts, ParseParamTest.ts
+│   ├── SnapshotTest.ts            # Auto-discovers HTML scenes, drags points,
+│   │                              #   diffs against tests/snapshots/ goldens
+│   ├── SnapshotHelper.ts          # Render + drag + pixel-diff utilities
+│   ├── HtmlParamParser.ts         # Loads Java <applet>/<param> HTML into Slate config
+│   ├── shared/dragScenes.ts       # Reusable scenes for slate-drag tests
+│   └── snapshots/                 # Golden PNGs (one per slate)
 ├── geom_applet/
 │   └── source/                   # Original Java source files (.java + .class)
 ├── view/
 │   ├── euclid-html/              # Original Java applet HTML (Books I–XIII)
-│   │   ├── booki/ … bookxiii/    # Per-book proposition HTML files
-│   └── test/                     # TypeScript demo pages, one per construction type
-│       ├── point/                # point/foot.html, point/intersection.html, …
-│       ├── line/                 # line/bichord.html, line/perpendicular.html, …
-│       ├── circle/               # circle/circle.html, circle/circumcircle.html
-│       ├── poly/                 # poly/index.html
-│       └── sector/               # sector/index.html
+│   ├── test/{type}/{sub}.html    # TypeScript demo pages, one per construction
+│   └── applet-tests/{type}/{cons}/{original,applet}.html
+│                                  # Three-way harness pairs (see AGENTS.md)
 ├── dist/
 │   └── bundle.js                 # Webpack output (consumed by view/test/ HTML files)
 └── AGENTS.md                     # Agent quick-start guide
@@ -43,28 +47,36 @@ euclid/
 ## Data flow: from `init()` to canvas
 
 ```
-geomlib.init({ canvasid, elements: [...] })
+geomlib.init({ canvasid, elements: [...], pivot?, background?, title?, … })
   └─ new Slate(canvas)
        ├─ creates screen plane (three FixedPoints + PlaneElement)
-       └─ for each element spec:
+       └─ for each element spec (object form OR Java param string):
+            (parseParam if string) → IConstructionInfo
             slate.createElement(construction, params, name)
-              ├─ convertParams(params)        ← string → element lookup
-              │                                 LineElement → two PointElements
-              ├─ findConstruction(cm, params)  ← iterates constructions[], validateSignature()
-              └─ Construction.construct(screen, params)
+              ├─ convertParams(params) ← string → element lookup; sorts into
+              │                          SortedParams { P[], E[], N[] }
+              │                          (LineElement names expand to their
+              │                           two endpoint PointElements in P)
+              ├─ findConstruction(cm, sp) ← iterates constructions[], picks the
+              │                              first whose validateSignature() matches
+              │                              by type counts (and elementTypes if set)
+              └─ Construction.construct(screen, P, E, N)
                    └─ returns [elementsForUpdate, newElement]
                         ├─ elementsForUpdate → pushed onto slate._elementsForUpdate
                         └─ newElement        → pushed onto slate._elements
 
-slate.update()
-  ├─ for each elem in _elementsForUpdate: elem.update()
-  └─ drawElements()
-       └─ for each elem in _elements:
-            elem.drawFace() → elem.drawEdge() → elem.drawVertex() → elem.drawName()
+  ├─ if config.pivot: slate.setPivot(config.pivot)
+  ├─ slate.update()
+  │     ├─ for each elem in _elementsForUpdate: elem.update()
+  │     └─ drawElements()
+  │          └─ for each elem in _elements:
+  │               elem.drawFace() → elem.drawEdge() → elem.drawVertex() → elem.drawName()
+  └─ createControls(slate, canvas, config)   ← injects reset/maximize/new-window
+                                                buttons + keyboard shortcuts on top
+                                                of the canvas (src/SlateControls.ts)
 ```
 
-Mouse/touch events call `movePick(x, y)` which translates the picked `PointElement`,
-then calls `slate.update()` to redraw.
+Mouse/touch events call `movePick(x, y)`; see "Drag pipeline" below.
 
 ---
 
@@ -140,20 +152,39 @@ explicit plane from the construction parameters.
 
 ## Construction dispatch: the `constructions` array
 
-`Slate.findConstruction(cm, params)` iterates the exported `constructions` array
-(`Constructions.ts`) and calls `validateSignature(cm, params)` on each entry.
+`Slate.findConstruction(cm, sp)` iterates the exported `constructions` array
+(`Constructions.ts`) and calls `validateSignature(cm, sp)` on each entry.
 The array is a spread-concatenation of 8 per-type arrays, each exported from
 its `{Type}Constructions.ts` file (e.g., `pointConstructions` from
 `point/PointConstructions.ts`).
 
-`validateSignature` checks two things:
-1. `construction.constructionMethod === cm` (the enum value matches)
-2. `params` types match `construction.signature` (element types in order)
+Dispatch is **type-counted**, mirroring Java's `selectDataChoice` in
+`Slate.java` 344-393. A `ConstructionSignature` is an object with numeric
+counts plus an optional subtype list:
 
-Because multiple `Construction` subclasses can share the same `constructionMethod`
-enum value with different signatures (2D vs. 3D variants), the **first match wins**.
-Insertion order in `constructions` is therefore significant — longer (3D) signatures
-must come before shorter (2D) ones to avoid greedy prefix matching.
+```typescript
+{ points: number, elements: number, integers: number, elementTypes?: Function[] }
+```
+
+`validateSignature` checks:
+
+1. `construction.constructionMethod === cm` (the enum value matches)
+2. `sp.P.length === sig.points`, `sp.E.length === sig.elements`,
+   `sp.N.length === sig.integers` (post-`convertParams` type counts match)
+3. If `sig.elementTypes` is set, each `sp.E[i] instanceof sig.elementTypes[i]`
+
+Because dispatch is by counts (not positional types), the source HTML param
+order is irrelevant — `"E,Vplane,D,B"` and `"E,D,B,Vplane"` both match
+`{ points: 3, elements: 1, elementTypes: [PlaneElement] }`. See
+`doc/analysis/type-counted-dispatch-plan.md` for the migration rationale.
+
+Because multiple `Construction` subclasses can share the same
+`constructionMethod` enum value, the **first match wins**. Insertion
+order matters **only** when two subclasses have *identical*
+`(points, elements, integers)` counts but differ in `elementTypes` —
+then the more specific (subtype-narrowed) signature must come first
+so it's checked before a more permissive sibling. With distinct counts
+(typical of 2D vs. 3D variants), order is irrelevant.
 
 ---
 
@@ -234,28 +265,48 @@ For `PointElement` subclasses: write `this._x`, `this._y`, `this._z`.
 For `LineElement` subclasses: write `this._A._x/y/z` and `this._B._x/y/z`
 (the two endpoint `PointElement`s stored on the line element).
 
+### `reset()` vs. `update()`
+
+`update()` recomputes from current parents. `reset()` restores an element
+to its construction-time state — `PlaneSlider.reset()` rewinds to its
+`_initx/_inity/_initz`, `LineSlider.reset()` to its initial `t`, and so on.
+`Slate.reset()` calls `elem.reset()` on every element and then `slate.update()`,
+which is what the reset button (and the `r`/`space` keyboard shortcut) on each
+SlateControls overlay invokes. After dragging, `update()` keeps showing the
+*current* dragged state; `reset()` rewinds the whole scene to where `init()`
+left it.
+
 ---
 
-## `convertParams` — the param expansion step
+## `convertParams` — the type-sort step
 
-Before a construction receives its `params`, `Slate.convertParams` transforms them:
+Before `findConstruction` looks anything up, `Slate.convertParams(params)`
+walks the raw `params` array and returns `SortedParams { P, E, N }`:
 
-1. **String → element lookup**: `"A"` → the `GeomElement` named `"A"` on the slate
-2. **`LineElement` → two `PointElement`s**: if the looked-up element is a `LineElement`,
-   it is replaced with `[lineElement._A, lineElement._B]` in the params array
+1. **String → element lookup**: `"A"` is replaced with the slate's element
+   named `"A"`.
+2. **Bucket by type**:
+   - `PointElement` instances → `P[]`
+   - `LineElement` instances → expanded to their two endpoint
+     `PointElement`s, both pushed into `P[]`
+   - all other elements (Circle, Plane, Sphere, Polygon, Polyhedron) → `E[]`
+   - numbers → `N[]`
 
-This means the `params` array that arrives at `Construction.construct()` can be longer
-than the original param list in the HTML. Construction `signature` arrays must reflect
-the post-expansion types, not the raw HTML param count.
+`Construction.construct()` then receives `(screen, P, E, N)` — three
+already-sorted arrays, not a single mixed list. Signatures match by the
+*counts* of these arrays, not by positional types; see the dispatch
+section above.
 
 ---
 
 ## Adding a new construction — the four-file checklist
 
 1. **Element class**: `src/elements/{type}/FooElement.ts`
-2. **Construction class**: new subclass in `src/elements/{type}/{Type}Constructions.ts`,
-   add to the per-type `{type}Constructions` array at the bottom of the same file
-3. **Test**: new `it(...)` block in `tests/SlateTest.ts`
+2. **Construction class**: new subclass in `src/elements/{type}/{Type}Constructions.ts`;
+   append `new FooConstruction()` to that file's `{type}Constructions` array
+3. **Test**: new `it(...)` block in `tests/{Type}Test.ts` (the suite is now
+   split per element type — point tests in `PointTest.ts`, line tests in
+   `LineTest.ts`, etc.). Slate-level integration tests stay in `SlateTest.ts`.
 4. **Demo page**: `view/test/{super_type}/{sub_type}.html`
 
 The enum entry for the construction (e.g. `PointConstructions.foo = N`) already exists
@@ -309,5 +360,24 @@ geomlib.init({
 `Align` is `{ ABOVE, BELOW, LEFT, RIGHT, CENTRAL }`.
 `parseParam(s)` converts a Java param string to `IConstructionInfo`.
 
-UI controls (reset, maximize, new window) are injected automatically by `init()`.
-Keyboard shortcuts when canvas is focused: `r`/`space` = reset, `u`/`return` = new window, `m` = maximize.
+`init()` accepts an optional `pivot` setting that fixes the rotation
+center for the drag pipeline (see "Drag pipeline" above):
+
+```typescript
+geomlib.init({ … , pivot: "C"            }) // pivot on screen plane
+geomlib.init({ … , pivot: "origin,xyplane" }) // 3D pivot on a non-screen plane
+```
+
+`Slate.setPivot(name)` accepts the same string format and can be called
+post-init.
+
+`init()` appends each constructed `Slate` to the exported `slates` array
+(`geomlib.slates`), so multiple canvases on the same page each get their
+own slate instance.
+
+UI controls (reset, maximize, new window) are injected by `init()` via
+`createControls(slate, canvas, config)` from `src/SlateControls.ts`. The
+overlay draws three icon buttons at the canvas's top-right and binds
+keyboard shortcuts when the canvas is focused: `r`/`space` = reset,
+`u`/`return` = open a new window with this scene maximized, `m` =
+maximize/minimize. See the file header for the icon and shortcut catalog.

--- a/doc/creating-constructions.md
+++ b/doc/creating-constructions.md
@@ -1,0 +1,325 @@
+# Creating a New Construction
+
+This guide walks through adding a new construction type to the port —
+the four files you'll touch and the contracts your new code must
+satisfy. It's the operational counterpart to
+[architecture.md](architecture.md), which explains *why* things are
+shaped the way they are.
+
+If you're porting a construction from Joyce's Java applet (which is the
+default expectation), the canonical reference for what the construction
+should *do* is `geom_applet/source/{ConstructionName}.java`, with the
+public-facing description at `geom_applet/source/tables.html`.
+The corresponding row of [api.md's construction tables](api.md#construction-tables)
+shows which `E.{Type}.{name}` slot the construction occupies and what
+its argument list looks like *after* `LineElement` expansion.
+
+For the broader workflow (branch off main, commit each step
+separately, three-way harness verification), see
+[process.md](process.md).
+
+---
+
+## Prerequisites — read these once
+
+| Doc | Why |
+|---|---|
+| [architecture.md § Element class hierarchy](architecture.md#element-class-hierarchy) | Where your new element class fits. |
+| [architecture.md § The `update()` contract](architecture.md#the-update-contract) | Hard rules for `update()`. |
+| [architecture.md § Construction dispatch](architecture.md#construction-dispatch-the-constructions-array) | How `validateSignature` matches by type counts. |
+| [architecture.md § convertParams](architecture.md#convertparams--the-type-sort-step) | Why `LineElement` names show up in `params` as two endpoint points. |
+| [api.md § Construction tables](api.md#construction-tables) | The construction slot you're filling. |
+
+---
+
+## The four files
+
+For a new construction `E.Foo.bar`, you'll touch:
+
+1. **Element class** — `src/elements/{type}/BarElement.ts` (or `Bar.ts`,
+   matching the Java filename)
+2. **Construction class** — appended to the existing
+   `src/elements/{type}/{Type}Constructions.ts`
+3. **Mocha test** — appended to the existing `tests/{Type}Test.ts`
+4. **Demo page** — `view/test/{type}/{sub}.html`
+
+For three-way harness verification (recommended), also add:
+
+5. **Harness pair** — `view/applet-tests/{type}/{cons}/original.html`
+   (verbatim Joyce extract) and `applet.html` (trimmed Java form
+   matching the TS demo). See [process.md § Step 7](process.md) for
+   the full harness recipe.
+
+---
+
+## Step 1 — Read the Java source
+
+`geom_applet/source/{Name}.java` is the source of truth for
+behavior. Note:
+
+- **Constructor signature** → which parents the element holds. These
+  become the `Construction.signature`'s type counts.
+- **`update()` body** → the math your TS `update()` must mirror. Most
+  ports are line-for-line; the `PointElement` helpers (`toCircumcenter`,
+  `toLine`, `toCircle`, `toIntersection`, `toInvertPoint`, `toSimilar`,
+  `rotate`, `angle`, etc.) already exist and match Java exactly.
+- **Dispatch case in `Slate.java`** → which `Construction` class to
+  build and what signature it carries. The cases at lines 396-723
+  enumerate every construction; line 73-122 has the
+  construction-name-to-index lookup tables.
+
+Convert *all* constructors and methods in one pass — see
+[process.md § Step 2 "Full Java class conversion rule"](process.md).
+
+---
+
+## Step 2 — The element class
+
+Skeleton at `src/elements/{type}/BarElement.ts`:
+
+```typescript
+import {PointElement} from "./PointElement";
+import {PlaneElement} from "../plane/PlaneElement";
+
+export class BarElement extends PointElement {   // or LineElement, etc.
+    private _A: PointElement;
+    private _B: PointElement;
+    private _AP: PlaneElement;
+
+    constructor(a: PointElement, b: PointElement, plane: PlaneElement) {
+        super();
+        this.dimension = 0;     // 0=point, 1=line/circle, 2=polygon/sector/filled
+        this._A = a;
+        this._B = b;
+        this._AP = plane;
+    }
+
+    update(): void {
+        // Read this._A, this._B, this._AP only.
+        // Write this._x, this._y, this._z (for point) or
+        //       this._A, this._B (for line, in subclasses)
+        //       …etc.
+    }
+}
+```
+
+### Hard rules from the `update()` contract
+
+1. **Idempotent.** Calling `update()` twice in a row must produce the
+   same coordinates. No accumulation.
+2. **Read only stored parents.** Don't read other slate elements by
+   name or look up the slate.
+3. **Write only own coords.** Don't push to global lists, don't mutate
+   parents.
+4. **No side effects.** No DOM access, no `console.log`, no random.
+
+The full contract is in
+[architecture.md § The `update()` contract](architecture.md#the-update-contract).
+
+### `dimension` controls draw layers
+
+| `dimension` | Drawn layers |
+|---|---|
+| `0` (point) | `vertex`, `name` |
+| `1` (line, edge of circle) | `edge`, `name` |
+| `2` (polygon, sector, filled circle) | `face`, `edge`, `name` |
+
+If your element draws a fill, set `dimension = 2`; if just a stroke,
+`1`; if just a dot/label, `0`.
+
+### Container elements: `rotate()` and `translate()` — the preexists footgun
+
+If your new element *holds* sub-points that aren't free `PlaneSlider`s
+(e.g. a Bichord holds its own two endpoint `PointElement`s), and you
+override `rotate()` / `translate()` to call those methods on the
+sub-points, **those sub-points must NOT also be iterated by the outer
+loop in `rotateCoordinates` / `translateCoordinates`** or they'll be
+moved twice. The mechanism that prevents this is the `preexists` flag
+described in
+[architecture.md § Drag pipeline](architecture.md#drag-pipeline-movepick--translatecoordinates--rotatecoordinates).
+The current heuristic is coarse; if your element's sub-points show
+double-movement under rotation around a pivot, see the open
+`preexists` item in
+[construction-tracker.md § Platform-level TODOs](construction-tracker.md#platform-level-todos).
+
+---
+
+## Step 3 — The Construction class
+
+Appended to `src/elements/{type}/{Type}Constructions.ts`:
+
+```typescript
+import {Construction, ConstructionSignature, AllConstructions,
+        PointConstructions, GeomElementsForUpdate} from "../Constructions";
+import {GeomElement} from "../GeomElement";
+import {PlaneElement} from "../plane/PlaneElement";
+import {PointElement} from "./PointElement";
+import {BarElement} from "./BarElement";
+
+export class BarPointConstruction extends Construction {
+    constructionMethod: AllConstructions = PointConstructions.bar;
+    signature: ConstructionSignature = {
+        points: 2, elements: 0, integers: 0,
+    };
+
+    construct(screen: PlaneElement,
+              P: PointElement[], E: GeomElement[], N: number[]
+             ): [GeomElementsForUpdate, GeomElement] {
+        let g = new BarElement(P[0], P[1], screen);
+        return [[g], g];
+    }
+}
+```
+
+Then add `new BarPointConstruction()` to the file's exported
+`{type}Constructions` array.
+
+### Signature counts are *post*-`convertParams`
+
+`P[]` holds `PointElement`s **after `LineElement` expansion**. If
+Joyce's Java HTML param is `"D;point;foo;AB,C"` where `AB` is a line,
+`convertParams` puts `[AB._A, AB._B, C]` into `P[]` and your signature
+should be `{ points: 3, … }`, not 2.
+
+### Optional planes / 3D variants — multiple Construction classes
+
+If `tables.html` shows a construction with `[plane X]` (optional plane
+for the 3D form), register **two** Construction classes — one with
+`elements: 0` (2D, uses screen plane) and one with `elements: 1,
+elementTypes: [PlaneElement]` (3D, takes the plane explicitly).
+Type-counted dispatch handles both because the counts differ. See
+[architecture.md § Construction dispatch](architecture.md#construction-dispatch-the-constructions-array)
+for the ordering rule (only matters when counts are identical).
+
+### `[elementsForUpdate, newElement]` return contract
+
+`construct()` returns a tuple:
+
+- `newElement`: the element being created (also the value `params: ["…"]`
+  references resolve to in later constructions).
+- `elementsForUpdate`: the list of elements `Slate` will call
+  `update()` on every frame.
+
+If your construction creates **intermediate** elements that aren't the
+return value but need per-frame `update()` (e.g. `CircumcenterConstruction`
+internally builds a `CircumcircleElement` and returns its center), put
+them in `elementsForUpdate`. If they're missing, they never recompute
+and the dependent element drifts on stale coords.
+
+---
+
+## Step 4 — Mocha test
+
+Appended to `tests/{Type}Test.ts` (point tests in `PointTest.ts`,
+line tests in `LineTest.ts`, …; slate-level integration tests stay in
+`SlateTest.ts`):
+
+```typescript
+it("should compute foo correctly", () => {
+    let data: IConstructionInfo[] = [
+        { name: "A", construction: E.Point.free, params: [60, 100] },
+        { name: "B", construction: E.Point.free, params: [140, 100] },
+        { name: "F", construction: E.Point.foo,  params: ["A", "B"] },
+    ];
+    let slate = new Slate(createCanvas(400, 300));
+    toElements(slate, data);
+    slate.elements.forEach(e => e.update());
+
+    let F = slate.lookupElement("F") as PointElement;
+    almostEqual(F.x, expectedX, 0.001);
+    almostEqual(F.y, expectedY, 0.001);
+});
+```
+
+Use input coordinates that match a known proposition (e.g. propI12
+for `line;chord`) so the expected output can be hand-derived from the
+geometry. `tests/shared/testHelpers.ts` exports `toElements`,
+`almostEqual`, and friends.
+
+For container elements with `rotate`/`translate` overrides, also add
+isolation tests — see e.g. `tests/SectorTest.ts`'s arc tests for the
+pattern (`should translate only the arc center, leaving A, M, B
+untouched` and `should rotate only the arc center around a pivot`).
+
+---
+
+## Step 5 — Demo page
+
+`view/test/{type}/{sub}.html`. Pattern:
+
+```html
+<html>
+<head><title>Test View - Foo</title></head>
+<body>
+<canvas id="canvasId" style="width:400px; height:400px;"></canvas>
+<script src="../../../dist/bundle.js"></script>
+
+<!--applet code=Geometry archive=Geometry.zip width=400 height=400>
+<param name=background value="35,19,100">
+<param name=e[1] value="A;point;free;60,100">
+<param name=e[2] value="B;point;free;140,100">
+<param name=e[3] value="F;point;foo;A,B">
+</applet-->
+
+<script>
+let E = geomlib.E;
+geomlib.init({
+    background: "35,19,100",
+    canvasid: "canvasId",
+    elements: [
+        { name: "A", construction: E.Point.free, params: [60, 100] },
+        { name: "B", construction: E.Point.free, params: [140, 100] },
+        { name: "F", construction: E.Point.foo,  params: ["A", "B"] },
+    ],
+});
+</script>
+</body></html>
+```
+
+Preserving the original Java `<applet>` block as an HTML comment is
+a project convention — it lets the next person to maintain this page
+diff against Joyce's exact param list.
+
+Rebuild the bundle (`npx webpack`) and verify in a browser
+(`python3 -m http.server`).
+
+---
+
+## Step 6 — Three-way harness verification (optional but recommended)
+
+For visual A/B/C verification (Java original ↔ Java up-to-construction
+↔ TS port), drop a pair of files into `view/applet-tests/{type}/{cons}/`:
+`original.html` and `applet.html`. The harness in `run_euclid_applet.sh`
+auto-discovers them. See [process.md § Step 7](process.md) for the full
+recipe and the `<!-- TS: ... -->` header convention.
+
+---
+
+## Tracker updates
+
+Once the construction is verified, update three trackers:
+
+- `doc/constructions-reference.md` — flip the row from TBD to IMPL,
+  link to your test page.
+- `doc/proposition-tracker.md` — check off any propositions your new
+  construction unblocks (use the proposition-tracker NEEDS lines as
+  a starting point; verify against the actual `<param>` list).
+- `doc/construction-tracker.md` — flip the per-construction status
+  and append any new platform-level findings.
+- `doc/journal.md` — append a dated entry following the
+  Completed/Discovered/Next-session template.
+
+For the PR body template, see
+[process.md § Step 8 "Pull request body template"](process.md).
+
+---
+
+## Common pitfalls
+
+| Symptom | Likely cause |
+|---|---|
+| `Construction not found for "X" Foo.bar with params P=[…] E=[…] N=[…]` | Signature counts don't match what `convertParams` produced. Check for `LineElement` expansion in your inputs and adjust `signature.points`. |
+| Element renders correctly at first but drifts on drag | Intermediate element you created inside `construct()` isn't in `elementsForUpdate`. |
+| Element draws on top of itself with growing artifacts under pivot rotation | Container element's `rotate()` is moving sub-points that the outer loop is *also* moving — preexists tracking gap. See the [drag pipeline](architecture.md#drag-pipeline-movepick--translatecoordinates--rotatecoordinates) and the open `preexists` item in [construction-tracker.md](construction-tracker.md#platform-level-todos). |
+| 2D test passes, 3D variant matches a 2D-shaped param list and crashes | Two Construction classes for the same `constructionMethod` with overlapping signatures and the wrong order. Type counts should disambiguate; double-check `signature.points/elements/integers`. |
+| Free point picks the wrong neighbor | Check `vertexColor` is non-null on the points you want pickable; `closestVisiblePoint` filters by visibility. |


### PR DESCRIPTION
## Summary

Documentation refresh for the post-2026-04-18 codebase. Two commits on
this branch:

- `009fd3d` Bring `architecture.md` in line with the current dispatch
  model (type-counted via `SortedParams { P, E, N }`, not positional),
  the split test layout, and the file-per-type Constructions
  organization. Add a Drag-pipeline section that documents the
  `_elements`-vs-`_elementsForUpdate` invariants and the
  `update()`-after-rotate hook landed in #43.
- `e428c80` Add a dedicated public-API reference (`doc/api.md`),
  pull the "adding a new construction" walkthrough out of
  `architecture.md` into a dedicated `doc/creating-constructions.md`,
  and reframe `architecture.md`'s opening in the style of Joyce's
  `Geometry.html` applet overview (eight element classes, interaction
  model, element schema, slate-level params, Java→TS class mapping
  table).

No source code changes; tests untouched and unaffected.

## Files

| File | Status | Lines | Purpose |
|---|---|---|---|
| `doc/api.md` | NEW | +537 | Public-API reference. |
| `doc/creating-constructions.md` | NEW | +325 | Recipe for adding a construction. |
| `doc/architecture.md` | UPDATED | +297 / −76 | Implementation-level "how the pieces fit together" — corrected, expanded, and stripped of content that now lives in the two new docs. |

## What's in `doc/api.md`

A reference doc whose target audience is anyone calling `geomlib`
from a page (not contributing to the port). It maps the public
surface back to the canonical Java contracts in
`geom_applet/source/Geometry.html` and `tables.html`:

- `IInitialization` — every field with its Java applet param
  counterpart, default value, and behavior. Includes the renames
  (`pivot`'s `"P,plane"` two-part form, `font`/`fontsize`,
  `align: Align.CENTRAL` default).
- `IConstructionInfo` — every field, including the four optional
  color slots (name / vertex / edge / face) and how `null`
  short-circuits the corresponding draw layer.
- `parseParam(s)` — the format string, the `type → E.{Type}` mapping,
  the args-CSV parsing rule, and the `polyhedron → Polyhedra` and
  `3points → threePoints` rewrites that the parser handles silently.
- `E` enum accessor — the eight construction enums, their numeric
  ranges, and a complete reference table for each:
  point / line / circle / polygon / sector / plane / sphere /
  polyhedra. Each row shows the TS API form, the Java construction
  string, the post-`LineElement`-expansion argument list, and a
  one-line description. The eight tables are derived directly from
  `tables.html` and updated with the additions Joyce added after v2.2
  (`harmonic`, `lineSegmentSlider`, `intersection` plane variant,
  `face`, etc.).
- `Align` — the five values, the CENTRAL default, and the (open)
  per-element-align gap.
- Colors — the full `parseColor` grammar (named, hex, HSB triple,
  `random`, `background`, `brighter`, `darker`, `none`, numeric `0`,
  defaults).
- `Slate` runtime methods that are public-ish: `lookupElement`,
  `setPivot`, `reset`, `update`, `bgcolor`, plus the read-only
  `elements` / `elementsForUpdate` views.
- SlateControls — the three buttons, three keyboard shortcuts, and
  the headless skip path.
- A worked example porting a Joyce `<applet>` block to a
  `geomlib.init({...})` call.

## What's in `doc/creating-constructions.md`

A step-by-step guide whose target audience is contributors. Was
previously a thin checklist at the bottom of `architecture.md` and a
longer-but-stale walkthrough in `CLAUDE.md` / `AGENTS.md`. Consolidated
and made operational, with cross-links back to `architecture.md`
(update contract, drag pipeline, dispatch, `convertParams`) and
`api.md` (construction tables) at every relevant step.

Sections:

- Prerequisites — which `architecture.md` / `api.md` sections to
  read first.
- The four files (element class, construction class, test in the
  per-type `{Type}Test.ts` rather than the old monolithic
  `SlateTest.ts`, demo page) plus the optional fifth (three-way
  harness pair under `view/applet-tests/`).
- Step-by-step recipe with skeleton code for each of the four files
  and the post-`LineElement`-expansion signature counting rule.
- A "common pitfalls" table covering the recurring failure modes:
  signature mismatches when expansion isn't accounted for; drift on
  drag when an intermediate element wasn't pushed into
  `elementsForUpdate`; double-rotation under pivot when a container's
  `rotate()` moves sub-points the outer loop is also moving (the
  preexists footgun that #41 partially addressed); 2D/3D variant
  ordering hazards; pick-by-`vertexColor` filtering.

## What changed in `doc/architecture.md`

Two passes — both are in this branch (commit `009fd3d` then
`e428c80`).

**Pass 1 (the dispatch refresh, `009fd3d`):**

- Repository layout: tests are now per-element-type
  (`{Circle,Line,Plane,Point,Polygon,Polyhedron,Sector,Sphere,Slate}Test.ts`)
  plus `ColorsTest.ts`, `ParseParamTest.ts`, `SnapshotTest.ts`, and
  `view/applet-tests/`.
- Data-flow diagram: `convertParams` returns `SortedParams { P, E, N }`
  rather than expanding into a single mixed array;
  `Construction.construct` receives `(screen, P, E, N)`. Added the
  `parseParam` pre-step for string inputs, the optional `setPivot`
  call, and `createControls` being invoked by `init()`.
- Construction dispatch section: rewritten to describe type-counted
  dispatch (mirroring Java's `selectDataChoice`). Documents
  `ConstructionSignature` as an object
  (`{ points, elements, integers, elementTypes? }`) rather than an
  array. The `elementTypes` field is the per-slot subtype check (e.g.
  `point;center(Circle)` vs `point;center(Sphere)` — same counts,
  different `elementTypes`). Narrows the ordering caveat to its real
  scope: order matters only when two `Construction` subclasses share
  both `constructionMethod` and identical `(points, elements, integers)`
  counts but differ in `elementTypes`. With distinct counts (e.g.
  typical 2D vs 3D variants), order is irrelevant.
- New `convertParams` section: reframed as type-sort, not
  "expansion." `LineElement` names auto-expand to two endpoint
  `PointElement`s, both pushed into `P[]`.
- New `reset()` vs. `update()` subsection: documents
  `Slate.reset() → elem.reset()` cascade and how it differs from
  `update()`'s parent-derivation pass.
- New "Drag pipeline" section covering `movePick` /
  `translateCoordinates` / `rotateCoordinates`, the
  iterate-`_elements`-then-call-`update()` invariant in
  `rotateCoordinates`, and the rotation-vs-update-commute footgun for
  container elements that move their own owned points.
- Fixed the duplicate `TBD\|0` row in `java-port-tracker.md`'s
  summary (still landed in this branch via the same pass).

**Pass 2 (the overview rewrite + redirect, `e428c80`):**

- New top-of-file companion-docs banner pointing at `api.md` and
  `creating-constructions.md`.
- New "What this library is" section in the style of Joyce's
  `Geometry.html`: what the port is (a TS reimplementation of
  v2.2 of the Geometry Applet), the eight element classes, the
  interaction model (free / sliding / computed-or-pivot points),
  the `Name;type;construction;…` element schema, the slate-level
  params, and a Java-class → TS-file source-mapping table.
- "Adding a new construction" checklist collapsed to a 4-line
  pointer at `creating-constructions.md` — content moved there
  in full and expanded.
- "Public API" section collapsed to a brief overview that points at
  `api.md` as the canonical reference, with just the high-level
  shape (`IInitialization` / `IConstructionInfo` / mixed object-or-string
  `elements` array).

## Cross-link audit

After the two passes, the doc/ folder reads as a coherent set:

- `architecture.md` (449 lines) — implementation-level, with banner
  links at the top to `api.md` and `creating-constructions.md`.
- `api.md` (537 lines) — public-API reference, with back-links to
  `architecture.md` for `convertParams`, drag pipeline, etc.
- `creating-constructions.md` (325 lines) — contributor recipe,
  back-linking to `architecture.md` (update contract, dispatch, drag
  pipeline) and `api.md` (construction tables) at each relevant step.
- `process.md`, `journal.md`, `construction-tracker.md`,
  `proposition-tracker.md`, `constructions-reference.md`,
  `java-port-tracker.md` — unchanged in this PR; the
  `creating-constructions.md` recipe and `api.md` reference are the
  layer that was missing.

## Verification

- [x] `wc -l` totals: architecture 449, api 537, creating-constructions 325.
- [x] No source-code changes (`git diff --stat main..HEAD` touches
      only `doc/*.md` files).
- [x] `npm test` and `npm run test:snapshot` are unaffected by this
      branch (verified at the prior commits — both pass; this PR
      adds no test-touching changes).
- [x] Spot-read `api.md`'s eight construction tables against the
      currently-implemented Construction classes in
      `src/elements/{type}/{Type}Constructions.ts` for any drift.
- [x] Verify the cross-links render (relative `[text](api.md#anchor)`
      paths in all three files) on GitHub's preview.

## Out of scope (deliberately not touched)

- `doc/analysis/` — historical analysis at the time, leave-alone
  charter.
- `process.md` — the 8-step workflow is unchanged. The
  "create-a-new-construction" detail moves to
  `creating-constructions.md` but the surrounding session
  workflow stays in `process.md`.
- The trackers (`construction-tracker.md`, `proposition-tracker.md`,
  `constructions-reference.md`, `java-port-tracker.md`) — content is
  current as of the post-#41 review (PR #44).
- README / coverage setup / snapshot framework deep-dive — judged
  to belong outside `architecture.md`'s scope; possible follow-up
  doc, not blocking.
