### PR TITLE
Circle highlight on null edge + skip dead fill step for faceless targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Library is **post-porting, publish-ready**. There is no longer a
 "next construction to port" backlog or session-startup ritual.
 
 - All 69 construction methods (with 19 3D variants) are implemented.
-- 202 unit tests + 700 snapshot tests pass.
+- 211 unit tests + 700 snapshot tests pass.
 - 0.4.0 shipped cross-highlighting (`emphasized` / `emphasisAmount`
   + `lookupElement`); 0.5.0 shipped the slideshow surface
   (`slides`, `setVisibleNames`, `addAlias`, `resolveJustification`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ That's it.
 ## Running tests
 
 ```sh
-npm run test:unit      # 202 unit tests — fast (~100 ms)
+npm run test:unit      # 211 unit tests — fast (~100 ms)
 npm run test:snapshot  # 700 visual-regression tests against snapshot goldens
 npm test               # both (snapshot then unit)
 ```

--- a/doc/animations-reference.md
+++ b/doc/animations-reference.md
@@ -66,7 +66,7 @@ Rates are in `px/ms` for linear traces and `rad/ms` for arc sweeps.
 
 | Name | Status | Target | Args | Default | Visual |
 |---|---|---|---|---|---|
-| `A.Circle.compass` | **IMPL** | `CircleElement` | `{ startAngle?: number }` | rate `0.003 rad/ms`, fill cap `600 ms` | Strict two-step. **Step 1** — anchor at centre, pick up the pencil at the radius-defining point `B`, sweep `2π` back to the start (default `startAngle` = angle from centre to `B`, so the trace begins where a real compass would). **Step 2** — face fades in over the now-complete arc at ~half the sweep duration. Independent fields drive the two steps: `drawProgress` finalises to 1 before `faceAlpha` ticks 0 → 1, so the edge stays stable while the fill lands. |
+| `A.Circle.compass` | **IMPL** | `CircleElement` | `{ startAngle?: number }` | rate `0.003 rad/ms`, fill cap `600 ms` | Strict two-step. **Step 1** — anchor at centre, pick up the pencil at the radius-defining point `B`, sweep `2π` back to the start (default `startAngle` = angle from centre to `B`, so the trace begins where a real compass would). **Step 2** — face fades in over the now-complete arc at ~half the sweep duration. Independent fields drive the two steps: `drawProgress` finalises to 1 before `faceAlpha` ticks 0 → 1, so the edge stays stable while the fill lands. A face-less circle (`faceColor` null) skips step 2 entirely — no dead time mid-cascade. |
 | `A.Circle.compassExplicit` | TBD | `CircleElement` | — | — | Reserved. Same sweep as `compass`, but renders ephemeral compass arms (two short lines from centre to the pencil) during the trace. Good for early teaching propositions where the tool itself is part of the explanation. |
 
 ## Polygon animations
@@ -74,7 +74,7 @@ Rates are in `px/ms` for linear traces and `rad/ms` for arc sweeps.
 | Name | Status | Target | Args | Default | Visual |
 |---|---|---|---|---|---|
 | `A.Polygon.outline` | **IMPL** | `PolygonElement` | — | rate `0.25 px/ms`, min `180 ms` | Cascade-trace each edge in `V[]` order. `PolygonElement.drawEdge` partitions `drawProgress` across edges so a single `0 → 1` step traces every edge in sequence at the right per-edge proportion. |
-| `A.Polygon.outlineAndFill` | **IMPL** | `PolygonElement` | — | outline rate `0.25 px/ms`, fill cap `500 ms` | Strict two-step. **Step 1** — outline trace (`drawProgress: 0 → 1`). **Step 2** — face fade-in (`faceAlpha: 0 → 1`) at ~half the outline's runtime. Fill is intentionally shorter than the outline — the eye has already absorbed the shape from the trace, so the fill should land quickly. |
+| `A.Polygon.outlineAndFill` | **IMPL** | `PolygonElement` | — | outline rate `0.25 px/ms`, fill cap `500 ms` | Strict two-step. **Step 1** — outline trace (`drawProgress: 0 → 1`). **Step 2** — face fade-in (`faceAlpha: 0 → 1`) at ~half the outline's runtime. Fill is intentionally shorter than the outline — the eye has already absorbed the shape from the trace, so the fill should land quickly. A face-less polygon (`faceColor` null) skips step 2 entirely. |
 
 ## Reserved / no-namespace
 

--- a/src/SlateAnimator.ts
+++ b/src/SlateAnimator.ts
@@ -158,12 +158,17 @@ export class SlateAnimator {
             const willBeVisible = targetVisible.has(e.name);
             const willBeHighlighted = targetHighlighted.has(e.name);
             if (animatedTargets.has(e)) {
-                // Animation owns visible flag during its run. Pre-flip
-                // shouldHighlight + drawProgress to 0 so the step's
-                // tick / setup start from a clean slate.
+                // Animation owns the visible flag during its run.
+                // Deferred reveal (#83): the target stays hidden until
+                // its own first step starts — drawProgress only gates
+                // the edge, so a pre-revealed target would render its
+                // face fill and name label at full strength while
+                // earlier cascade steps play. _startStep flips it
+                // visible; finalise() restores the final state on
+                // every exit path.
                 e.shouldHighlight = willBeHighlighted;
                 e.drawProgress = 0;
-                e.visible = willBeVisible;
+                e.visible = false;
             } else {
                 // Instant flip — matches 4b behaviour.
                 e.visible = willBeVisible;
@@ -271,6 +276,12 @@ export class SlateAnimator {
         if (stepIdx >= g.steps.length) return;
         const as = g.steps[stepIdx];
         if (as.started) return;
+        // Deferred reveal (#83): the target was held invisible through
+        // any earlier cascade steps; it appears the moment its own
+        // first step begins. setup() runs after this, so an animation
+        // that hides the target to render ephemeral proxies instead
+        // can still do so.
+        if (stepIdx === 0) g.target.visible = true;
         if (as.step.setup) as.step.setup();
         as.started = true;
         g.currentIndex = stepIdx;

--- a/src/elements/circle/CircleAnimations.ts
+++ b/src/elements/circle/CircleAnimations.ts
@@ -37,31 +37,41 @@ export class CircleCompassAnimation extends Animation {
             ? args.startAngle
             : Math.atan2(circle.B.y - circle.Center.y, circle.B.x - circle.Center.x);
         const sweepMs = (2 * Math.PI) / this.defaultRate;
+        const fullRestore = () => {
+            circle.faceAlpha = 1;
+            circle.drawProgress = 1;
+            circle.drawStartAngle = 0;
+            circle.visible = true;
+        };
+        // Step 1 — edge sweep with the face hidden.
+        const sweep: IAnimationStep = {
+            durationMs: sweepMs,
+            setup: () => {
+                circle.drawStartAngle = explicitStart;
+                circle.faceAlpha = 0;
+                circle.drawProgress = 0;
+            },
+            tick: (progress) => { circle.drawProgress = progress; },
+            finalise: () => { circle.drawProgress = 1; },
+        };
+        // A face-less circle has nothing to fade — scheduling the
+        // fill step anyway would be pure dead time in the middle of
+        // a cascade (#81). Run the sweep alone, with its finalise
+        // doing the full restore.
+        if (circle.faceColor == null) {
+            sweep.finalise = fullRestore;
+            return [sweep];
+        }
         // Fill ~twice as fast as the sweep, capped by the class-level
         // default so a tiny circle doesn't yield a blink-of-an-eye fade.
         const fillMs = Math.min(sweepMs / 2, this.defaultDurationMs);
         return [
-            // Step 1 — edge sweep with the face hidden.
-            {
-                durationMs: sweepMs,
-                setup: () => {
-                    circle.drawStartAngle = explicitStart;
-                    circle.faceAlpha = 0;
-                    circle.drawProgress = 0;
-                },
-                tick: (progress) => { circle.drawProgress = progress; },
-                finalise: () => { circle.drawProgress = 1; },
-            },
+            sweep,
             // Step 2 — face fade-in over the now-complete arc.
             {
                 durationMs: fillMs,
                 tick: (progress) => { circle.faceAlpha = progress; },
-                finalise: () => {
-                    circle.faceAlpha = 1;
-                    circle.drawProgress = 1;
-                    circle.drawStartAngle = 0;
-                    circle.visible = true;
-                },
+                finalise: fullRestore,
             },
         ];
     }

--- a/src/elements/circle/CircleElement.ts
+++ b/src/elements/circle/CircleElement.ts
@@ -136,11 +136,19 @@ export class CircleElement extends GeomElement {
 
     public drawEdge(c: SlateCanvas): void {
         if (!this.visible) return;
-        if (this.edgeColor == null || !this.defined()) return;
-        let ctx = c.getContext("2d") as CanvasRenderingContext2D;
-        ctx.strokeStyle = (this.emphasized || this.shouldHighlight)
+        // Pick the highlight color BEFORE the null bail, matching
+        // LineElement / PolygonElement (#81). A circle with a null
+        // edgeColor can still render in the highlight stroke while
+        // emphasized or slide-highlighted — the "invisible highlight
+        // target" pattern, and what lets a zero-color transitionary
+        // circle show up during its compass animation (SlateAnimator
+        // holds emphasisAmount = 1 on animating targets).
+        const color = (this.emphasized || this.shouldHighlight)
             ? this.edgeHighlightColor
             : this.edgeColor;
+        if (color == null || !this.defined()) return;
+        let ctx = c.getContext("2d") as CanvasRenderingContext2D;
+        ctx.strokeStyle = color;
         // Match LineElement: smooth interpolation between baseline (1 or 3)
         // and 6 via emphasisAmount. Always assigned explicitly so a
         // previous element's value doesn't leak.

--- a/src/elements/polygon/PolygonAnimations.ts
+++ b/src/elements/polygon/PolygonAnimations.ts
@@ -75,30 +75,40 @@ export class PolygonOutlineAndFillAnimation extends Animation {
     public build(target: GeomElement, slate: Slate, args: any): IAnimationStep[] {
         const poly = target as PolygonElement;
         const outlineMs = Math.max(180, perimeter(poly) / this.defaultRate);
+        const fullRestore = () => {
+            poly.faceAlpha = 1;
+            poly.drawProgress = 1;
+            poly.visible = true;
+        };
+        // Step 1 — outline trace.
+        const outline: IAnimationStep = {
+            durationMs: outlineMs,
+            setup: () => {
+                poly.drawProgress = 0;
+                poly.faceAlpha = 0;   // hide fill until step 2
+            },
+            tick: (progress) => { poly.drawProgress = progress; },
+            finalise: () => { poly.drawProgress = 1; },
+        };
+        // A face-less polygon has nothing to fade — scheduling the
+        // fill step anyway would be pure dead time in the middle of
+        // a cascade (#81). Run the outline alone, with its finalise
+        // doing the full restore.
+        if (poly.faceColor == null) {
+            outline.finalise = fullRestore;
+            return [outline];
+        }
         // Fill ~twice as fast as the outline, capped at the
         // class-level default so a giant polygon doesn't yield a
         // glacial fade.
         const fillMs = Math.min(outlineMs / 2, this.defaultDurationMs);
         return [
-            // Step 1 — outline trace.
-            {
-                durationMs: outlineMs,
-                setup: () => {
-                    poly.drawProgress = 0;
-                    poly.faceAlpha = 0;   // hide fill until step 2
-                },
-                tick: (progress) => { poly.drawProgress = progress; },
-                finalise: () => { poly.drawProgress = 1; },
-            },
+            outline,
             // Step 2 — face fade-in over the already-traced outline.
             {
                 durationMs: fillMs,
                 tick: (progress) => { poly.faceAlpha = progress; },
-                finalise: () => {
-                    poly.faceAlpha = 1;
-                    poly.drawProgress = 1;
-                    poly.visible = true;
-                },
+                finalise: fullRestore,
             },
         ];
     }

--- a/tests/AnimationSnapshotTest.ts
+++ b/tests/AnimationSnapshotTest.ts
@@ -45,7 +45,9 @@ const TRIANGLE_CONFIG: SlateConfig = {
         "A;point;free;90,200",
         "B;point;free;250,200",
         "C;point;free;170,70",
-        "ABC;polygon;triangle;A,B,C;0;0;black;random",
+        // Deterministic face color — "random" rolls a new pastel per
+        // run, so goldens only match the run that created them (#84).
+        "ABC;polygon;triangle;A,B,C;0;0;black;#ffb6c1",
     ],
 };
 

--- a/tests/AnimationTest.ts
+++ b/tests/AnimationTest.ts
@@ -13,6 +13,7 @@ import {PointElement} from "../src/elements/point/PointElement";
 import {LineElement} from "../src/elements/line/LineElement";
 import {CircleElement} from "../src/elements/circle/CircleElement";
 import {PolygonElement} from "../src/elements/polygon/PolygonElement";
+import {A, findAnimation} from "../src/elements/Animations";
 import {toElements} from "./shared/testHelpers";
 
 // Re-uses the recordingCanvas pattern from HighlightTest, extended to
@@ -310,6 +311,146 @@ describe("element drawProgress rendering (issue #78)", () => {
             const r = recordingCanvas(300, 300);
             pt.drawVertex(r.canvas as any);
             assert.ok(approx(r.recorded.arcs[0].r, 2));
+        });
+    });
+});
+
+// Issue #81 — two related fixes:
+//   1. CircleElement.drawEdge picks the highlight color BEFORE the
+//      null-edgeColor bail, matching LineElement / PolygonElement, so
+//      a zero-color circle renders in the highlight stroke while
+//      emphasized or slide-highlighted (the "invisible highlight
+//      target" pattern; also what makes zero-color transitionary
+//      circles visible during their compass animation, since the
+//      SlateAnimator holds emphasisAmount = 1 on animating targets).
+//   2. Circle.compass / Polygon.outlineAndFill skip their face-fade
+//      step entirely when the target has no faceColor — a null face
+//      never draws, so the step was pure dead time mid-cascade.
+describe("null-edge highlight + face-less animation steps (issue #81)", () => {
+
+    const circle_data: IConstructionInfo[] = [
+        { construction: E.Point.free,    name: "A",   params: [100, 100] },
+        { construction: E.Point.free,    name: "B",   params: [200, 100] },
+        { construction: E.Circle.radius, name: "BCD", params: ["A", "B"] },
+    ];
+
+    const triangle_data: IConstructionInfo[] = [
+        { construction: E.Point.free,       name: "A",   params: [50, 50] },
+        { construction: E.Point.free,       name: "B",   params: [150, 50] },
+        { construction: E.Point.free,       name: "C",   params: [100, 150] },
+        { construction: E.Polygon.triangle, name: "ABC", params: ["A", "B", "C"] },
+    ];
+
+    function makeCircle(): [Slate, CircleElement] {
+        const slate = new Slate(createCanvas(400, 400));
+        toElements(slate, circle_data);
+        slate.elements.forEach(e => e.update());
+        return [slate, slate.lookupElement("BCD") as CircleElement];
+    }
+
+    function makeTriangle(): [Slate, PolygonElement] {
+        const slate = new Slate(createCanvas(300, 300));
+        toElements(slate, triangle_data);
+        return [slate, slate.lookupElement("ABC") as PolygonElement];
+    }
+
+    describe("CircleElement.drawEdge with null edgeColor", () => {
+        it("draws nothing when neither emphasized nor highlighted", () => {
+            const [, circle] = makeCircle();
+            circle.edgeColor = null;
+
+            const r = recordingCanvas(400, 400);
+            circle.drawEdge(r.canvas);
+            assert.strictEqual(r.recorded.ellipses.length, 0);
+        });
+
+        it("draws in the highlight stroke while emphasized", () => {
+            const [, circle] = makeCircle();
+            circle.edgeColor = null;
+            circle.emphasisAmount = 1;
+
+            const r = recordingCanvas(400, 400);
+            circle.drawEdge(r.canvas);
+            assert.strictEqual(r.recorded.ellipses.length, 1);
+        });
+
+        it("draws in the highlight stroke while slide-highlighted", () => {
+            const [, circle] = makeCircle();
+            circle.edgeColor = null;
+            circle.shouldHighlight = true;
+
+            const r = recordingCanvas(400, 400);
+            circle.drawEdge(r.canvas);
+            assert.strictEqual(r.recorded.ellipses.length, 1);
+        });
+    });
+
+    describe("Circle.compass build() on a face-less circle", () => {
+        it("returns the sweep step alone — no dead fill step", () => {
+            const [slate, circle] = makeCircle();
+            circle.faceColor = null;
+            const anim = findAnimation(A.Circle.compass)!;
+            const steps = anim.build(circle, slate, {});
+            assert.strictEqual(steps.length, 1);
+        });
+
+        it("the lone step's finalise does the full restore", () => {
+            const [slate, circle] = makeCircle();
+            circle.faceColor = null;
+            const anim = findAnimation(A.Circle.compass)!;
+            const steps = anim.build(circle, slate, {});
+
+            steps[0].setup!();
+            assert.strictEqual(circle.drawProgress, 0);
+            assert.strictEqual(circle.faceAlpha, 0);
+
+            steps[0].finalise();
+            assert.strictEqual(circle.drawProgress, 1);
+            assert.strictEqual(circle.faceAlpha, 1);
+            assert.strictEqual(circle.drawStartAngle, 0);
+            assert.strictEqual(circle.visible, true);
+        });
+
+        it("still returns sweep + fill when the circle has a face", () => {
+            const [slate, circle] = makeCircle();
+            circle.faceColor = "#ffe9cd";
+            const anim = findAnimation(A.Circle.compass)!;
+            const steps = anim.build(circle, slate, {});
+            assert.strictEqual(steps.length, 2);
+        });
+    });
+
+    describe("Polygon.outlineAndFill build() on a face-less polygon", () => {
+        it("returns the outline step alone — no dead fill step", () => {
+            const [slate, tri] = makeTriangle();
+            tri.faceColor = null;
+            const anim = findAnimation(A.Polygon.outlineAndFill)!;
+            const steps = anim.build(tri, slate, {});
+            assert.strictEqual(steps.length, 1);
+        });
+
+        it("the lone step's finalise does the full restore", () => {
+            const [slate, tri] = makeTriangle();
+            tri.faceColor = null;
+            const anim = findAnimation(A.Polygon.outlineAndFill)!;
+            const steps = anim.build(tri, slate, {});
+
+            steps[0].setup!();
+            assert.strictEqual(tri.drawProgress, 0);
+            assert.strictEqual(tri.faceAlpha, 0);
+
+            steps[0].finalise();
+            assert.strictEqual(tri.drawProgress, 1);
+            assert.strictEqual(tri.faceAlpha, 1);
+            assert.strictEqual(tri.visible, true);
+        });
+
+        it("still returns outline + fill when the polygon has a face", () => {
+            const [slate, tri] = makeTriangle();
+            tri.faceColor = "#ffe9cd";
+            const anim = findAnimation(A.Polygon.outlineAndFill)!;
+            const steps = anim.build(tri, slate, {});
+            assert.strictEqual(steps.length, 2);
         });
     });
 });

--- a/tests/SlateAnimatorTest.ts
+++ b/tests/SlateAnimatorTest.ts
@@ -158,6 +158,61 @@ describe("SlateAnimator (issue #78)", () => {
         });
     });
 
