### PR TITLE
Sector angle-arc sweep + polygon superposition ghost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Library is **post-porting, publish-ready**. There is no longer a
 "next construction to port" backlog or session-startup ritual.
 
 - All 69 construction methods (with 19 3D variants) are implemented.
-- 211 unit tests + 700 snapshot tests pass.
+- 223 unit tests + 700 snapshot tests pass.
 - 0.4.0 shipped cross-highlighting (`emphasized` / `emphasisAmount`
   + `lookupElement`); 0.5.0 shipped the slideshow surface
   (`slides`, `setVisibleNames`, `addAlias`, `resolveJustification`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ That's it.
 ## Running tests
 
 ```sh
-npm run test:unit      # 211 unit tests — fast (~100 ms)
+npm run test:unit      # 223 unit tests — fast (~100 ms)
 npm run test:snapshot  # 700 visual-regression tests against snapshot goldens
 npm test               # both (snapshot then unit)
 ```

--- a/doc/animations-reference.md
+++ b/doc/animations-reference.md
@@ -75,6 +75,13 @@ Rates are in `px/ms` for linear traces and `rad/ms` for arc sweeps.
 |---|---|---|---|---|---|
 | `A.Polygon.outline` | **IMPL** | `PolygonElement` | — | rate `0.25 px/ms`, min `180 ms` | Cascade-trace each edge in `V[]` order. `PolygonElement.drawEdge` partitions `drawProgress` across edges so a single `0 → 1` step traces every edge in sequence at the right per-edge proportion. |
 | `A.Polygon.outlineAndFill` | **IMPL** | `PolygonElement` | — | outline rate `0.25 px/ms`, fill cap `500 ms` | Strict two-step. **Step 1** — outline trace (`drawProgress: 0 → 1`). **Step 2** — face fade-in (`faceAlpha: 0 → 1`) at ~half the outline's runtime. Fill is intentionally shorter than the outline — the eye has already absorbed the shape from the trace, so the fill should land quickly. A face-less polygon (`faceColor` null) skips step 2 entirely. |
+| `A.Polygon.superpose` | **IMPL** | `PolygonElement` | `{ onto: string }` | translate `0.25 px/ms`, rotate `0.003 rad/ms`, hold `800 ms` | Euclid's superposition (I.4). An **ephemeral gold-outline ghost copy** of the target lifts off, translates so its vertex 0 lands on `onto`'s vertex 0, rotates about the landing point to lay side 0→1 onto the target side, holds a beat coinciding, then retraces both motions home. The real polygon never moves. `onto` must name a polygon with the same vertex count — anything else warns and no-ops. |
+
+## Sector animations
+
+| Name | Status | Target | Args | Default | Visual |
+|---|---|---|---|---|---|
+| `A.Sector.sweep` | **IMPL** | `SectorElement` (incl. `ArcElement`) | — | rate `0.003 rad/ms`, min `250 ms`, fill cap `500 ms` | The arc grows from the A arm toward the B arm (`drawProgress: 0 → 1`) — the angle-marker reveal. Two-step (sweep then face fade) when the sector has a face; a face-less sector skips the fill step. Zero-color sectors render in the gold emphasis stroke only while animating — the invisible angle-marker pattern. |
 
 ## Reserved / no-namespace
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -459,6 +459,7 @@ A.Point      // PointAnimations
 A.Line       // LineAnimations
 A.Circle     // CircleAnimations
 A.Polygon    // PolygonAnimations
+A.Sector     // SectorAnimations (0.7.0+)
 A.instant    // no-op finalise (suppress an inherited animation)
 ```
 

--- a/src/elements/Animations.ts
+++ b/src/elements/Animations.ts
@@ -31,6 +31,8 @@ export enum AllAnimations {
     CIRCLE_COMPASS_EXPLICIT,         // future
     POLYGON_OUTLINE,
     POLYGON_OUTLINE_AND_FILL,
+    POLYGON_SUPERPOSE,
+    SECTOR_SWEEP,
 }
 
 // Typed constants object, mirroring E for constructions. Authors
@@ -52,6 +54,10 @@ export const A = {
     Polygon: {
         outline:             AllAnimations.POLYGON_OUTLINE,
         outlineAndFill:      AllAnimations.POLYGON_OUTLINE_AND_FILL,
+        superpose:           AllAnimations.POLYGON_SUPERPOSE,
+    },
+    Sector: {
+        sweep:               AllAnimations.SECTOR_SWEEP,
     },
     instant:                 AllAnimations.INSTANT,
 };

--- a/src/elements/polygon/PolygonAnimations.ts
+++ b/src/elements/polygon/PolygonAnimations.ts
@@ -5,6 +5,7 @@ import {Animation, AllAnimations, IAnimationStep, registerAnimation} from "../An
 import {GeomElement} from "../GeomElement";
 import {Slate} from "../../Slate";
 import {PolygonElement} from "./PolygonElement";
+import {PointElement} from "../point/PointElement";
 
 // Default per-edge trace rate matches LineAnimations so a polygon's
 // edges feel like the same instrument tracing each side in turn.
@@ -114,5 +115,156 @@ export class PolygonOutlineAndFillAnimation extends Animation {
     }
 }
 
+// A.Polygon.superpose — Euclid's superposition (I.4): an ephemeral
+// gold-outline ghost copy of the target lifts off, translates so its
+// vertex 0 lands on the `onto` polygon's vertex 0, rotates about the
+// landing point to lay side 0→1 onto the target side 0→1 (carrying
+// the remaining vertices with it), holds a beat coinciding, then
+// retraces both motions home. The real polygon never moves — the
+// ephemeral system owns the moving copy and its cleanup.
+//
+// Args: { onto: string } — the polygon to superpose onto. Must
+// resolve to a PolygonElement with the same vertex count; anything
+// else warns and falls through to an instant no-op.
+const SUPERPOSE_TRANSLATE_RATE_PX_PER_MS = 0.25;
+const SUPERPOSE_ROTATE_RATE_RAD_PER_MS = 0.003;
+const SUPERPOSE_MIN_STEP_MS = 250;
+const SUPERPOSE_HOLD_MS = 800;
+const GHOST_COLOR = "#FFD700";
+
+export class PolygonSuperposeAnimation extends Animation {
+    public animationMethod = AllAnimations.POLYGON_SUPERPOSE;
+    public name = "Polygon.superpose";
+    public elementType = PolygonElement;
+
+    public build(target: GeomElement, slate: Slate, args: any): IAnimationStep[] {
+        const poly = target as PolygonElement;
+        const ontoName = args && args.onto;
+        const onto = ontoName != null ? slate.lookupElement(String(ontoName)) : null;
+        if (!(onto instanceof PolygonElement) || onto.V.length !== poly.V.length) {
+            if (typeof console !== "undefined" && console.warn) {
+                console.warn("[geomlib] Polygon.superpose: args.onto ('"
+                    + ontoName + "') is not a polygon with "
+                    + poly.V.length + " vertices — skipping");
+            }
+            return [{
+                durationMs: 0,
+                tick: () => {},
+                finalise: () => {
+                    poly.drawProgress = 1;
+                    poly.visible = true;
+                },
+            }];
+        }
+
+        // Source coordinates are captured at setup time (not build
+        // time) so the ghost reflects any drags that happened between
+        // slide construction and this step actually starting.
+        const n = poly.V.length;
+        let src: Array<{x: number, y: number}> = [];
+        let dx = 0, dy = 0;         // translate delta: V[0] → onto.V[0]
+        let theta = 0;              // rotation about the landing point
+        const ghostPts: PointElement[] = [];
+        const ghost = new PolygonElement();
+        ghost.edgeColor = GHOST_COLOR;
+        ghost.faceColor = null;
+        ghost.nameColor = null;
+        ghost.vertexColor = null;
+
+        const setGhost = (coords: Array<{x: number, y: number}>) => {
+            for (let i = 0; i < n; i++) {
+                ghostPts[i].x = coords[i].x;
+                ghostPts[i].y = coords[i].y;
+            }
+        };
+        const translated = (t: number) =>
+            src.map(p => ({ x: p.x + dx * t, y: p.y + dy * t }));
+        // Rotate the fully-translated coords about the landing point
+        // (onto.V[0]) by angle · t.
+        const rotated = (t: number) => {
+            const cx = onto.V[0].x, cy = onto.V[0].y;
+            const cos = Math.cos(theta * t), sin = Math.sin(theta * t);
+            return translated(1).map(p => ({
+                x: cx + (p.x - cx) * cos - (p.y - cy) * sin,
+                y: cy + (p.x - cx) * sin + (p.y - cy) * cos,
+            }));
+        };
+
+        // Durations are estimated from build-time geometry; the exact
+        // path re-derives from setup-time coords so a stale estimate
+        // only affects pacing, never correctness.
+        const estDist = Math.hypot(onto.V[0].x - poly.V[0].x, onto.V[0].y - poly.V[0].y);
+        const translateMs = Math.max(SUPERPOSE_MIN_STEP_MS,
+            estDist / SUPERPOSE_TRANSLATE_RATE_PX_PER_MS);
+        const estTheta = Math.abs(this._sideAngleDelta(poly, onto));
+        const rotateMs = Math.max(SUPERPOSE_MIN_STEP_MS,
+            estTheta / SUPERPOSE_ROTATE_RATE_RAD_PER_MS);
+
+        return [
+            // ① glide: vertex 0 travels to onto's vertex 0.
+            {
+                durationMs: translateMs,
+                setup: () => {
+                    src = poly.V.map(p => ({ x: p.x, y: p.y }));
+                    dx = onto.V[0].x - src[0].x;
+                    dy = onto.V[0].y - src[0].y;
+                    theta = this._sideAngleDelta(poly, onto);
+                    for (let i = 0; i < n; i++) {
+                        const gp = new PointElement();
+                        gp.x = src[i].x;
+                        gp.y = src[i].y;
+                        ghostPts.push(gp);
+                        ghost.V.push(gp);
+                    }
+                    slate.addEphemeral(ghost);
+                },
+                tick: (p) => { setGhost(translated(p)); },
+                finalise: () => { setGhost(translated(1)); },
+            },
+            // ② rotate about the landing point: side 0→1 lays onto
+            // the target's side 0→1.
+            {
+                durationMs: rotateMs,
+                tick: (p) => { setGhost(rotated(p)); },
+                finalise: () => { setGhost(rotated(1)); },
+            },
+            // ③ hold, coinciding.
+            {
+                durationMs: SUPERPOSE_HOLD_MS,
+                tick: () => {},
+                finalise: () => {},
+            },
+            // ④ rotate home.
+            {
+                durationMs: rotateMs,
+                tick: (p) => { setGhost(rotated(1 - p)); },
+                finalise: () => { setGhost(translated(1)); },
+            },
+            // ⑤ glide home; the ghost's work is done.
+            {
+                durationMs: translateMs,
+                tick: (p) => { setGhost(translated(1 - p)); },
+                finalise: () => {
+                    slate.removeEphemeral(ghost);
+                    poly.drawProgress = 1;
+                    poly.visible = true;
+                },
+            },
+        ];
+    }
+
+    // Angle that carries the source side V[0]→V[1] onto the target
+    // side, normalized to [-π, π] so the ghost takes the short way.
+    private _sideAngleDelta(from: PolygonElement, onto: PolygonElement): number {
+        const a = Math.atan2(from.V[1].y - from.V[0].y, from.V[1].x - from.V[0].x);
+        const b = Math.atan2(onto.V[1].y - onto.V[0].y, onto.V[1].x - onto.V[0].x);
+        let d = b - a;
+        while (d > Math.PI) d -= 2 * Math.PI;
+        while (d < -Math.PI) d += 2 * Math.PI;
+        return d;
+    }
+}
+
 registerAnimation(new PolygonOutlineAnimation());
 registerAnimation(new PolygonOutlineAndFillAnimation());
+registerAnimation(new PolygonSuperposeAnimation());

--- a/src/elements/polygon/PolygonAnimations.ts
+++ b/src/elements/polygon/PolygonAnimations.ts
@@ -205,6 +205,12 @@ export class PolygonSuperposeAnimation extends Animation {
             {
                 durationMs: translateMs,
                 setup: () => {
+                    // Superpose is not a reveal — the real polygon is
+                    // already on stage and must stay fully drawn while
+                    // its ghost travels. Undo the animator's reveal-
+                    // convention pre-zeroing.
+                    poly.drawProgress = 1;
+                    poly.visible = true;
                     src = poly.V.map(p => ({ x: p.x, y: p.y }));
                     dx = onto.V[0].x - src[0].x;
                     dy = onto.V[0].y - src[0].y;

--- a/src/elements/sector/SectorAnimations.ts
+++ b/src/elements/sector/SectorAnimations.ts
@@ -1,0 +1,65 @@
+// Animations targeting SectorElement (and its ArcElement subclass).
+// See ../Animations.ts for the abstract base + registry mechanics.
+
+import {Animation, AllAnimations, IAnimationStep, registerAnimation} from "../Animations";
+import {GeomElement} from "../GeomElement";
+import {Slate} from "../../Slate";
+import {SectorElement} from "./SectorElement";
+
+// Same sweep rate as Circle.compass so an angle arc feels like the
+// same instrument; a typical quarter-turn marker (~π/2) sweeps in
+// ~500 ms. Min duration keeps a narrow angle from blinking past.
+const DEFAULT_SWEEP_RATE_RAD_PER_MS = 0.003;
+const MIN_SWEEP_MS = 250;
+const DEFAULT_SECTOR_FILL_MS = 500;
+
+// A.Sector.sweep — the arc grows from the A arm toward the B arm by
+// driving drawProgress. Args: none. Duration = |arcAngle| / rate.
+//
+// Two-step when the sector has a face (sweep then face fade-in,
+// mirroring Circle.compass); a face-less sector skips the fill step
+// entirely (#81 pattern) — which is the common case for zero-color
+// angle markers that render gold only while animating.
+export class SectorSweepAnimation extends Animation {
+    public animationMethod = AllAnimations.SECTOR_SWEEP;
+    public name = "Sector.sweep";
+    public elementType = SectorElement;
+    public defaultRate = DEFAULT_SWEEP_RATE_RAD_PER_MS;
+    public defaultDurationMs = DEFAULT_SECTOR_FILL_MS;
+
+    public build(target: GeomElement, slate: Slate, args: any): IAnimationStep[] {
+        const sector = target as SectorElement;
+        const arcAngle = Math.abs(
+            sector._Center.angle(sector._A, sector._B, sector._P));
+        const sweepMs = Math.max(MIN_SWEEP_MS, arcAngle / this.defaultRate);
+        const fullRestore = () => {
+            sector.faceAlpha = 1;
+            sector.drawProgress = 1;
+            sector.visible = true;
+        };
+        const sweep: IAnimationStep = {
+            durationMs: sweepMs,
+            setup: () => {
+                sector.faceAlpha = 0;
+                sector.drawProgress = 0;
+            },
+            tick: (progress) => { sector.drawProgress = progress; },
+            finalise: () => { sector.drawProgress = 1; },
+        };
+        if (sector.faceColor == null) {
+            sweep.finalise = fullRestore;
+            return [sweep];
+        }
+        const fillMs = Math.min(sweepMs / 2, this.defaultDurationMs);
+        return [
+            sweep,
+            {
+                durationMs: fillMs,
+                tick: (progress) => { sector.faceAlpha = progress; },
+                finalise: fullRestore,
+            },
+        ];
+    }
+}
+
+registerAnimation(new SectorSweepAnimation());

--- a/src/elements/sector/SectorElement.ts
+++ b/src/elements/sector/SectorElement.ts
@@ -39,6 +39,16 @@ export class SectorElement extends GeomElement {
 
     _angle : number = null;
 
+    // Face fill alpha — drives drawFace's globalAlpha independent of
+    // drawProgress (which drives the arc sweep). Default 1 keeps every
+    // existing render path identical. Mirrors Circle/Polygon (#86).
+    private _faceAlpha : number = 1;
+
+    set faceAlpha(value: number) {
+        this._faceAlpha = value < 0 ? 0 : (value > 1 ? 1 : value);
+    }
+    get faceAlpha(): number { return this._faceAlpha; }
+
     constructor(isec?: ISectorElementConstruction) {
         super();
         this.dimension = 2;
@@ -77,17 +87,31 @@ export class SectorElement extends GeomElement {
 
     drawEdge(c: SlateCanvas): void {
         if (!this.visible) return;
-        if (this.edgeColor == null || !this.defined()) return;
+        // Pick the highlight color BEFORE the null bail, matching the
+        // other element types (#81 / #86) — a zero-color sector can
+        // still render in the highlight stroke while emphasized or
+        // slide-highlighted, which is what lets invisible angle
+        // markers light up on demand.
+        const color = (this.emphasized || this.shouldHighlight)
+            ? this.edgeHighlightColor
+            : this.edgeColor;
+        if (color == null || !this.defined()) return;
         let ctx = c.getContext("2d") as CanvasRenderingContext2D;
-        ctx.strokeStyle = this.edgeColor;
+        ctx.strokeStyle = color;
+        {
+            const baseW = this.shouldHighlight ? 3 : 1;
+            ctx.lineWidth = baseW + this.emphasisAmount * (6 - baseW);
+        }
         ctx.beginPath();
         let r = this.radius();
-        let d = 2 * r;
         let startAngle = Math.atan2(
             this._A.y - this._Center.y,
             this._A.x - this._Center.x);
         let arcAngle = this._Center.angle(this._A, this._B, this._P);
-        let endAngle = startAngle + arcAngle;
+        // Partial sweep for slide-transition animation: the arc grows
+        // from the A arm toward the B arm as drawProgress goes 0 → 1.
+        // Default progress = 1 reproduces the full arc bit-for-bit.
+        let endAngle = startAngle + arcAngle * this.drawProgress;
         ctx.arc(this._Center.x, this._Center.y, r, startAngle, endAngle, true);
         ctx.stroke();
     }
@@ -95,11 +119,16 @@ export class SectorElement extends GeomElement {
     drawFace(c: SlateCanvas): void {
         if (!this.visible) return;
         if (this.faceColor == null || !this.defined()) return;
+        // Face is independent of the edge sweep — always the full
+        // sector wedge, with alpha driven by the dedicated faceAlpha
+        // field (mirrors Circle/Polygon, #86). Default 1 preserves
+        // the fully-opaque behaviour for every non-animating consumer.
+        let a = this.faceAlpha;
+        if (a <= 0) return;
         let ctx = c.getContext("2d") as CanvasRenderingContext2D;
         ctx.fillStyle = this.faceColor;
         ctx.beginPath();
         let r = this.radius();
-        let d = 2 * r;
         let startAngle = Math.atan2(
             this._A.y - this._Center.y,
             this._A.x - this._Center.x);
@@ -115,7 +144,14 @@ export class SectorElement extends GeomElement {
             ctx.lineTo(this._A.x, this._A.y);
         }
         ctx.lineTo(this._Center.x, this._Center.y);
-        ctx.fill();
+        if (a < 1) {
+            ctx.save();
+            ctx.globalAlpha = a;
+            ctx.fill();
+            ctx.restore();
+        } else {
+            ctx.fill();
+        }
     }
 
     drawName(c: SlateCanvas): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import "./elements/point/PointAnimations";
 import "./elements/line/LineAnimations";
 import "./elements/circle/CircleAnimations";
 import "./elements/polygon/PolygonAnimations";
+import "./elements/sector/SectorAnimations";
 import {PointElement} from "./elements/point/PointElement";
 import {Slate} from "./Slate";
 import {PlaneSlider} from "./elements/point/PlaneSlider";

--- a/tests/AnimationTest.ts
+++ b/tests/AnimationTest.ts
@@ -603,8 +603,15 @@ describe("sector sweep + polygon superposition (issue #86)", () => {
             const anim = findAnimation(A.Polygon.superpose)!;
             const steps = anim.build(abc, slate, { onto: "DEF" });
             assert.strictEqual(slate.ephemerals.length, 0);
+            // The animator's reveal convention pre-zeroes the target;
+            // superpose's setup must immediately restore it (the real
+            // polygon stays fully drawn while the ghost travels).
+            abc.drawProgress = 0;
+            abc.visible = false;
             steps[0].setup!();
             assert.strictEqual(slate.ephemerals.length, 1);
+            assert.strictEqual(abc.drawProgress, 1);
+            assert.strictEqual(abc.visible, true);
             for (const s of steps) s.finalise();
             assert.strictEqual(slate.ephemerals.length, 0);
         });

--- a/tests/AnimationTest.ts
+++ b/tests/AnimationTest.ts
@@ -13,6 +13,7 @@ import {PointElement} from "../src/elements/point/PointElement";
 import {LineElement} from "../src/elements/line/LineElement";
 import {CircleElement} from "../src/elements/circle/CircleElement";
 import {PolygonElement} from "../src/elements/polygon/PolygonElement";
+import {SectorElement} from "../src/elements/sector/SectorElement";
 import {A, findAnimation} from "../src/elements/Animations";
 import {toElements} from "./shared/testHelpers";
 
@@ -28,7 +29,10 @@ function recordingCanvas(w: number, h: number) {
             x: number, y: number, rx: number, ry: number,
             rotation: number, startAngle: number, endAngle: number,
         }>,
-        arcs:       [] as Array<{x: number, y: number, r: number}>,
+        arcs:       [] as Array<{
+            x: number, y: number, r: number,
+            startAngle?: number, endAngle?: number,
+        }>,
         alphas:     [] as number[],
     };
     const ctx: any = new Proxy(real.getContext("2d") as any, {
@@ -59,7 +63,10 @@ function recordingCanvas(w: number, h: number) {
             }
             if (prop === "arc") {
                 return function(x: number, y: number, r: number, ...rest: any[]) {
-                    recorded.arcs.push({x, y, r});
+                    recorded.arcs.push({
+                        x, y, r,
+                        startAngle: rest[0], endAngle: rest[1],
+                    });
                     return (target as any).arc(x, y, r, ...rest);
                 };
             }
@@ -451,6 +458,200 @@ describe("null-edge highlight + face-less animation steps (issue #81)", () => {
             const anim = findAnimation(A.Polygon.outlineAndFill)!;
             const steps = anim.build(tri, slate, {});
             assert.strictEqual(steps.length, 2);
+        });
+    });
+});
+
+// Issue #86 — sector angle-arc animation + polygon superposition.
+//   1. SectorElement.drawEdge gains drawProgress partial sweep,
+//      emphasisAmount stroke interpolation, and the highlight-before-
+//      null-bail color pick (so zero-color angle markers render gold
+//      under emphasis / slide-highlight).
+//   2. A.Sector.sweep — arc grows from the A arm toward the B arm;
+//      face-less sectors skip the fill step (the #81 pattern).
+//   3. A.Polygon.superpose — ephemeral gold ghost translates onto the
+//      args.onto polygon, rotates side onto side, holds, and retraces
+//      home; the real polygon never moves.
+describe("sector sweep + polygon superposition (issue #86)", () => {
+
+    const sector_data: IConstructionInfo[] = [
+        { construction: E.Point.free,     name: "O", params: [100, 100] },
+        { construction: E.Point.free,     name: "P", params: [200, 100] },
+        { construction: E.Point.free,     name: "Q", params: [100, 200] },
+        { construction: E.Sector.sector,  name: "S", params: ["O", "P", "Q"] },
+    ];
+
+    // DEF is ABC translated by (150, 50) then rotated 90° about D —
+    // congruent, same orientation, so a superposed ghost lands exactly.
+    const two_triangles: IConstructionInfo[] = [
+        { construction: E.Point.free,       name: "A",   params: [50, 50] },
+        { construction: E.Point.free,       name: "B",   params: [150, 50] },
+        { construction: E.Point.free,       name: "C",   params: [100, 130] },
+        { construction: E.Polygon.triangle, name: "ABC", params: ["A", "B", "C"] },
+        { construction: E.Point.free,       name: "D",   params: [200, 100] },
+        { construction: E.Point.free,       name: "E2",  params: [200, 200] },
+        { construction: E.Point.free,       name: "F",   params: [120, 150] },
+        { construction: E.Polygon.triangle, name: "DEF", params: ["D", "E2", "F"] },
+    ];
+
+    function makeSector(): [Slate, SectorElement] {
+        const slate = new Slate(createCanvas(300, 300));
+        toElements(slate, sector_data);
+        slate.elements.forEach(e => e.update());
+        return [slate, slate.lookupElement("S") as SectorElement];
+    }
+
+    describe("SectorElement.drawEdge", () => {
+        it("sweeps a partial arc at drawProgress = 0.5", () => {
+            const [, sector] = makeSector();
+            sector.edgeColor = "#000000";
+            sector.drawProgress = 0.5;
+
+            const r = recordingCanvas(300, 300);
+            sector.drawEdge(r.canvas);
+            assert.strictEqual(r.recorded.arcs.length, 1);
+            const a = r.recorded.arcs[0];
+            // P is due east of O → startAngle 0; Q is due south (+90°
+            // in canvas coords) but the sector sweeps anticlockwise
+            // (-270°): arcAngle from angle() keeps its sign and the
+            // half sweep is exactly half of the full endAngle.
+            const rFull = recordingCanvas(300, 300);
+            sector.drawProgress = 1;
+            sector.drawEdge(rFull.canvas);
+            const full = rFull.recorded.arcs[0];
+            assert.ok(approx(a.startAngle!, full.startAngle!),
+                `start angles differ: ${a.startAngle} vs ${full.startAngle}`);
+            const half = full.startAngle! + (full.endAngle! - full.startAngle!) / 2;
+            assert.ok(approx(a.endAngle!, half),
+                `endAngle at 0.5: ${a.endAngle} (expected ${half})`);
+        });
+
+        it("renders nothing with null edgeColor and no emphasis", () => {
+            const [, sector] = makeSector();
+            sector.edgeColor = null;
+            const r = recordingCanvas(300, 300);
+            sector.drawEdge(r.canvas);
+            assert.strictEqual(r.recorded.arcs.length, 0);
+        });
+
+        it("renders in the highlight stroke while emphasized", () => {
+            const [, sector] = makeSector();
+            sector.edgeColor = null;
+            sector.emphasisAmount = 1;
+            const r = recordingCanvas(300, 300);
+            sector.drawEdge(r.canvas);
+            assert.strictEqual(r.recorded.arcs.length, 1);
+        });
+
+        it("renders in the highlight stroke while slide-highlighted", () => {
+            const [, sector] = makeSector();
+            sector.edgeColor = null;
+            sector.shouldHighlight = true;
+            const r = recordingCanvas(300, 300);
+            sector.drawEdge(r.canvas);
+            assert.strictEqual(r.recorded.arcs.length, 1);
+        });
+    });
+
+    describe("A.Sector.sweep build()", () => {
+        it("face-less sector gets the sweep step alone, with full restore", () => {
+            const [slate, sector] = makeSector();
+            sector.faceColor = null;
+            const anim = findAnimation(A.Sector.sweep)!;
+            const steps = anim.build(sector, slate, {});
+            assert.strictEqual(steps.length, 1);
+
+            steps[0].setup!();
+            assert.strictEqual(sector.drawProgress, 0);
+            steps[0].tick(0.5, 8, steps[0].durationMs);
+            assert.ok(approx(sector.drawProgress, 0.5));
+            steps[0].finalise();
+            assert.strictEqual(sector.drawProgress, 1);
+            assert.strictEqual(sector.faceAlpha, 1);
+            assert.strictEqual(sector.visible, true);
+        });
+
+        it("faced sector gets sweep + fill", () => {
+            const [slate, sector] = makeSector();
+            sector.faceColor = "#ffe9cd";
+            const anim = findAnimation(A.Sector.sweep)!;
+            const steps = anim.build(sector, slate, {});
+            assert.strictEqual(steps.length, 2);
+        });
+    });
+
+    describe("A.Polygon.superpose build()", () => {
+        function makeTriangles(): [Slate, PolygonElement, PolygonElement] {
+            const slate = new Slate(createCanvas(400, 300));
+            toElements(slate, two_triangles);
+            return [
+                slate,
+                slate.lookupElement("ABC") as PolygonElement,
+                slate.lookupElement("DEF") as PolygonElement,
+            ];
+        }
+
+        it("returns the five-step out-and-back journey", () => {
+            const [slate, abc] = makeTriangles();
+            const anim = findAnimation(A.Polygon.superpose)!;
+            const steps = anim.build(abc, slate, { onto: "DEF" });
+            assert.strictEqual(steps.length, 5);
+        });
+
+        it("setup spawns the ghost ephemeral; the last finalise removes it", () => {
+            const [slate, abc] = makeTriangles();
+            const anim = findAnimation(A.Polygon.superpose)!;
+            const steps = anim.build(abc, slate, { onto: "DEF" });
+            assert.strictEqual(slate.ephemerals.length, 0);
+            steps[0].setup!();
+            assert.strictEqual(slate.ephemerals.length, 1);
+            for (const s of steps) s.finalise();
+            assert.strictEqual(slate.ephemerals.length, 0);
+        });
+
+        it("translate midpoint, rotated landing, and untouched original", () => {
+            const [slate, abc, def] = makeTriangles();
+            const anim = findAnimation(A.Polygon.superpose)!;
+            const steps = anim.build(abc, slate, { onto: "DEF" });
+
+            steps[0].setup!();
+            const ghost = slate.ephemerals[0] as PolygonElement;
+
+            // Halfway through the glide: vertex 0 between A(50,50)
+            // and D(200,100).
+            steps[0].tick(0.5, 8, steps[0].durationMs);
+            assert.ok(approx(ghost.V[0].x, 125), `ghost V0.x ${ghost.V[0].x}`);
+            assert.ok(approx(ghost.V[0].y, 75), `ghost V0.y ${ghost.V[0].y}`);
+            steps[0].finalise();
+
+            // Rotation complete: every ghost vertex coincides with DEF.
+            steps[1].tick(1, 8, steps[1].durationMs);
+            for (let i = 0; i < 3; i++) {
+                assert.ok(approx(ghost.V[i].x, def.V[i].x, 0.5),
+                    `ghost V${i}.x ${ghost.V[i].x} vs ${def.V[i].x}`);
+                assert.ok(approx(ghost.V[i].y, def.V[i].y, 0.5),
+                    `ghost V${i}.y ${ghost.V[i].y} vs ${def.V[i].y}`);
+            }
+
+            // Return trip ends at home; the real ABC never moved.
+            steps[1].finalise(); steps[2].finalise();
+            steps[3].finalise();
+            steps[4].tick(1, 8, steps[4].durationMs);
+            assert.ok(approx(ghost.V[0].x, 50));
+            assert.ok(approx(ghost.V[0].y, 50));
+            assert.strictEqual(abc.V[0].x, 50);
+            assert.strictEqual(abc.V[0].y, 50);
+            steps[4].finalise();
+        });
+
+        it("warns and no-ops on a missing or mismatched onto", () => {
+            const [slate, abc] = makeTriangles();
+            const anim = findAnimation(A.Polygon.superpose)!;
+            const steps = anim.build(abc, slate, { onto: "NOPE" });
+            assert.strictEqual(steps.length, 1);
+            steps[0].finalise();
+            assert.strictEqual(abc.visible, true);
+            assert.strictEqual(slate.ephemerals.length, 0);
         });
     });
 });


### PR DESCRIPTION
Fixes #86.

## Changes

- **`SectorElement` render upgrade** (inherited by `ArcElement`): `drawProgress` partial arc sweep, `emphasisAmount` stroke-width interpolation, highlight-color-before-null-bail (#81 treatment — zero-color angle markers render gold under emphasis/highlight), and `faceAlpha` gating in `drawFace`.
- **`A.Sector.sweep`** — the arc grows from the A arm toward the B arm (rate 0.003 rad/ms, min 250 ms); face-less sectors skip the fill step.
- **`A.Polygon.superpose`** — Euclid's superposition (I.4): an ephemeral gold-outline ghost copy of the target translates so vertex 0 lands on `args.onto`'s vertex 0, rotates about the landing point to lay side 0→1 onto the target side, holds 800 ms coinciding, then retraces home. The real polygon never moves (its setup explicitly restores `drawProgress`/`visible` since superpose is not a reveal). Mismatched/missing `onto` warns and no-ops.
- Docs: animations-reference Sector section + superpose row; api.md `A.Sector` accessor.

## Test plan

- [x] 10 new unit cases (223 total): sector partial sweep, zero-color highlight render, sweep build shapes, superpose 5-step journey with ephemeral lifecycle, ghost midpoint/landing coordinates, untouched original, mismatch fallback
- [x] `npm run test:snapshot` — 700 passing
- [x] Visual pass on the consumer site's propI.4 deck (22 slides) via the local dev-bundle toggle: parallel angle sweeps, cascade sweeps, two superpose journeys, interior-arc markers