### PR TITLE
fix(SlateControls): track window resize while maximized (closes #61)

### DIFF
--- a/src/SlateControls.ts
+++ b/src/SlateControls.ts
@@ -23,6 +23,23 @@ const BTN_SIZE = 20;
 const BTN_GAP = 4;
 const BTN_MARGIN = 8;
 
+// Minimal event-target interface so this helper is testable without a real
+// `Window`. Browser `Window`, `Document`, and `Element` all satisfy it.
+export interface IResizeTarget {
+    addEventListener(type: "resize", listener: () => void): void;
+    removeEventListener(type: "resize", listener: () => void): void;
+}
+
+/**
+ * Attach `callback` to the target's "resize" event. Returns a teardown
+ * function that removes the listener — call it to stop tracking.
+ */
+export function trackWindowResize(target: IResizeTarget, callback: () => void): () => void {
+    const handler = () => callback();
+    target.addEventListener("resize", handler);
+    return () => target.removeEventListener("resize", handler);
+}
+
 export function createControls(slate: Slate, canvas: HTMLCanvasElement, config: IInitConfig): void {
     // Skip in headless/test environments
     if (!canvas.parentElement) return;
@@ -50,6 +67,7 @@ class SlateControls {
         canvasAttrWidth: number;
         canvasAttrHeight: number;
     } = null;
+    private _stopTrackingResize: (() => void) | null = null;
 
     constructor(slate: Slate, canvas: HTMLCanvasElement, config: IInitConfig) {
         this._slate = slate;
@@ -209,10 +227,22 @@ class SlateControls {
         this.resizeAndRedraw();
         this._maximized = true;
         this.updateMaximizeIcon();
+
+        // Track window resize so the canvas bitmap stays in sync with the
+        // wrapper's 100vw × 100vh CSS size. Without this the bitmap stays
+        // at its maximize-time dimensions while the CSS display follows
+        // viewport changes, and the diagram visibly stretches/squishes.
+        this._stopTrackingResize = trackWindowResize(window, () => this.resizeAndRedraw());
     }
 
     private minimize(): void {
         if (!this._savedStyles) return;
+
+        // Stop tracking window resize before restoring saved layout.
+        if (this._stopTrackingResize) {
+            this._stopTrackingResize();
+            this._stopTrackingResize = null;
+        }
 
         // Restore saved styles
         this._wrapper.style.position = this._savedStyles.wrapperPosition;

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -4,6 +4,7 @@ import {Slate} from "../src/Slate";
 import {E, IConstructionInfo, init, slates} from "../src/index";
 import {PlaneSlider} from "../src/elements/point/PlaneSlider";
 import {PointElement} from "../src/elements/point/PointElement";
+import {trackWindowResize} from "../src/SlateControls";
 import {createCanvas} from "canvas";
 import {almostEqual, toElements} from "./shared/testHelpers";
 import {
@@ -417,5 +418,42 @@ describe("slate", () => {
             if (savedDoc === undefined) delete (global as any).document;
             else (global as any).document = savedDoc;
         }
+    });
+
+    // Helper used by SlateControls.maximize() to keep the canvas bitmap in
+    // sync with the wrapper's CSS size when the viewport changes (issue #61).
+    // Pure function — no real Window needed for the unit test.
+    describe("trackWindowResize", () => {
+        it("attaches a resize listener and the teardown removes it", () => {
+            let attached: Array<{type: string; fn: () => void}> = [];
+            let removed: Array<{type: string; fn: () => void}> = [];
+            let target = {
+                addEventListener: (type: "resize", fn: () => void) => {
+                    attached.push({type, fn});
+                },
+                removeEventListener: (type: "resize", fn: () => void) => {
+                    removed.push({type, fn});
+                },
+            };
+            let callCount = 0;
+            let teardown = trackWindowResize(target, () => { callCount++; });
+
+            assert.equal(attached.length, 1, "should attach exactly one listener");
+            assert.equal(attached[0].type, "resize");
+
+            // Firing the attached handler triggers the callback.
+            attached[0].fn();
+            assert.equal(callCount, 1);
+            attached[0].fn();
+            assert.equal(callCount, 2);
+
+            // Teardown removes the SAME handler reference (otherwise the
+            // browser would keep firing it after we stopped caring).
+            teardown();
+            assert.equal(removed.length, 1);
+            assert.equal(removed[0].type, "resize");
+            assert.equal(removed[0].fn, attached[0].fn,
+                "teardown must pass the original handler so removeEventListener actually unregisters it");
+        });
     });
 });


### PR DESCRIPTION
## Summary

Closes #61. When the canvas is maximized and the window resizes (or device rotates), the diagram visibly stretches/squishes because:

- The wrapper has `position:fixed; width:100vw; height:100vh` → CSS size follows the viewport
- The canvas's CSS size is `100%` → also follows the viewport
- But `canvas.width` / `canvas.height` (the **bitmap** resolution) were set once by `resizeAndRedraw()` at maximize time → frozen

So a window resize stretches the unchanging bitmap to fit the new CSS size.

## Fix

Register a `window` resize listener in `maximize()` that re-runs `resizeAndRedraw()`. Unregister it in `minimize()` so we don't leak listeners.

## Testability refactor

The resize-tracking is extracted into a small standalone helper, `trackWindowResize(target, callback)`, exported from `SlateControls`. The helper takes any `EventTarget`-shaped object (any value implementing `addEventListener`/`removeEventListener` for `"resize"`). Browser `Window` satisfies it; the unit test passes a plain JS object with spy methods.

## Test

[`tests/SlateTest.ts`](tests/SlateTest.ts) — new `trackWindowResize` describe block. Verifies:

- Exactly one resize listener attached on call
- Firing the attached listener invokes the callback (twice → callback fires twice)
- Teardown calls `removeEventListener` with the **same function reference** (otherwise the listener leaks)

Unit tests: 141 passing (up from 140).