### PR TITLE
ci: add github actions for typecheck + unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  unit:
+    name: typecheck + unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run build
+
+      - name: Unit tests
+        run: npm run test:unit


### PR DESCRIPTION
Minimal CI workflow at .github/workflows/test.yml:

- Triggers on push to main + PRs targeting main
- Single job on ubuntu-latest with Node 24 (current LTS)
- Steps: `npm ci` -> `npm run build` (tsc --noEmit) -> `npm run test:unit` (137 tests, ~100 ms)

Snapshot tests intentionally out of scope — the goldens are gitignored per the regenerate-locally workflow. Publishing via a separate workflow on tag push is a natural follow-up.