### PR TITLE
0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brownnrl/geomlib",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Interactive Euclidean geometry constructions in the browser — a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
   "keywords": [
     "euclid",


### PR DESCRIPTION
Patch release 0.6.1.

## Fixes since 0.6.0

- #81 — `CircleElement.drawEdge` honors highlight/emphasis color on null edgeColor (matches Line/Polygon; enables zero-color transitionary circles that render only while animating); `Circle.compass` / `Polygon.outlineAndFill` skip the face-fade step on faceless targets (no dead time mid-cascade)
- #83 — animated targets stay hidden until their own cascade step starts (face fills and name labels no longer render early)
- #84 — deterministic snapshot fixture color (test-only)

## Test plan

- [x] `npm run test:unit` — 213 passing
- [x] `npm run test:snapshot` — 700 passing, deterministic across consecutive runs
- [x] propI.2 slideshow walked end-to-end against the dev bundle on the consumer site