### PR TITLE
0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brownnrl/geomlib",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Interactive Euclidean geometry constructions in the browser — a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
   "keywords": [
     "euclid",


### PR DESCRIPTION
Minor release 0.7.0.

## New since 0.6.1

- #86 — `A.Sector.sweep` angle-arc animation + `SectorElement` render upgrade (drawProgress partial sweep, emphasis stroke widths, zero-color highlight, faceAlpha); `A.Polygon.superpose` ephemeral gold-ghost superposition (Euclid I.4)

## Test plan

- [x] `npm run test:unit` — 223 passing
- [x] `npm run test:snapshot` — 700 passing
- [x] Consumer-site propI.4 deck (22 slides) walked end-to-end against the dev bundle