### PR TITLE
0.7.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,10 @@ Library is **post-porting, publish-ready**. There is no longer a
   (`slides`, `setVisibleNames`, `addAlias`, `resolveJustification`,
   SlateControls overlay); 0.6.0 shipped slide-transition animations
   (`A.{Type}.{name}` registry, `drawProgress`, `SlateAnimator`,
-  `slate.animateTo`). All three are additive and default-off — every
-  pre-existing render path is bit-for-bit unchanged.
+  `slate.animateTo`); 0.7.0 added `A.Sector.sweep` + `A.Polygon.superpose`
+  with the `SectorElement` render upgrade; 0.7.1 added `deferDraggables`
+  + the `{DISPLAY|element}` caption token override. All additive and
+  default-off — every pre-existing render path is bit-for-bit unchanged.
 - npm publish pipeline is wired: `prepublishOnly` runs `test:unit`
   + `bundle:prod`. `npm publish --dry-run` previews the tarball.
 - MIT-licensed, joint copyright (Joyce 1996–2020, Brown 2019–2026).

--- a/doc/api.md
+++ b/doc/api.md
@@ -96,6 +96,8 @@ interface IInitialization {
     resolveJustification?: (ref: string) => string | null | undefined;
     // 0.6.0+ — slide-transition animation
     animationConfig?: IAnimationConfig;
+    // 0.7.1+ — draggables exempt from the slideshow auto-union
+    deferDraggables?: string[];
 }
 ```
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -282,8 +282,11 @@ the most recent earlier slide that declared it), `highlighted?`
 "I.Post.3" }]`), and `transition?` (0.6.0+ animation directives — see
 below). Every `draggable` element on the slate is auto-unioned into
 the visible set on every slide so free construction points stay
-interactive while the reader walks the proof; highlighted elements are
-auto-unioned into visible (can't highlight what isn't drawn).
+interactive while the reader walks the proof — except names passed to
+`init({ deferDraggables: [...] })` (0.7.1+), which follow slide
+`visible` sets like any other element (for draggables the proof
+introduces mid-walk); highlighted elements are auto-unioned into
+visible (can't highlight what isn't drawn).
 
 **Justification refs.** `init({ resolveJustification: ref => urlMap[ref] })`
 maps a symbolic ref to a URL at render time, so refs don't go stale

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brownnrl/geomlib",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Interactive Euclidean geometry constructions in the browser — a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
   "keywords": [
     "euclid",


### PR DESCRIPTION
Patch release 0.7.1.

## New since 0.7.0

- #89 — `deferDraggables` init field: exempt named draggables from the slideshow's every-slide auto-union (for proof-introduced points like "Take an arbitrary point F")
- #90 — `{DISPLAY|element}` caption token override: render DISPLAY but bind the highlight to `element`, for prose names that collide with another element's name (angle ABC vs triangle ABC)

## Test plan

- [x] `npm run test:unit` — 225 passing
- [x] `npm run test:snapshot` — 700 passing
- [x] propI.5 deck walked against the dev bundle