### PR TITLE
fix(Slate): replace touch→mouse synthesis with Pointer Events (closes #55)

### DIFF
--- a/src/Slate.ts
+++ b/src/Slate.ts
@@ -67,48 +67,53 @@ export class Slate {
 
         if(this._htmlCanvas.addEventListener == null) return;
 
-        this._htmlCanvas.addEventListener("mousedown", (ev) => {
-            let [x, y] : number[] = this._getCanvasPosition(ev.clientX, ev.clientY);
+        // Pointer Events unify mouse / touch / stylus into one event model.
+        // Setting touch-action: none here (rather than relying on
+        // consumer-side CSS) tells the browser not to claim drag gestures
+        // for scroll/zoom; calling setPointerCapture on pointerdown ensures
+        // we keep getting move/up events even when the finger leaves the
+        // canvas bounds. See issue #55 for the design rationale.
+        this._htmlCanvas.style.touchAction = "none";
+
+        // Only the primary pointer drives the drag pipeline for now.
+        // Multi-touch (two-finger rotation etc.) is intentionally not yet
+        // wired — design questions tracked in issue #57.
+        let activePointerId: number | null = null;
+
+        this._htmlCanvas.addEventListener("pointerdown", (ev: PointerEvent) => {
+            if (activePointerId !== null) return; // already tracking a primary
+            activePointerId = ev.pointerId;
+            try { slate._htmlCanvas.setPointerCapture(ev.pointerId); } catch (_) { /* ignore */ }
+            let [x, y] = slate._getCanvasPosition(ev.clientX, ev.clientY);
             slate._onMouseDown(x, y);
         });
 
-        this._htmlCanvas.addEventListener("mouseup", (ev) => {
-            let [x, y] : number[] = this._getCanvasPosition(ev.clientX, ev.clientY);
-            slate._onMouseUp(x, y);
-        });
-
-        this._htmlCanvas.addEventListener("mousemove", (ev) => {
-            let [x, y] : number[] = this._getCanvasPosition(ev.clientX, ev.clientY);
+        this._htmlCanvas.addEventListener("pointermove", (ev: PointerEvent) => {
+            if (ev.pointerId !== activePointerId) return;
+            let [x, y] = slate._getCanvasPosition(ev.clientX, ev.clientY);
             slate._onMouseDrag(x, y);
         });
 
-        for(let [tEvent, mEvent] of [
-            ["touchend", "mouseup"],
-            ["touchstart", "mousedown"],
-            ["touchmove", "mousemove"]
-        ]) {
-            this._htmlCanvas.addEventListener(tEvent, (tv : TouchEvent) => {
-                let pos = slate._getTouchPos(tv);
-                let me = new MouseEvent(mEvent,
-                    {clientX: pos[0], clientY: pos[1]});
-                slate._htmlCanvas.dispatchEvent(me);
-            });
-        }
-        for(let eventType of ["touchstart", "touchmove", "touchend"]) {
-            document.body.addEventListener(eventType, (tv) => {
-                if (tv.target == slate._htmlCanvas) {
-                    tv.preventDefault();
+        let endPointer = (ev: PointerEvent) => {
+            if (ev.pointerId !== activePointerId) return;
+            let [x, y] = slate._getCanvasPosition(ev.clientX, ev.clientY);
+            slate._onMouseUp(x, y);
+            try { slate._htmlCanvas.releasePointerCapture(ev.pointerId); } catch (_) { /* ignore */ }
+            activePointerId = null;
+        };
+
+        this._htmlCanvas.addEventListener("pointerup", endPointer);
+        this._htmlCanvas.addEventListener("pointercancel", endPointer);
+        this._htmlCanvas.addEventListener("lostpointercapture", (ev: PointerEvent) => {
+            if (ev.pointerId === activePointerId) {
+                // Browser revoked capture (e.g., system gesture); clear pick state.
+                if (slate._pick != null) {
+                    slate._pick = null;
                 }
-            }, false);
-        }
+                activePointerId = null;
+            }
+        });
 
-    }
-
-    _getTouchPos(te : TouchEvent) : [number, number] {
-        if (this._htmlCanvas == null) return;
-        let r = this._htmlCanvas.getBoundingClientRect();
-        return [te.touches[0].clientX - r.left,
-                te.touches[0].clientY - r.top];
     }
 
     _getCanvasPosition(x: number, y: number) : [number, number] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,11 @@ export type IndexAllConstructions = AllConstructions;
 export {align  as Align};
 export {e as E};
 
+// Build marker — bumped when behaviour-affecting changes ship so consumers
+// (e.g. the test pages used to investigate #55) can confirm which bundle
+// they're actually running.
+export const BUILD_MARKER = "pointer-events-refactor-v1 (Slate.ts #55)";
+
 export let slates : Slate[] = [];
 
 export interface IConstructionInfo {

--- a/view/test/sample_page/index.html
+++ b/view/test/sample_page/index.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Touch repro — sample proposition page</title>
+
+<!-- VARIABLE A: viewport meta. Mirrors what euclids-elements.org now does
+     post-Phase-1. Comment out to test the no-viewport-meta baseline that
+     the working circle.html test uses. -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<!-- VARIABLE B: external CSS. This is the site's actual style.css copy.
+     The ?v= query string is a cache-buster — bump when iterating so the
+     phone refetches CSS instead of using a cached copy. -->
+<link rel="stylesheet" type="text/css" href="style.css?v=2">
+
+<!-- Bundle from local build, so we can edit src/Slate.ts and rebuild
+     without re-publishing. The ?ts= cache-buster forces the phone to
+     refetch when the bundle is rebuilt locally. Use document.write
+     so the timestamp is computed at page-load time. -->
+<script>
+  document.write('<script src="../../../dist/bundle.js?ts=' + Date.now() + '"><\/script>');
+</script>
+</head>
+<body>
+
+<div id="build-version" style="background:#222;color:#0f0;font-family:monospace;font-size:12px;padding:6px;text-align:center;">
+  test build: v6 — Pointer Events + bundle cache-bust + BUILD_MARKER log
+</div>
+
+<!-- Live touch/pointer/mouse event log. Latest events at top. Tap a
+     canvas and watch what fires (or doesn't). -->
+<div id="evt-log" style="background:#111;color:#0ff;font-family:monospace;font-size:11px;padding:6px;height:120px;overflow-y:auto;white-space:pre;position:sticky;top:0;z-index:1000;"></div>
+<div style="display:flex;gap:6px;padding:4px;background:#111;position:sticky;top:120px;z-index:1000;">
+  <button id="evt-log-copy" style="flex:1;padding:8px;background:#0ff;color:#000;border:none;font-family:monospace;font-size:14px;font-weight:bold;">Copy log</button>
+  <button id="evt-log-clear" style="flex:0 0 80px;padding:8px;background:#444;color:#0ff;border:none;font-family:monospace;font-size:14px;">Clear</button>
+</div>
+<script>
+(function () {
+  var log = document.getElementById("evt-log");
+  function append(line) {
+    var t = new Date();
+    var ts = t.toTimeString().slice(0, 8) + "." + String(t.getMilliseconds()).padStart(3, "0");
+    log.textContent = ts + " " + line + "\n" + log.textContent;
+    // Cap so the log doesn't grow forever
+    if (log.textContent.length > 4000) {
+      log.textContent = log.textContent.slice(0, 4000);
+    }
+  }
+
+  // Copy + clear buttons
+  document.getElementById("evt-log-copy").addEventListener("click", function () {
+    var btn = this;
+    var orig = btn.textContent;
+    var version = (document.getElementById("build-version").textContent || "").trim();
+    var text = "===== " + version + " =====\n" + log.textContent;
+    // Prefer the modern Clipboard API; fall back to a hidden textarea for
+    // older Android Chrome that doesn't have it on http:// origins.
+    var done = function (ok) {
+      btn.textContent = ok ? "Copied!" : "Copy failed — long-press log to select";
+      setTimeout(function () { btn.textContent = orig; }, 1500);
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(function () { done(true); }, function () { done(false); });
+    } else {
+      var ta = document.createElement("textarea");
+      ta.value = text;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.focus(); ta.select();
+      var ok = false;
+      try { ok = document.execCommand("copy"); } catch (_) {}
+      document.body.removeChild(ta);
+      done(ok);
+    }
+  });
+  document.getElementById("evt-log-clear").addEventListener("click", function () {
+    log.textContent = "";
+  });
+  // Wait until canvases exist (geomlib.init has run)
+  window.addEventListener("load", function () {
+    // Log which geomlib bundle is actually running (catches stale-cache cases)
+    try {
+      append("geomlib.BUILD_MARKER = " + (geomlib && geomlib.BUILD_MARKER || "<missing — old bundle>"));
+    } catch (e) {
+      append("geomlib not loaded: " + e.message);
+    }
+    var canvases = document.querySelectorAll("canvas");
+    canvases.forEach(function (c, i) {
+      var label = "c" + i + "(" + (c.id || "?") + ")";
+      ["touchstart", "touchmove", "touchend", "touchcancel",
+       "pointerdown", "pointermove", "pointerup", "pointercancel",
+       "mousedown", "mouseup", "mousemove"].forEach(function (ev) {
+        c.addEventListener(ev, function (e) {
+          // Throttle move events
+          if (ev.indexOf("move") >= 0 && Math.random() > 0.1) return;
+          var x = e.clientX || (e.touches && e.touches[0] && e.touches[0].clientX) || "?";
+          var y = e.clientY || (e.touches && e.touches[0] && e.touches[0].clientY) || "?";
+          append(label + " " + ev + " @ (" + x + "," + y + ")");
+        }, { passive: true });
+      });
+    });
+    append("listeners attached to " + canvases.length + " canvas(es)");
+  });
+})();
+</script>
+
+<h1>I.1 — On a given finite straight line to construct an equilateral triangle</h1>
+
+<div class="theorem">
+
+<div class="statement">Sample statement text — on a given finite straight line to construct an equilateral triangle.</div>
+
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent ac risus
+quis lectus pulvinar ornare. Vivamus euismod, mi vel dictum porttitor, dolor
+neque pulvinar nisi, sit amet aliquam ipsum nibh nec sapien. Fusce viverra
+arcu eu metus euismod, in vehicula lectus pretium.
+
+<div class="ldiagram">
+<!-- VARIABLE C: canvas width/height as HTML attributes (the site's pattern).
+     The working test/circle/circle.html uses CSS sizing instead, which is
+     known to be touch-safe. -->
+<canvas id="canvas_prop" width="340" height="200" tabindex="0"></canvas>
+<script type="text/javascript">
+    geomlib.init({
+        canvasid: "canvas_prop",
+        background: "35,19,100",
+        title: "I.1 (repro)",
+        elements: [
+            "A;point;free;100,150",
+            "B;point;free;240,150",
+            "ABC;polygon;equilateralTriangle;A,B;0;0;black;random",
+            "C;point;vertex;ABC,3"
+        ],
+    });
+</script>
+</div>
+
+<div class="just"><a href="#">I.Post.1</a><br><a href="#">I.Post.3</a></div>
+
+<p>Quisque consectetur, lacus eu congue tincidunt, sapien eros placerat ipsum,
+quis fermentum elit eros sit amet ipsum. Aliquam erat volutpat. Phasellus
+dignissim, ex non porttitor euismod, sapien metus interdum ex.
+
+<p>Etiam non lectus nec arcu interdum aliquam. Curabitur fermentum nibh quis
+mi pharetra, eget tristique magna laoreet. Donec luctus, augue at posuere
+posuere, lectus turpis bibendum velit, in posuere arcu enim non purus.
+
+<p>Therefore the triangle <i>ABC</i> is equilateral, and it has been
+constructed on the given finite straight line <i>AB</i>.
+
+<div class="qed">Q.E.F.</div>
+</div>
+
+<h2>Guide</h2>
+
+<p>Sed posuere consectetur lorem, eget sodales nisl pulvinar sit amet. Donec
+porttitor, neque a faucibus sodales, nisl tellus ornare leo, et vestibulum
+dolor ipsum vitae nisi.
+
+<table cellpadding="5">
+<tr>
+<td>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur vehicula
+nec quam non auctor. Praesent fermentum dictum tortor, vitae malesuada turpis
+laoreet ut. Maecenas dignissim risus a velit posuere, sed pulvinar ipsum
+fermentum.
+
+<p>Vivamus euismod, mi vel dictum porttitor, dolor neque pulvinar nisi, sit
+amet aliquam ipsum nibh nec sapien. Fusce viverra arcu eu metus euismod, in
+vehicula lectus pretium.
+</td>
+<td>
+<canvas id="canvas_guide" width="280" height="200" tabindex="0"></canvas>
+<script type="text/javascript">
+    geomlib.init({
+        canvasid: "canvas_guide",
+        background: "0,0,100",
+        title: "Guide (repro)",
+        elements: [
+            "P;point;free;80,100",
+            "Q;point;free;200,100",
+            "PQ;line;connect;P,Q"
+        ],
+    });
+</script>
+</td>
+</tr>
+</table>
+
+<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames
+ac turpis egestas. Cras commodo ipsum vitae arcu mollis, et porta nulla
+finibus. Aenean ut lectus mi.
+
+</body>
+</html>

--- a/view/test/sample_page/style.css
+++ b/view/test/sample_page/style.css
@@ -1,0 +1,167 @@
+body
+{
+  background-color:#ffffff;
+}
+
+@font-face {
+  font-family: 'Felipa';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Felipa'), local('Felipa-Regular'), url(https://themes.googleusercontent.com/static/fonts/felipa/v1/CGA4sfSyBqMA9-nMl4k29-vvDin1pK8aKteLpeZ5c0A.ttf) format('truetype');
+}
+
+h1 {font-family: 'Felipa';
+  color:#0020C2; 
+  font-weight:normal;
+  text-align: center;}
+h2 {font-family: 'Felipa';
+  color:#0020C2;}
+h3 {font-family: 'Felipa';
+  color:#0020C2;}
+h4 {font-family: 'Felipa';
+  color:#0020C2;}
+  
+div.theorem {
+  background-color:#ffe9cd;
+  border:1px solid #000000;
+  height:auto;
+  width:auto;
+  padding:5px;
+}
+
+div.theorem p {
+  font-weight:normal;
+  padding:4px;
+  border:0px solid #000000;
+  margin:1px;
+}
+
+div.theorem h1 {
+  font-family: 'Felipa';
+  color:#0020C2; 
+  font-weight:normal;
+  text-align: center;
+  border:0px solid #000000;
+  margin:5px;
+  padding:5px;
+}
+div.theorem h2 {
+  font-family: 'Felipa';
+  color:#0020C2;
+}
+div.theorem h3 {
+  font-family: 'Felipa';
+  color:#0020C2;
+}
+div.theorem h4 {
+  font-family: 'Felipa';
+  color:#0020C2;
+}
+
+div.title {
+  font-family: 'Felipa';
+  color:#0020C2; 
+  font-size:200%;
+  font-weight:normal;
+  text-align: center;
+  border:0px solid #000000;
+  margin:5px;
+  padding:5px;
+}
+
+div.statement {
+  text-align:center;
+  font-weight:normal;
+  font-style:italic;
+  font-size:120%;
+  border:0px solid #000000;
+  margin:5px;
+  padding:5px;
+}
+
+div.just {
+  text-align:right;
+  float:right;
+  font-weight:normal;
+  font-size:75%;
+  border:0px solid #000000;
+  width:70px;
+  margin:4px;
+  padding:2px;
+}
+
+div.ldiagram {
+  float:left;
+  border:0px solid #000000;
+  margin:5px;
+}
+
+div.ldiagram {
+  ;
+  border:0px solid #000000;
+  margin:5px;
+}
+
+div.rdiagram {
+  float:right;
+  border:0px solid #000000;
+  margin:5px;
+}
+
+div.qed {
+  text-align:right;
+  font-size:75%;
+  border:0px solid #000000;
+  margin:0px;
+}
+
+/* a.hover to hide a link until the mouse is over it */
+  a.hover:link {text-decoration:none;}    /* unvisited link */
+  a.hover:visited {text-decoration:none;} /* visited link */
+  a.hover:hover {text-decoration:underline;}   /* mouse over link */
+  a.hover:active {text-decoration:underline;}  /* selected link */
+  
+div.twocolumn
+{
+  -moz-column-count:2; /* Firefox */
+  -webkit-column-count:2; /* Safari and Chrome */
+  column-count:2;
+}
+
+  
+div.threecolumn
+{
+  -moz-column-count:3; /* Firefox */
+  -webkit-column-count:3; /* Safari and Chrome */
+  column-count:3;
+}
+
+/* --- Phase 1 mobile-readability patch (issue #4) --- */
+/* Temporary. Proper template-driven redesign lands with the SSG
+   migration in #13. */
+
+/* Don't scale canvases with `max-width: 100%`. CSS-scaling the
+   canvas leaves the bitmap at its declared width/height, so touch
+   events (which fire in CSS pixels) no longer line up with
+   geomlib's hit-testing (which is in canvas-internal pixels). The
+   pages still have a "maximize" button for users who want a bigger
+   view. Proper fix lives in geomlib (event-coord → canvas-coord
+   mapping); see brownnrl/euclid#55. */
+canvas {
+    touch-action: none;
+}
+
+@media (max-width: 768px) {
+    body {
+        padding: 0 10px;
+        box-sizing: border-box;
+    }
+    .ldiagram, .rdiagram {
+        float: none;
+        width: auto;
+    }
+    .just {
+        float: none;
+        width: auto;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #55. Mobile users could not drag points on proposition pages — touch landed but the figure never moved. Diagnosis: `Slate.ts`'s touch handlers synthesized `MouseEvent`s with canvas-local coordinates packed into `clientX/clientY`, then the mousedown handler called `getBoundingClientRect` and subtracted rect.left/top a *second* time. With the canvas near the top of the page (e.g. the [`view/test/circle/circle.html`](view/test/circle/circle.html) test) the double-subtraction was tiny and the bug was invisible. On a real proposition page where the canvas is hundreds of pixels down the page, the effective click landed off the canvas and hit-testing always failed.

Fix: replace touch→mouse synthesis with native Pointer Events.

- Pointer Events unify mouse / touch / stylus into one event model
- `clientX/clientY` are viewport-relative; only one `getBoundingClientRect` subtraction needed
- `canvas.setPointerCapture(pointerId)` on pointerdown keeps move/up events flowing when the finger leaves the canvas bounds
- `canvas.style.touchAction = "none"` from TS tells the browser not to claim drag gestures for scroll/zoom (replaces the brittle `preventDefault()` on touchmove)

Single-pointer drag only here. Multi-touch (two-finger rotation, pinch) has substantive design questions (rotation pivot? does pinch make geometric sense?) tracked in #57.

## Test infrastructure (second commit)

[`view/test/sample_page/`](view/test/sample_page/) — debug fixture that mirrors the consuming site's proposition + guide page structure (which is what surfaced the bug; the pure single-canvas `test/circle/circle.html` couldn't have shown it). Inline event tracer with sticky log + Copy-log button + bundle cache-busting + a `BUILD_MARKER` readout. Keeping this fixture in-repo for future mobile touch investigations.

`BUILD_MARKER` is a small new export from `index.ts` (e.g. `"pointer-events-refactor-v1 (Slate.ts #55)"`) — lets you confirm at a glance which bundle is actually loaded. Useful any time someone changes geomlib locally and wonders whether their phone is hitting cache.

## Verification

- `npm run build` clean
- `npm run test:unit` — 140 passing (no new tests; existing tests didn't simulate input events)
- Manual: tested on user's Android phone via local server. Both canvases on the sample_page fixture now respond to touch drag end-to-end. The maximize button still works. Page-scroll still works when touching outside the canvas. Confirmed via the on-page event tracer (pointerdown → pointermove → pointerup all reaching the canvas with correct coords).

## Versioning

This is a behavioural change to canvas input dispatch. Plan is to ship as **0.2.0** after merge — bump, npm publish, then the consuming site bumps its pinned version.

## Out of scope

- Multi-touch / two-finger gestures — #57
- Pointer Events tests in the unit suite — would require simulating PointerEvent dispatch under JSDOM/canvas, design left for follow-up. Current coverage relies on the manual mobile test on the sample_page fixture