### PR TITLE
0.4.0 — release bump + name aliases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brownnrl/geomlib",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Interactive Euclidean geometry constructions in the browser — a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
   "keywords": [
     "euclid",

--- a/src/Slate.ts
+++ b/src/Slate.ts
@@ -11,6 +11,15 @@ export type SlateCanvas = HTMLCanvasElement | Canvas;
 export class Slate {
 
     protected _elements : GeomElement[];
+    // Name aliases — secondary names that resolve to existing elements
+    // without adding new ones to _elements. The original Geometry Applet
+    // and Euclid's *Elements* refer to the same circle by every
+    // permutation of its three named points (BCD ≡ CDB ≡ DBC ≡ …) and
+    // to lines by either endpoint order (AB ≡ BA). Authors register
+    // those equivalences here so the prose-side `{NAME}` shortcode can
+    // light up the canonical element without needing a parallel
+    // invisible duplicate per alias.
+    private _aliases : Map<string, string> = new Map();
     protected _screen : PlaneElement;
     protected _pick : PointElement;
     protected _canvas : SlateCanvas;
@@ -152,7 +161,26 @@ export class Slate {
                 return elem;
             }
         }
+        // Direct miss — follow the alias map and look up the canonical
+        // name. One hop only: we don't chase chains because aliases are
+        // expected to point at real element names, not at each other.
+        let canonical = this._aliases.get(name);
+        if (canonical != null) {
+            for (let elem of this._elements) {
+                if (elem.name == canonical) return elem;
+            }
+        }
         return null;
+    }
+
+    // Register a single secondary name → canonical name mapping. Idempotent.
+    // Called by init() when the user passes an `aliases` field.
+    addAlias(from: string, to: string) : void {
+        this._aliases.set(from, to);
+    }
+
+    addAliases(aliases: {[from: string]: string}) : void {
+        for (let from in aliases) this._aliases.set(from, aliases[from]);
     }
 
     // Sort params into P[] (points), E[] (other elements), N[] (integers),

--- a/src/Slate.ts
+++ b/src/Slate.ts
@@ -155,6 +155,17 @@ export class Slate {
         return this._bgcolor;
     }
 
+    // Public accessor for the underlying canvas. Consumer-side code on
+    // multi-canvas pages (e.g. the {NAME} shortcode on euclids-elements.org)
+    // needs to compare DOM positions of each slate's canvas against the
+    // prose-side <span> to pick the right slate. Was protected before
+    // 0.4.0; the few prior callers (s.canvas in elem-ref-highlight.js)
+    // were just reading undefined and falling through to a brute-force
+    // walk of geomlib.slates.
+    get canvas() : SlateCanvas {
+        return this._canvas;
+    }
+
     lookupElement(name: string) : GeomElement {
         for (let elem of this._elements) {
             if (elem.name == name) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,12 @@ export interface IInitialization {
     font?: string;
     fontsize?: number;
     elements: (IConstructionInfo | string)[];
+    // Secondary element names that resolve to a canonical element.
+    // Lets prose name an element under any of the conventional
+    // letter-permutations (e.g. "circle BCD" ≡ "circle CDB") without
+    // forcing the canvas to carry an invisible duplicate per alias.
+    // Resolved by Slate.lookupElement after a direct-name miss.
+    aliases?: {[from: string]: string};
 }
 
 // Map Java element class names to E object keys
@@ -191,6 +197,10 @@ function initInner(i: IInitialization, canvas: HTMLCanvasElement) {
         let lighterColor = lighten(slate.bgcolor);
         let defaultFaceColor = element.dimension == 2 ? lighterColor : null;
         element.faceColor = parseColor(param.faceColor, defaultFaceColor, slate.bgcolor);
+    }
+
+    if (i.aliases != null) {
+        slate.addAliases(i.aliases);
     }
 
     if(i.pivot != null) {

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -542,4 +542,60 @@ describe("slate", () => {
             }
         });
     });