+    describe("deferred reveal (issue #83)", () => {
+        it("keeps a cascade target invisible until its own step starts", async () => {
+            const slate = buildSlate(propI1);
+            slate.animationConfig = {};
+            const ab = slate.lookupElement("AB") as LineElement;
+            const bcd = slate.lookupElement("BCD") as CircleElement;
+            ab.visible = false;
+            bcd.visible = false;
+            // Kick off a two-entry cascade without awaiting: AB's step
+            // starts on kickoff; BCD's turn hasn't come.
+            const p = slate.animateTo(
+                new Set(["A","B","AB","BCD"]),
+                new Set(),
+                [
+                    { elem: "AB",  name: A.Line.straightEdgeConnect },
+                    { elem: "BCD", name: A.Circle.compass },
+                ],
+                "cascade",
+            );
+            // First step (AB) revealed immediately; the pending target
+            // (BCD) stays hidden — its face fill and name label must
+            // not render while AB is still tracing.
+            assert.strictEqual(ab.visible, true, "active target should be revealed");
+            assert.strictEqual(bcd.visible, false, "pending target should stay hidden");
+            slate.animator!.cancel();
+            await p;
+            // Cancel finalises everything — both end visible.
+            assert.strictEqual(ab.visible, true);
+            assert.strictEqual(bcd.visible, true);
+        });
+
+        it("reveals every target up front in parallel mode", async () => {
+            const slate = buildSlate(propI1);
+            slate.animationConfig = {};
+            const ab = slate.lookupElement("AB") as LineElement;
+            const bcd = slate.lookupElement("BCD") as CircleElement;
+            ab.visible = false;
+            bcd.visible = false;
+            const p = slate.animateTo(
+                new Set(["A","B","AB","BCD"]),
+                new Set(),
+                [
+                    { elem: "AB",  name: A.Line.straightEdgeConnect },
+                    { elem: "BCD", name: A.Circle.compass },
+                ],
+                "parallel",
+            );
+            // Parallel kickoff starts every group's first step at once.
+            assert.strictEqual(ab.visible, true);
+            assert.strictEqual(bcd.visible, true);
+            slate.animator!.cancel();
+            await p;
+        });
+    });
+
     describe("cancel()", () => {
         it("finalises every step started so far + clears ephemerals", async () => {
             const slate = buildSlate(propI1);


### PR DESCRIPTION
Fixes #81.

## Changes

- **`CircleElement.drawEdge`** now picks the highlight color *before* the null-edgeColor bail, matching `LineElement` / `PolygonElement`. A zero-color circle renders in the gold highlight stroke while emphasized or slide-highlighted — the "invisible highlight target" pattern. Since `SlateAnimator` holds `emphasisAmount = 1` on animating targets, a zero-color transitionary circle now draws during its compass sweep and fades away with the post-animation emphasis taper.
- **`Circle.compass` / `Polygon.outlineAndFill`** skip their face-fade step when the target has no `faceColor` — a null face never draws, so the step was pure dead time mid-cascade (up to 600 ms per circle, 500 ms per polygon). The sweep/outline step's `finalise` does the full restore instead.
- Doc rows in `animations-reference.md` note the conditional fill step.

## Why now

The propI.2 slideshow (consumer site) wants the two I.1 construction circles to exist *only* during the slide-3 animation — invisible in the static figure, invisible after presentation exit. Zero-color authoring achieves that for free with this fix.

## Test plan

- [x] 9 new unit cases: null-edge circle draws only under emphasis/highlight; faceless circle/polygon builds return a single step whose finalise restores `drawProgress` / `faceAlpha` / `drawStartAngle` / `visible`; faced targets still get two steps
- [x] `npm run test:unit` — 211 passing
- [x] `npm run test:snapshot` — 700 passing (defaults unchanged: emphasis 0 → identical render)
- [x] `npm run build` — clean typecheck