### PR TITLE
release: 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brownnrl/geomlib",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Interactive Euclidean geometry constructions in the browser — a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
   "keywords": [
     "euclid",


### PR DESCRIPTION
## Release 0.3.0

Minor bump — new exported function plus a couple of fixes.

### Since 0.2.0

| PR | Issue | Change |
|---|---|---|
| #62 | #45 | refactor(Slate): remove `_elementsForUpdate`, iterate `_elements` directly |
| #63 | #60 | ci: add explicit `contents: read` permissions to the test workflow |
| #64 | #61 | fix(SlateControls): track window resize while maximized — fixes diagram distortion when window resizes |
| #65 | #53 | fix(init): graceful fallback to `<noscript>` image when `init()` throws + exports new `revealNoscriptFallback` helper |
| #66 | — | docs: link to euclids-elements.org from top of README |

### Minor (not patch) rationale

#65 adds a new public export, `revealNoscriptFallback(canvas)`. Adding API surface bumps minor under semver, even though no existing behavior changed.

### Verification

- `npm run build` clean
- `npm run test:unit` — 145 passing
- `npm run test:snapshot` — 678 passing
- `npm publish --dry-run` — 100.6 kB tarball, 6 files

### Merge strategy

Should be a fast-forward (one bump commit on top of current main). Use rebase-merge to preserve the `v0.3.0` tag pointing at the same SHA.

### After merge

- `npm publish` from main (needs OTP)
- Bump pin in euclids-elements.org: `@brownnrl/geomlib@0.2.0` → `@0.3.0`