### PR TITLE
refactor(Slate): remove _elementsForUpdate, iterate _elements directly (closes #45)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,14 +102,17 @@ When a `LineElement` name appears in `params`, `Slate.convertParams`
 two elements, not one. Signature counts (`{ points, elements,
 integers }`) must reflect the post-expansion form.
 
-### `[elementsForUpdate, newElement]` return contract
+### `[dependencyElements, newElement]` return contract
 
 `Construction.construct()` returns
-`[elementsForUpdate: GeomElement[], newElement: GeomElement]`.
+`[dependencyElements: GeomElement[], newElement: GeomElement]`.
 Any intermediate element your construction creates (e.g.
 `CircumcenterConstruction` builds an internal `CircumcircleElement`)
-MUST appear in `elementsForUpdate` — otherwise it never recomputes
-and dependents drift on stale data.
+MUST appear in `dependencyElements` — otherwise it never gets
+added to the slate's element list, never recomputes, and dependents
+drift on stale data. (Historically this first return value was called
+`elementsForUpdate` and maintained as a separate array on the slate;
+since #45 the slate iterates `_elements` directly.)
 
 ### Signature variant ordering
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -460,8 +460,7 @@ The publicly-useful methods, all defined in
 |---|---|
 | `slate.lookupElement(name)` | Return the `GeomElement` named `name`, or `null`. |
 | `slate.elements` | Read-only view of all elements (in construction order). |
-| `slate.elementsForUpdate` | Read-only view of elements whose `update()` recomputes from parents each frame. Subset of `elements`. |
-| `slate.update()` | Walk `_elementsForUpdate` calling `update()`, then redraw. Use after directly mutating an element's coords. |
+| `slate.update()` | Walk `_elements` calling `update()`, then redraw. Use after directly mutating an element's coords. |
 | `slate.reset()` | Restore every element to its construction-time position (sliders rewind to their initial coords) and redraw. Same action as the SlateControls reset button (`r` / `space`). |
 | `slate.setPivot(name)` | Set the rotation pivot. `"P"` for screen-plane pivot, `"P,plane"` for a 3D pivot on a non-screen plane. See [Drag pipeline](architecture.md#drag-pipeline-movepick--translatecoordinates--rotatecoordinates). |
 | `slate.bgcolor` | Get or set the canvas background color. |

--- a/src/Slate.ts
+++ b/src/Slate.ts
@@ -11,7 +11,6 @@ export type SlateCanvas = HTMLCanvasElement | Canvas;
 export class Slate {
 
     protected _elements : GeomElement[];
-    protected _elementsForUpdate : GeomElement[];
     protected _screen : PlaneElement;
     protected _pick : PointElement;
     protected _canvas : SlateCanvas;
@@ -26,7 +25,6 @@ export class Slate {
         this._itsNumSlate = Slate.numSlate;
 
         this._elements = [];
-        this._elementsForUpdate = [];
         if(canvas == null) {
             throw new TypeError("canvas cannot be null or undefined.");
         }
@@ -58,8 +56,6 @@ export class Slate {
             e.faceHighlightColor = null;
             this._elements.push(e);
         }
-        this._elementsForUpdate = [...this._elements];
-
         let slate = this;
 
         let cnv : HTMLCanvasElement = this._canvas as HTMLCanvasElement;
@@ -140,10 +136,6 @@ export class Slate {
 
     get elements() : GeomElement[] {
         return this._elements;
-    }
-
-    get elementsForUpdate() : GeomElement[] {
-        return this._elementsForUpdate;
     }
 
     set bgcolor(value: string ) {
@@ -227,8 +219,6 @@ export class Slate {
         if(name != null)
             g.name = name;
         for (let elem of gs) {
-            if (this._elementsForUpdate.indexOf(elem) == -1)
-                this._elementsForUpdate.push(elem);
             if (this._elements.indexOf(elem) == -1)
                 this._elements.push(elem);
         }
@@ -245,7 +235,7 @@ export class Slate {
     }
 
     update() : void {
-        for(let element of this._elementsForUpdate) element.update();
+        for(let element of this._elements) element.update();
         this.drawElements();
     }
 

--- a/tests/LineTest.ts
+++ b/tests/LineTest.ts
@@ -42,10 +42,10 @@ describe("line", () => {
         let slate: Slate = new Slate(createCanvas(200, 200));
         let elms = toElements(slate, circumcenter_data);
         slate.elements.forEach(e => e.update());
-        let elmsUpdate = slate.elementsForUpdate;
-        let n = elmsUpdate.length;
-        let pcircle = elmsUpdate[n - 2] as CircumcircleElement;
-        let pcenter = elmsUpdate[n - 1] as PointElement;
+        let allElms = slate.elements;
+        let n = allElms.length;
+        let pcircle = allElms[n - 2] as CircumcircleElement;
+        let pcenter = allElms[n - 1] as PointElement;
         assert.equal(pcircle.Center, pcenter);
         almostEqual(pcenter.x, 165, 1);
         almostEqual(pcenter.y, 115, 1);


### PR DESCRIPTION
## Summary

Closes #45. Removes the `_elementsForUpdate` array from `Slate`, replacing its sole remaining consumer (`update()`) with a direct iteration over `_elements`.

## Background

`_elementsForUpdate` was a subset of `_elements`: when `construct()` returned `[gs, g]`, only `gs` (the dependency elements) were pushed to `_elementsForUpdate`, while both `gs` and `g` went to `_elements`. The `update()` loop iterated `_elementsForUpdate` to re-derive only dependency elements each frame.

This split was **already partially broken** by the #41 fix, which switched `rotateCoordinates()` from iterating `_elementsForUpdate` to `_elements` (filtering by `!preexists`). After that fix, `update()` was the only remaining consumer of `_elementsForUpdate`.

## Why it's safe

Calling `update()` on the extra elements (those in `_elements` but not the old `_elementsForUpdate`) is harmless: `FreePoint.update()` and other root-level elements' `update()` methods are no-ops. For ~20–50 elements per typical slate, the cycle cost is negligible.

Verified: 678 snapshot tests regenerated identically, 140 unit tests pass.

## What changed

- `src/Slate.ts` — removed `_elementsForUpdate` declaration, its two initializations, both push sites in `createElement()`, and the public getter. `update()` now iterates `_elements`.
- `tests/LineTest.ts` — `slate.elementsForUpdate` → `slate.elements`
- `AGENTS.md` — updated the return-contract section
- `doc/api.md` — removed the `elementsForUpdate` getter row

Historical docs under `doc/historical/` left as-is (frozen).