### PR TITLE
docs: use Dr. Joyce for attribution; original Geometry Applet for design

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,12 @@
 # geomlib — Agent Guide
 
 `geomlib` is a TypeScript library that renders interactive Euclidean
-constructions on an HTML5 `<canvas>` — a port of David E. Joyce's
-1996 Java *Geometry Applet*. Published to npm as
-**@brownnrl/geomlib**. The converted *Elements* site (where the
-library will be consumed) lives in a separate content-site repo
-targeted at [euclids-elements.org](https://euclids-elements.org).
+constructions on an HTML5 `<canvas>` — a port of Dr. David E. Joyce's
+(Professor Emeritus, Clark University) 1996 Java *Geometry Applet*.
+Published to npm as **@brownnrl/geomlib**. The converted *Elements*
+site (where the library will be consumed) lives in a separate
+content-site repo targeted at
+[euclids-elements.org](https://www.euclids-elements.org/).
 
 ## Project status
 
@@ -18,7 +19,7 @@ Library is **post-porting, publish-ready**. There is no longer a
   + `bundle:prod`. `npm publish --dry-run` previews the tarball
   (97.7 kB gzipped, 6 files).
 - MIT-licensed, joint copyright (Joyce 1996–2020, Brown 2019–2026).
-  Joyce's permission text + Quora source recorded in
+  Dr. Joyce's permission text + Quora source recorded in
   [NOTICE.md](NOTICE.md).
 
 Ongoing work is library maintenance: bug fixes, doc edits, occasional
@@ -38,7 +39,7 @@ and publish-time polish. Approach those like normal feature work
   recipe for adding a new construction (element class, Construction
   class, test, demo page).
 - [CONTRIBUTING.md](CONTRIBUTING.md) — test/snapshot/bundle commands.
-- [NOTICE.md](NOTICE.md) — Joyce's permission + license posture.
+- [NOTICE.md](NOTICE.md) — Dr. Joyce's permission + license posture.
 
 The porting-era trackers and the dated session journal live under
 [doc/historical/](doc/historical/) — frozen, read-only history.
@@ -60,7 +61,7 @@ tests/                    Mocha suites
   HtmlParamParser.ts      Parses <applet> blocks from HTML test fixtures
 
 view/                     HTML test fixtures + demos
-  euclid-html/            Joyce's original HTML, Books I–XIII (snapshot input)
+  euclid-html/            Original Geometry Applet HTML, Books I–XIII (snapshot input)
   compass_geometry/       Compass-series scenes (snapshot input)
   round_geometry/         Spherical-geometry scenes (snapshot input)
   test/{type}/*.html      Per-construction TS demo pages
@@ -136,13 +137,13 @@ for the full recipe — the 4 files (element class, Construction
 class, Mocha test, demo page), the contracts above, and the common
 pitfalls.
 
-The enum entries for every construction Joyce documented in
-`tables.html` already exist in `src/elements/Constructions.ts`.
+The enum entries for every construction documented in the original
+applet's `tables.html` already exist in `src/elements/Constructions.ts`.
 
 ## Original HTML param format
 
 Many test fixtures (`view/euclid-html/`, `view/compass_geometry/`,
-`view/round_geometry/`) still carry Joyce's original Java applet
+`view/round_geometry/`) still carry the original Java applet's
 `<param>` strings:
 
 ```
@@ -158,8 +159,8 @@ Many test fixtures (`view/euclid-html/`, `view/compass_geometry/`,
 
 ## What this repo doesn't contain
 
-- The converted *Elements* proposition pages (Joyce's narrative text
-  + TS-canvas init calls) live in a separate content-site repo
+- The converted *Elements* proposition pages (Dr. Joyce's narrative
+  text + TS-canvas init calls) live in a separate content-site repo
   targeted at euclids-elements.org. Phase 3 (HTML conversion) was
   completed there.
 - The Java↔TypeScript visual comparison harness (docker, applet

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2,9 +2,10 @@
 
 ## About this project
 
-**geomlib** is a TypeScript port of David E. Joyce's *Geometry Applet*
-(Clark University, 1996, Java version 2.2), originally written to
-illustrate Euclid's *Elements* on the web. The port reimplements the
+**geomlib** is a TypeScript port of Dr. David E. Joyce's (Professor
+Emeritus, Clark University) *Geometry Applet* (1996, Java version
+2.2), originally written to illustrate Euclid's *Elements* on the
+web. The port reimplements the
 applet's construction model on top of the HTML5 `<canvas>` element so
 the diagrams render in modern browsers without a Java plugin.
 
@@ -36,9 +37,9 @@ License** (see [LICENSE](LICENSE)), under joint copyright:
 
 > Copyright (c) 1996–2020 David E. Joyce, 2019–2026 Nelson Brown
 
-Joyce's years credit his authorship of the original Java applet and
-its continued maintenance through the *Elements* web edition. Brown's
-years credit the TypeScript port.
+Dr. Joyce's years credit his authorship of the original Java applet
+and its continued maintenance through the *Elements* web edition.
+Brown's years credit the TypeScript port.
 
 ## Preserved Java artifacts
 
@@ -55,7 +56,7 @@ they are preserved verbatim for reference and historical fidelity.
 
 ## Related: *Elements* narrative content
 
-Joyce's translation and commentary on Euclid's *Elements* are not
-included in this code repository. They are published as a separate
+Dr. Joyce's translation and commentary on Euclid's *Elements* are
+not included in this code repository. They are published as a separate
 site at [euclids-elements.org](https://euclids-elements.org), which
 carries its own copyright notice.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # geomlib
 
-A TypeScript port of David E. Joyce's *Geometry Applet* (Clark
+A TypeScript port of Dr. David E. Joyce's *Geometry Applet* (Clark
 University, 1996, Java version 2.2). `geomlib` renders interactive
 Euclidean geometry diagrams on an HTML5 `<canvas>`: drag a point, and
 every construction that depends on it follows. The original Java applet
@@ -9,7 +9,7 @@ modern browser, no JVM required.
 
 The library exposes eight element classes — *point*, *line*, *circle*,
 *polygon*, *sector*, *plane*, *sphere*, *polyhedron* — and the
-~70 construction methods Joyce documented in his
+~70 construction methods documented in the original applet's
 [`tables.html`](geom_applet/source/tables.html). All 465 propositions
 across Books I–XIII of the *Elements* are renderable.
 
@@ -104,8 +104,11 @@ so the tarball always contains a fresh production-built bundle. Run
 
 ## Origin
 
-Built atop David E. Joyce's [*Geometry Applet
-v2.2*](http://aleph0.clarku.edu/~djoyce/java/Geometry/Geometry.html)
-(Java, 1996–1997). Joyce's original applet pages — the source of every
-proposition this port can render — live at
-[*Euclid's Elements*](http://aleph0.clarku.edu/~djoyce/elements/elements.html).
+Built atop Dr. David E. Joyce's (Professor Emeritus, Clark
+University) [*Geometry Applet
+v2.2*](http://aleph0.clarku.edu/~djoyce/java/Geometry/Geometry.html),
+Java, 1996–1997. The original *Elements* applet pages at
+[aleph0.clarku.edu](http://aleph0.clarku.edu/~djoyce/elements/elements.html)
+have been mirrored at [euclids-elements.org](https://www.euclids-elements.org/),
+with the static-image fallbacks replaced by live TypeScript
+animations powered by `geomlib`.

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,7 +1,8 @@
 # Public API Reference
 
-This document is the reference for the public surface of `geomlib` — the
-TypeScript port of David Joyce's Geometry Applet (1996, version 2.2). It
+This document is the reference for the public surface of `geomlib` —
+the TypeScript port of Dr. David E. Joyce's Geometry Applet (1996,
+version 2.2). It
 maps every accepted parameter, every construction enum value, and every
 helper to its source location in `src/`, with the original Java applet
 contract in `geom_applet/source/Geometry.html` and `tables.html` as the
@@ -43,7 +44,7 @@ The canvas can be any size. `init()` matches `canvas.width/height`
 attributes to its `clientWidth/clientHeight` once at startup so the bitmap
 resolution is sharp at the CSS size you set.
 
-`elements:` accepts either object form (above) or Joyce's original Java
+`elements:` accepts either object form (above) or the original Java
 `<param>` strings — see [`parseParam()`](#parseparam) below.
 
 ---
@@ -305,7 +306,7 @@ what it produces.
 Conventions:
 
 - Lowercase italic `a`/`b`/`c` denote points; uppercase italic letters
-  match Joyce's `tables.html`.
+  match the original applet's `tables.html`.
 - `[plane X]` means the plane is optional — when omitted, the screen
   plane is used and the construction is 2D. When present, the
   construction is 3D.
@@ -491,9 +492,9 @@ canvas whose `parentElement` is `null`.
 
 ---
 
-## Example: porting a Joyce HTML page
+## Example: porting an original applet HTML page
 
-Joyce's `<applet>` block:
+The original `<applet>` block:
 
 ```html
 <applet code=Geometry archive=Geometry.zip width=340 height=320>

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -9,11 +9,12 @@
 
 ## What this library is
 
-`geomlib` is a TypeScript port of David E. Joyce's *Geometry Applet*
-(Clark University, 1996, Java version 2.2). Joyce wrote it to
-illustrate Euclid's *Elements* on the web; it renders interactive
-Euclidean diagrams where the user can drag points and watch all
-derived constructions follow. The original Java applet's overview
+`geomlib` is a TypeScript port of Dr. David E. Joyce's (Professor
+Emeritus, Clark University) *Geometry Applet* (1996, Java version
+2.2). The original applet was built to illustrate Euclid's
+*Elements* on the web; it renders interactive Euclidean diagrams
+where the user can drag points and watch all derived constructions
+follow. The original Java applet's overview
 page is mirrored at
 `geom_applet/source/Geometry.html` and its construction reference at
 `geom_applet/source/tables.html`. We aim to be a faithful reimplementation
@@ -23,8 +24,8 @@ A diagram is described by an ordered list of *elements*. Each element
 belongs to one of **eight classes** — `point`, `line`, `circle`,
 `polygon`, `sector`, `plane`, `sphere`, `polyhedron` — and is built
 by one of that class's *construction methods*. Plane geometry uses the
-first five classes; all eight are needed for solid geometry. Joyce's
-`<param name=e[N] value="…">` schema and our
+first five classes; all eight are needed for solid geometry. The
+original applet's `<param name=e[N] value="…">` schema and our
 `elements: [{...}]` API are two surfaces over the same model.
 
 ### Interaction model
@@ -61,8 +62,8 @@ opens the same scene in a new window.
 - **args** — comma-separated. Strings reference earlier elements by
   name; numbers are integer coordinates or counts. A `LineElement`
   named in args auto-expands to its two endpoint `PointElement`s
-  (Joyce's "Special note 1": any time two points are needed, one line
-  may be given instead).
+  (per the original applet's "Special note 1": any time two points
+  are needed, one line may be given instead).
 - **colors** (all optional, in order): name, vertex, edge, face. Up to
   four layers per element. See [Colors](#colors) for the parser rules.
 
@@ -129,9 +130,9 @@ euclid/
 │   ├── source/                   # Original Java source files (*.java + Geometry.html + tables.html)
 │   └── Geometry.zip              # Original 1998 deployable applet archive (preserved as-is)
 ├── view/
-│   ├── euclid-html/              # Original Joyce HTML pages, Books I–XIII (snapshot test fixtures)
-│   ├── compass_geometry/         # Joyce compass-series scenes (snapshot test fixtures)
-│   ├── round_geometry/           # Joyce spherical-geometry scenes (snapshot test fixtures)
+│   ├── euclid-html/              # Original Geometry Applet HTML, Books I–XIII (snapshot test fixtures)
+│   ├── compass_geometry/         # Compass-series scenes (snapshot test fixtures)
+│   ├── round_geometry/           # Spherical-geometry scenes (snapshot test fixtures)
 │   └── test/{type}/{sub}.html    # TypeScript demo pages, one per construction
 ├── dist/
 │   └── bundle.js                 # Webpack output (consumed by view/test/ HTML files)
@@ -403,8 +404,8 @@ The four files (element class, construction class, test, demo page),
 the contracts each must satisfy, and the common pitfalls to watch
 for live in [creating-constructions.md](creating-constructions.md).
 The enum entries (`PointConstructions.foo = N`, etc.) already exist
-for every construction Joyce documents in `tables.html`; the slot for
-your work is in `src/elements/{type}/{Type}Constructions.ts`.
+for every construction documented in the original `tables.html`; the
+slot for your work is in `src/elements/{type}/{Type}Constructions.ts`.
 
 ---
 
@@ -427,8 +428,8 @@ Null color for a draw layer means `draw{Edge,Face,Vertex,Name}` is skipped entir
 The full reference for every `init()` field, every `E.{Type}.{name}`,
 every accepted color/align value, and every public `Slate` method is
 in **[api.md](api.md)**. That doc is the canonical mapping back to
-Joyce's `Geometry.html` parameter contract and `tables.html`
-construction catalog.
+the original applet's `Geometry.html` parameter contract and
+`tables.html` construction catalog.
 
 The high-level shape: `init()` takes an `IInitialization` object with
 slate-level params (`background`, `title`, `pivot`, `font`, `fontsize`,

--- a/doc/creating-constructions.md
+++ b/doc/creating-constructions.md
@@ -314,4 +314,4 @@ python3 -m http.server
   this guide.
 - [historical/java-port/creating-constructions.md](historical/java-port/creating-constructions.md)
   — the Java-port-era version of this guide, for anyone curious about
-  how new constructions were ported from Joyce's original Java applet.
+  how new constructions were ported from the original Java applet.

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -42,8 +42,8 @@ other so the result stays sharp.
 ## Naming the free points
 
 Every diagram begins with one or more **free points** — the points
-the user can drag around. Joyce drew red dots for these; `geomlib`
-follows the same convention.
+the user can drag around. The original Geometry Applet drew red dots
+for these; `geomlib` follows the same convention.
 
 ```javascript
 const E = geomlib.E;
@@ -66,7 +66,7 @@ draggable.
 
 ## Connecting them
 
-Joyce's first move in Proposition I.1 is to draw the segment AB.
+The first move in Proposition I.1 is to draw the segment AB.
 That's `E.Line.connect`:
 
 ```javascript
@@ -77,8 +77,8 @@ That's `E.Line.connect`:
 
 ## The two circles
 
-Next Joyce describes "the circle BCD with center A and radius AB"
-and "the circle ACE with center B and radius BA." In `geomlib` that's
+Next come "the circle BCD with center A and radius AB" and "the
+circle ACE with center B and radius BA." In `geomlib` that's
 `E.Circle.radius` — center first, edge point second:
 
 ```javascript
@@ -103,7 +103,7 @@ common chords of two circles. (`Ac` and `Bc` are the *circles*, not
 the centers — `bichord` takes circle elements directly.)
 
 The first endpoint of that line is the apex of our equilateral
-triangle — Joyce calls it **C**:
+triangle — we name it **C**:
 
 ```javascript
 { name: "C", construction: E.Point.first, params: ["CD"] },
@@ -153,7 +153,7 @@ Two new options snuck into that final version:
 - **`pivot: "C"`** — sets a rotation/scale center. If a user grabs a
   *non*-draggable point (like the line AB or the circle Ac) and
   drags, the whole diagram rotates and scales around C instead of
-  translating. This is the same behavior as Joyce's original.
+  translating. This matches the original Geometry Applet's behavior.
 
 ## What you can do now
 
@@ -172,8 +172,8 @@ buttons at the top-right of the canvas.
 
 ## What about the other shorter form?
 
-`geomlib` accepts Joyce's original Java `<param>` strings directly,
-which is convenient when porting one of his pages:
+`geomlib` accepts the original Java `<param>` strings directly,
+which is convenient when porting one of the applet's pages:
 
 ```javascript
 elements: [
@@ -190,7 +190,7 @@ elements: [
 
 Both forms produce the same diagram, and you can mix them in the same
 `elements` array. The string form is often handier when copy-pasting
-from one of Joyce's `<applet>` tags.
+from one of the original `<applet>` tags.
 
 ## Where to go from here
 

--- a/geom_applet/README.md
+++ b/geom_applet/README.md
@@ -9,10 +9,10 @@ historical fidelity.
 
 | Path | What it is |
 |---|---|
-| [`Geometry.zip`](Geometry.zip) | David E. Joyce's original deployable applet archive. The file timestamps inside (1998-02-17 through 2000-10-31) are the actual ship dates of the bytecode — this is what visitors to Joyce's *Elements* pages loaded into their browser's Java plugin from 1998 until applets were retired. 104 KB. Unzip it to recover the historical `.class` files alongside their 1998 timestamps. |
-| [`source/`](source/) | The Java source files Joyce wrote: 44 `.java` files plus `Geometry.html` (the applet's documentation page) and `tables.html` (the construction-method reference). The TypeScript port in [`../src/`](../src/) reimplements these classes. |
+| [`Geometry.zip`](Geometry.zip) | Dr. David E. Joyce's original deployable applet archive. The file timestamps inside (1998-02-17 through 2000-10-31) are the actual ship dates of the bytecode — this is what visitors to the *Elements* pages loaded into their browser's Java plugin from 1998 until applets were retired. 104 KB. Unzip it to recover the historical `.class` files alongside their 1998 timestamps. |
+| [`source/`](source/) | The Java source files written for the original Geometry Applet: 44 `.java` files plus `Geometry.html` (the applet's documentation page) and `tables.html` (the construction-method reference). The TypeScript port in [`../src/`](../src/) reimplements these classes. |
 
-The clean-mirror HTML of Joyce's compass-and-straightedge and
+The clean-mirror HTML of Dr. Joyce's compass-and-straightedge and
 spherical-geometry lecture series live one level up at
 [`../view/compass_geometry/`](../view/compass_geometry/) and
 [`../view/round_geometry/`](../view/round_geometry/) — they're
@@ -24,9 +24,9 @@ with the Java reference here.
 
 Two reasons:
 
-1. **Historical record.** Joyce's applet was originally hosted at Clark
-   University from 1996 onward; he lost write-access to those files
-   when he retired (his own words). The deployable
+1. **Historical record.** The original Geometry Applet was hosted at
+   Clark University from 1996 onward; Dr. Joyce lost write-access to
+   those files when he retired (his own words). The deployable
    archive isn't reliably recoverable from any other source if the
    Clark URL goes offline.
 2. **Reproducibility audit.** A reader who suspects the TS port drifts


### PR DESCRIPTION
Two consistent changes across user-facing docs (README, NOTICE, CONTRIBUTING, AGENTS, doc/*, geom_applet/README.md):

1. **Attribution prose** uses **Dr. Joyce** (with `Dr. David E. Joyce, Professor Emeritus, Clark University` on first reference in README / NOTICE / AGENTS / architecture).
2. **Technical descriptions** reference the original Geometry Applet rather than personalize design details to Dr. Joyce — e.g., "the original `<param>` schema" instead of "Joyce's `<param>` schema." Attribution to him stays in the permission and authorship sections.

Untouched: copyright lines (convention is no titles), his signature in the Quora quote, `doc/historical/` (frozen records), and direct quotes.