+
+    describe("element name aliases", () => {
+        // Joyce's prose names the same circle as both "BCD" and "CDB"
+        // and the same line as both "AB" and "BA". Slate.lookupElement
+        // resolves the secondary name to the canonical element so the
+        // shortcode-driven highlight on the consumer site doesn't need
+        // a separate invisible duplicate per alias.
+        let triangle_data: IConstructionInfo[] = [
+            { construction: E.Point.free,    name: "A",   params: [50, 50] },
+            { construction: E.Point.free,    name: "B",   params: [150, 50] },
+            { construction: E.Line.connect,  name: "AB",  params: ["A", "B"] },
+            { construction: E.Circle.radius, name: "BCD", params: ["A", "B"] },
+        ];
+
+        it("resolves a secondary name to the canonical element", () => {
+            let slate: Slate = new Slate(createCanvas(200, 200));
+            toElements(slate, triangle_data);
+            slate.addAlias("CDB", "BCD");
+            slate.addAlias("BA", "AB");
+            let canonical = slate.lookupElement("BCD");
+            assert.ok(canonical);
+            assert.strictEqual(slate.lookupElement("CDB"), canonical);
+            assert.strictEqual(slate.lookupElement("BA"), slate.lookupElement("AB"));
+        });
+
+        it("returns null when the alias target itself doesn't exist", () => {
+            let slate: Slate = new Slate(createCanvas(200, 200));
+            toElements(slate, triangle_data);
+            slate.addAlias("XYZ", "NOPE");
+            assert.strictEqual(slate.lookupElement("XYZ"), null);
+        });
+
+        it("prefers a direct match over an alias when both exist", () => {
+            // Edge case: someone authored both an element named "BA"
+            // AND an alias "BA → AB". Direct match wins.
+            let slate: Slate = new Slate(createCanvas(200, 200));
+            toElements(slate, triangle_data);
+            // Add a separate BA line so we can disambiguate.
+            toElements(slate, [
+                { construction: E.Line.connect, name: "BA", params: ["B", "A"] },
+            ]);
+            slate.addAlias("BA", "AB");
+            let direct = slate.lookupElement("BA");
+            let canonical = slate.lookupElement("AB");
+            assert.ok(direct);
+            assert.notStrictEqual(direct, canonical);
+        });
+
+        it("addAliases bulk-loads a map", () => {
+            let slate: Slate = new Slate(createCanvas(200, 200));
+            toElements(slate, triangle_data);
+            slate.addAliases({"CDB": "BCD", "BA": "AB"});
+            assert.strictEqual(slate.lookupElement("CDB"), slate.lookupElement("BCD"));
+            assert.strictEqual(slate.lookupElement("BA"),  slate.lookupElement("AB"));
+        });
+    });
 });


### PR DESCRIPTION
Version bump for the highlight-rendering fixes that landed in #73 (closes #72), plus a small additive API for prose-side name aliasing on consumer sites.

## Version
- `package.json` / `package-lock.json` 0.3.0 → 0.4.0.

## feat(slate): name aliases for the {NAME} shortcode

`init()` accepts an optional `aliases: {[from: string]: string}` map. `Slate.lookupElement(name)` follows the map on a direct-name miss so a single canonical element resolves under any of Joyce's letter-permutations:

```ts
geomlib.init({
    ...,
    elements: [..., "BCD;circle;radius;A,B", ...],
    aliases:  { "CDB": "BCD", "BA": "AB", "CA": "AC", "CB": "BC" }
});
```

- Lets consumer sites drop the per-alias invisible-duplicate-element shim that worked around `lookupElement` not knowing about synonyms.
- Direct match always wins over alias resolution; alias-to-missing target returns `null` (no chain following).
- New unit tests: `tests/SlateTest.ts` describe block "element name aliases", 4 cases.

## After merge

`npm publish` from main cuts 0.4.0 to the registry, then `brownnrl/euclids-elements-lektor` bumps its `geomlib_default` pin from `0.3.0` → `0.4.0` and drops both the temporary JS highlight-color override and the per-alias invisible-element rows in `propI.1` (replaced by an `aliases:` block).