### PR TITLE
deferDraggables + {DISPLAY|element} caption token override

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Library is **post-porting, publish-ready**. There is no longer a
 "next construction to port" backlog or session-startup ritual.
 
 - All 69 construction methods (with 19 3D variants) are implemented.
-- 223 unit tests + 700 snapshot tests pass.
+- 225 unit tests + 700 snapshot tests pass.
 - 0.4.0 shipped cross-highlighting (`emphasized` / `emphasisAmount`
   + `lookupElement`); 0.5.0 shipped the slideshow surface
   (`slides`, `setVisibleNames`, `addAlias`, `resolveJustification`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ That's it.
 ## Running tests
 
 ```sh
-npm run test:unit      # 223 unit tests — fast (~100 ms)
+npm run test:unit      # 225 unit tests — fast (~100 ms)
 npm run test:snapshot  # 700 visual-regression tests against snapshot goldens
 npm test               # both (snapshot then unit)
 ```

--- a/doc/api.md
+++ b/doc/api.md
@@ -400,6 +400,9 @@ Resolution rules:
 
 Captions go through a small markup pass: `{NAME}` tokens become
 clickable bold-italic spans tied to the matching slate element.
+`{DISPLAY|element}` (0.7.1+) renders DISPLAY but binds to `element` —
+for prose names that collide with another element's name ("the angle
+{ABC|angBint}" where bare `{ABC}` would resolve to the triangle).
 Hover / tap on a span flips `element.emphasisAmount` so the element
 pops with a thicker stroke; tapping pins a single sticky reference at
 a time.

--- a/doc/api.md
+++ b/doc/api.md
@@ -110,6 +110,7 @@ interface IInitialization {
 | `fontsize` | `fontsize` | `18` | Pixel size for the label font. |
 | `elements` | `e[1]`, `e[2]`, … | (required) | Ordered list of element specs. May mix `IConstructionInfo` objects and Java param strings. |
 | `aliases` | — | `{}` | Secondary element names that resolve to a canonical element. See [Slides & visibility](#slides--visibility). |
+| `deferDraggables` | — | `[]` | 0.7.1+. Draggable element names excluded from the slideshow's every-slide auto-union — they follow slide `visible` sets like any other element. For draggables the proof introduces mid-walk. |
 | `slides` | — | `[]` | Optional slideshow walk-through. When present, SlateControls shows a "▶ Present" button. See [Slides & visibility](#slides--visibility). |
 | `resolveJustification` | — | `null` | Callback that maps a symbolic justification ref (e.g. `"I.Post.3"`) to a URL string. See [Slides & visibility](#slides--visibility). |
 | `animationConfig` | — | `{}` | Per-animation rate / duration overrides, `speedMultiplier`, `reducedMotion`. See [Animation](#animation). |
@@ -390,7 +391,10 @@ Resolution rules:
   highlight must be re-listed every slide it should appear on.
 - Every `draggable` element on the slate is **auto-unioned** into the
   visible set on every slide — free construction points stay
-  interactive while the reader walks the proof.
+  interactive while the reader walks the proof. Names listed in
+  `init({ deferDraggables: [...] })` (0.7.1+) are exempt: they follow
+  slide `visible` sets like any other element, for draggables the
+  proof introduces mid-walk ("Take an arbitrary point F").
 - Highlighted elements are auto-unioned into visible (can't highlight
   what isn't drawn).
 

--- a/src/Slate.ts
+++ b/src/Slate.ts
@@ -221,6 +221,22 @@ export class Slate {
         for (let from in aliases) this._aliases.set(from, aliases[from]);
     }
 
+    // Draggable elements named here are excluded from the slideshow's
+    // every-slide auto-union and follow slide visible sets like any
+    // other element — for proof-introduced draggables ("Take an
+    // arbitrary point F") that shouldn't show before their moment.
+    // They stay fully draggable whenever visible (#89). Populated by
+    // init() from the `deferDraggables` field.
+    private _deferredDraggables : Set<string> = new Set();
+
+    get deferredDraggables() : Set<string> {
+        return this._deferredDraggables;
+    }
+
+    deferDraggables(names: string[]) : void {
+        for (const n of names || []) this._deferredDraggables.add(n);
+    }
+
     get slides() : ISlide[] {
         return this._slides;
     }

--- a/src/SlateControls.ts
+++ b/src/SlateControls.ts
@@ -624,23 +624,29 @@ class SlateControls {
     // text with the braces stripped. Hover / pointerdown toggles
     // element.emphasized so the figure picks the ref up with an
     // extra-thick gold stroke.
+    //
+    // Display override (#90): {DISPLAY|element} renders DISPLAY but
+    // binds the highlight to `element` — for prose names that collide
+    // with another element's name, e.g. "the angle {ABC|angBint}"
+    // where the bare token would resolve to the triangle ABC.
     private renderCaptionText(host: HTMLElement, text: string): void {
         host.innerHTML = "";
-        const re = /\{([A-Za-z][A-Za-z0-9'\-]*)\}/g;
+        const re = /\{([A-Za-z][A-Za-z0-9'\-]*)(?:\|([A-Za-z][A-Za-z0-9'\-]*))?\}/g;
         let lastIndex = 0;
         let m: RegExpExecArray | null;
         while ((m = re.exec(text)) !== null) {
             if (m.index > lastIndex) {
                 host.appendChild(document.createTextNode(text.slice(lastIndex, m.index)));
             }
-            const name = m[1];
-            const elem = this._slate.lookupElement(name);
+            const display = m[1];
+            const target = m[2] != null ? m[2] : m[1];
+            const elem = this._slate.lookupElement(target);
             if (elem) {
-                host.appendChild(this.buildCaptionRef(name, elem));
+                host.appendChild(this.buildCaptionRef(display, elem));
             } else {
                 // Unknown — render plain so a typo doesn't surface as
                 // raw "{XYZ}" to the reader.
-                host.appendChild(document.createTextNode(name));
+                host.appendChild(document.createTextNode(display));
             }
             lastIndex = m.index + m[0].length;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,13 @@ export interface IInitialization {
     // forcing the canvas to carry an invisible duplicate per alias.
     // Resolved by Slate.lookupElement after a direct-name miss.
     aliases?: {[from: string]: string};
+    // Draggable element names excluded from the slideshow's
+    // every-slide auto-union (#89). Use for draggables the proof
+    // introduces mid-walk ("Take an arbitrary point F") so they stay
+    // hidden until a slide's visible set includes them. They remain
+    // fully draggable whenever shown. No effect outside presentation
+    // mode.
+    deferDraggables?: string[];
     // Optional slideshow walk-through. When provided + non-empty,
     // SlateControls renders a "▶ Present" button that opens the
     // Presentation overlay. Stays empty (no button, no behaviour
@@ -289,6 +296,10 @@ function initInner(i: IInitialization, canvas: HTMLCanvasElement) {
 
     if (i.aliases != null) {
         slate.addAliases(i.aliases);
+    }
+
+    if (i.deferDraggables != null) {
+        slate.deferDraggables(i.deferDraggables);
     }
 
     if (i.slides != null && i.slides.length > 0) {

--- a/src/slideshow.ts
+++ b/src/slideshow.ts
@@ -11,7 +11,10 @@ import {ISlide} from "./index";
 //     visible (initial state is the empty set).
 //   - highlighted clears each slide (defaults to []).
 //   - Every draggable element on the slate is auto-unioned into
-//     visible — free construction points always stay interactive.
+//     visible — free construction points always stay interactive —
+//     EXCEPT names in slate.deferredDraggables (#89): draggables the
+//     proof introduces mid-walk follow visible sets like any other
+//     element.
 //   - Every highlighted name is auto-unioned into visible — you can't
 //     highlight what isn't drawn.
 export function computeSlideState(
@@ -33,7 +36,10 @@ export function computeSlideState(
     const highlighted = new Set<string>(slide.highlighted || []);
 
     for (const e of slate.elements) {
-        if (e.draggable && e.name != null) visible.add(e.name);
+        if (e.draggable && e.name != null
+            && !slate.deferredDraggables.has(e.name)) {
+            visible.add(e.name);
+        }
     }
     highlighted.forEach(name => visible.add(name));
 

--- a/tests/SlideTest.ts
+++ b/tests/SlideTest.ts
@@ -104,6 +104,19 @@ describe("ISlide on init() (issue #75)", () => {
         });
         assert.strictEqual(slates[0].resolveJustification, null);
     });
+
+    it("init({ deferDraggables: [...] }) populates slate.deferredDraggables", () => {
+        withFakeDOM((canvasId) => {
+            init({
+                canvasid: canvasId,
+                background: "0,0,100",
+                title: "test",
+                elements: propI1_elements,
+                deferDraggables: ["A"],
+            });
+        });
+        assert.ok(slates[0].deferredDraggables.has("A"));
+    });
 });
 
 describe("computeSlideState (issue #75)", () => {
@@ -169,6 +182,23 @@ describe("computeSlideState (issue #75)", () => {
         const slate = makeSlate(slides);
         const s = computeSlideState(slate, slides, 0);
         assert.ok(s.visible.has("BCD"), "highlighted BCD should auto-include in visible");
+    });
+
+    it("deferred draggables follow visible sets instead of auto-union (issue #89)", () => {
+        const slides: ISlide[] = [
+            { text: "1", visible: ["AB"] },           // B not listed
+            { text: "2", visible: ["AB","B"] },       // B's moment
+        ];
+        const slate = makeSlate(slides);
+        slate.deferDraggables(["B"]);
+        const s0 = computeSlideState(slate, slides, 0);
+        assert.ok(!s0.visible.has("B"),
+            "deferred draggable B should stay hidden until listed");
+        assert.ok(s0.visible.has("A"),
+            "non-deferred draggable A still auto-includes");
+        const s1 = computeSlideState(slate, slides, 1);
+        assert.ok(s1.visible.has("B"),
+            "B appears once a slide's visible set lists it");
     });
 
     it("initial state with no explicit visible array is hide-all (plus draggable)", () => {


### PR DESCRIPTION
Fixes #89, #90.

## Changes

- **`deferDraggables` (#89)** — `init({ deferDraggables: ["F"] })` exempts named draggables from the slideshow's every-slide auto-union; they follow slide `visible` sets like any other element and stay fully draggable whenever shown. For draggables the proof introduces mid-walk (propI.5's "Take an arbitrary point F"). Default behavior unchanged.
- **`{DISPLAY|element}` caption tokens (#90)** — renders DISPLAY but binds the highlight to `element`, for prose names that collide with another element's name ("the angle {ABC|angBint}" where bare `{ABC}` resolves to the triangle). Plain `{NAME}` unchanged. The consumer site's eucrefs plugin gained the same syntax for proof prose.

## Test plan

- [x] `npm run test:unit` — 225 passing (2 new: deferred draggable follows visible sets; init wiring)
- [x] `npm run test:snapshot` — 700 passing
- [x] propI.5 deck walked against the dev bundle: F hidden until slide 4, "ABC" caption hover lights the angle marker not the triangle