### PR TITLE
fix(LineElement): render name label at midpoint (#54)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bundle": "npx webpack",
     "bundle:prod": "NODE_ENV=production npx webpack",
     "test": "npm run test:snapshot && npm run test:unit",
-    "test:snapshot": "mocha --reporter min tests/SnapshotTest.ts",
+    "test:snapshot": "npm run bundle && mocha --reporter min tests/SnapshotTest.ts",
     "test:unit": "mocha tests/CircleTest.ts tests/ColorsTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateTest.ts tests/SphereTest.ts",
     "coverage": "c8 mocha --reporter min tests/SnapshotTest.ts tests/CircleTest.ts tests/ColorsTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateTest.ts tests/SphereTest.ts",
     "coverage:unit": "c8 mocha --reporter min tests/CircleTest.ts tests/ColorsTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateTest.ts tests/SphereTest.ts",

--- a/src/elements/line/LineElement.ts
+++ b/src/elements/line/LineElement.ts
@@ -63,6 +63,12 @@ export class LineElement extends GeomElement {
     }
 
     public drawName(c: SlateCanvas): void {
+        if (this.nameColor == null || this.name == null) return;
+        if (this._A == null || !this._A.defined()) return;
+        if (this._B == null || !this._B.defined()) return;
+        const ix = Math.round((this._A.x + this._B.x) / 2);
+        const iy = Math.round((this._A.y + this._B.y) / 2);
+        this.drawString(ix, iy, c);
     }
 
     public drawVertex(c: SlateCanvas): void {

--- a/tests/LineTest.ts
+++ b/tests/LineTest.ts
@@ -352,4 +352,58 @@ describe("line", () => {
         almostEqual(L.A.x, 50, 0.1);
         assert.ok(!isNaN(L.B.x));
     });
+
+    describe("drawName", () => {
+        function buildLine(slate: Slate, opts: { nameColor?: string, name?: string } = {}): LineElement {
+            let data: IConstructionInfo[] = [
+                { construction: E.Point.free,   name: "A",  params: [40, 60] },
+                { construction: E.Point.free,   name: "B",  params: [120, 200] },
+                { construction: E.Line.connect, name: "AB", params: ["A", "B"] },
+            ];
+            toElements(slate, data);
+            slate.elements.forEach(e => e.update());
+            let line = slate.lookupElement("AB") as LineElement;
+            if (opts.name !== undefined) line.name = opts.name;
+            if (opts.nameColor !== undefined) line.nameColor = opts.nameColor;
+            return line;
+        }
+
+        it("draws the label at the midpoint when nameColor and name are set", () => {
+            let slate = new Slate(createCanvas(300, 300));
+            let line = buildLine(slate, { name: "AB", nameColor: "black" });
+
+            let calls: [number, number][] = [];
+            (line as any).drawString = (ix: number, iy: number) => { calls.push([ix, iy]); };
+
+            line.drawName(slate as any);
+
+            assert.equal(calls.length, 1);
+            assert.equal(calls[0][0], Math.round((40 + 120) / 2));
+            assert.equal(calls[0][1], Math.round((60 + 200) / 2));
+        });
+
+        it("does nothing when nameColor is null", () => {
+            let slate = new Slate(createCanvas(300, 300));
+            let line = buildLine(slate, { name: "AB" });
+            line.nameColor = null;
+
+            let called = false;
+            (line as any).drawString = () => { called = true; };
+
+            line.drawName(slate as any);
+            assert.equal(called, false);
+        });
+
+        it("does nothing when name is null", () => {
+            let slate = new Slate(createCanvas(300, 300));
+            let line = buildLine(slate, { nameColor: "black" });
+            line.name = null;
+
+            let called = false;
+            (line as any).drawString = () => { called = true; };
+
+            line.drawName(slate as any);
+            assert.equal(called, false);
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Closes #54. Line name labels weren't rendering because `LineElement.drawName()` was an empty stub even though the param parser already assigns `nameColor` on LineElement instances. Ported the Java applet's algorithm: anchor the label at the midpoint of the two endpoints and delegate to the inherited `drawString` for quadrant-aware placement. Mirrors `PointElement.drawName`'s `nameColor`/`name`/`defined` guard pattern.

Also chains `npm run bundle` into `test:snapshot` so the generated `report.html` interactive previews stay in sync with the snapshot PNGs (previously the previews could lag behind the snapshots and confuse visual review).

## Reference

- Java source: `geom_applet/source/LineElement.java:37-39`
- Mirrors: `src/elements/point/PointElement.ts:371-375`

## Test plan

- [x] `npm run build` clean
- [x] `npm run test:unit` — 140 passing (137 → 140 with 3 new label tests)
- [x] `npm test` regenerates all 678 snapshots successfully
- [x] Spot-check `tests/snapshots/report.html`:
  - propI.22 — labels A, B, C now visible on the three reference segments
  - propII.1 — line "A" label visible above the rectangle
  - propII.12 slate2 — side labels `a`, `b`, `c` visible on the triangle
- [x] `dist/bundle.js` regenerated; report.html's live previews match the snapshots