### PR TITLE
0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brownnrl/geomlib",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Interactive Euclidean geometry constructions in the browser — a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
   "keywords": [
     "euclid",


### PR DESCRIPTION
Version bump for the slideshow presentation work that landed in #76 (closes #75). Matches the release-PR pattern from #68 (0.3.0) and #74 (0.4.0).

After merge: `npm publish` from `main` cuts 0.5.0 to the registry, then `brownnrl/euclids-elements-lektor` opens a separate PR bumping its `geomlib_default` pin from `0.4.0` → `0.5.0` and adding the propI.1 `slides` block + `window.eucrefs` map.