### PR TITLE
ci: add explicit GITHUB_TOKEN permissions to test workflow (closes #60)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   unit:
+    permissions:
+      contents: read
     name: typecheck + unit tests
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary

Closes #60. Adds `permissions: contents: read` to the `unit` job in `.github/workflows/test.yml`. The workflow only checks out code and runs npm commands — no write access needed.

Resolves CodeQL alert `actions/missing-workflow-permissions` (CWE-275).