### PR TITLE
0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brownnrl/geomlib",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Interactive Euclidean geometry constructions in the browser — a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
   "keywords": [
     "euclid",


### PR DESCRIPTION
Release 0.6.0 — slide-transition animations.

## Highlights since 0.5.0

- **Animation registry** (`A.{Type}.{name}`) parallel to constructions: `A.Point.appear`, `A.Line.straightEdgeConnect`, `A.Line.straightEdgeExtend`, `A.Circle.compass`, `A.Polygon.outline`, `A.Polygon.outlineAndFill`, plus `A.instant`.
- **Per-element progress fields** — `drawProgress`, `emphasisAmount` (numeric, replaces `emphasized: boolean` flag with a smooth interpolator), plus `drawStartAngle` / `faceAlpha` on Circle and `faceAlpha` on Polygon. All default to identity values — every pre-existing render path is bit-for-bit unchanged.
- **`Slate.animateTo()` + `SlateAnimator`** — `requestAnimationFrame` loop on `performance.now()` with `MAX_DT_MS = 100` clamp (consistent timing across 60 / 120 / 144 Hz displays and background tabs), cascade / parallel modes, in-flight `cancel()`, `prefers-reduced-motion` fast-path, 250 ms emphasis fade-out after finalise.
- **Ephemeral helpers** — `Slate.addEphemeral` / `removeEphemeral` / `clearEphemerals` for animation-local helper elements that render on top of `_elements` and never survive a cancel.
- **Slide DSL** — `slide.transition.animations: [{ elem, name, args?, durationMs? }]` is opt-in per slide; unannotated slides pop in instantly (matches 0.5.0 behaviour).
- **Docs** — new `doc/creating-animations.md` + `doc/animations-reference.md`; `api.md` + `architecture.md` updated with Slides & visibility and Animation sections.

## Test plan

- [x] `npm run test:unit` — 202 passing
- [x] `npm run test:snapshot` — 700 passing (locally)
- [x] `view/test/slideshow/propI1.html` — propI.1 walkthrough with circles sweeping in via `A.Circle.compass`, lines tracing via `A.Line.straightEdgeConnect`, triangle via `A.Polygon.outlineAndFill`
- [x] `prefers-reduced-motion` honoured — animations jump to finalise