### PR TITLE
Angle markers: fixed-radius interior markers + palette fills + reflex + wedge-flash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Library is **post-porting, publish-ready**. There is no longer a
 "next construction to port" backlog or session-startup ritual.
 
 - All 69 construction methods (with 19 3D variants) are implemented.
-- 234 unit tests + 700 snapshot tests pass.
+- 236 unit tests + 700 snapshot tests pass.
 - 0.4.0 shipped cross-highlighting (`emphasized` / `emphasisAmount`
   + `lookupElement`); 0.5.0 shipped the slideshow surface
   (`slides`, `setVisibleNames`, `addAlias`, `resolveJustification`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Library is **post-porting, publish-ready**. There is no longer a
 "next construction to port" backlog or session-startup ritual.
 
 - All 69 construction methods (with 19 3D variants) are implemented.
-- 225 unit tests + 700 snapshot tests pass.
+- 234 unit tests + 700 snapshot tests pass.
 - 0.4.0 shipped cross-highlighting (`emphasized` / `emphasisAmount`
   + `lookupElement`); 0.5.0 shipped the slideshow surface
   (`slides`, `setVisibleNames`, `addAlias`, `resolveJustification`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ That's it.
 ## Running tests
 
 ```sh
-npm run test:unit      # 234 unit tests — fast (~100 ms)
+npm run test:unit      # 236 unit tests — fast (~100 ms)
 npm run test:snapshot  # 700 visual-regression tests against snapshot goldens
 npm test               # both (snapshot then unit)
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ That's it.
 ## Running tests
 
 ```sh
-npm run test:unit      # 225 unit tests — fast (~100 ms)
+npm run test:unit      # 234 unit tests — fast (~100 ms)
 npm run test:snapshot  # 700 visual-regression tests against snapshot goldens
 npm test               # both (snapshot then unit)
 ```

--- a/doc/api.md
+++ b/doc/api.md
@@ -724,6 +724,8 @@ Conventions:
 |---|---|---|---|
 | `E.Sector.sector` | `sector;sector` | points `A, B, C, [plane D]` | Sector with center A, radial points B and C. |
 | `E.Sector.arc` | `sector;arc` | points `A, B, C, [plane D]` | Arc through A, B, C — the circumcircle's arc, drawn as a sector. |
+| `E.Sector.angleMarker` | `sector;angleMarker` | points `V, P1, P2, [int radiusPx]` | 0.8.0+. Marks the **interior** angle P1-V-P2 with a small wedge whose radius the element chooses (default 22px, clamped to 0.45× the shorter arm) — independent of arm length, and auto-oriented to the interior so arm order doesn't matter. Defaults to a translucent palette fill + colored edge (cycled per marker); overridable per element. |
+| `E.Sector.angleMarkerReflex` | `sector;angleMarkerReflex` | points `V, P1, P2, [int radiusPx]` | 0.8.0+. Same as `angleMarker` but draws the **major (reflex, > 180°)** arc. Euclid avoids reflex angles, so this is for rare teaching cases (a III.20-style central angle); interior is the default. |
 
 ### Plane — `E.Plane.{name}` (all 3D-only)
 

--- a/doc/constructions-reference.md
+++ b/doc/constructions-reference.md
@@ -114,6 +114,8 @@ must reflect these post-expansion types, not the raw HTML param count.
 |------|--------|-------------|--------------------------|-------------|------------|---------|
 | `sector` | IMPL | `SectorElement.java` | `Point A, B, C [, Plane]` | Circular sector from center through A and B (2 variants) | ~8 | I.9 |
 | `arc` | IMPL | `Arc.java` | `Point A, M, B [, Plane]` | Arc of circle passing through A, M, B (M is on the arc, 2D + 3D) | ~20 | I.4 |
+| `angleMarker` | IMPL | — (geomlib 0.8.0) | `Point V, P1, P2 [, int radiusPx]` | Interior angle marker at V — element-chosen radius (default 22px, clamped to 0.45× shorter arm), auto-interior, translucent palette fill | slideshows | I.5 |
+| `angleMarkerReflex` | IMPL | — (geomlib 0.8.0) | `Point V, P1, P2 [, int radiusPx]` | As `angleMarker` but the major (reflex, >180°) arc; for rare teaching cases | rare | III.20 |
 
 ---
 

--- a/src/Colors.ts
+++ b/src/Colors.ts
@@ -29,6 +29,22 @@ export const colors : {[colorName: string]: string} =
     "yellow": "rgb(255,255,0)"
 };
 
+// Default color cycle for angle markers (#91). Each entry pairs a
+// solid edge color with a translucent face twin so concurrent markers
+// read as distinct, readable wedges. Hues are spread and deliberately
+// avoid gold (#FFD700, the highlight color) so an emphasized marker
+// still contrasts against its own fill. init() assigns these in
+// construction order; authors can override per element.
+export const anglePalette : {edge: string, face: string}[] =
+[
+    { edge: "rgb(59,110,165)",  face: "rgba(59,110,165,0.30)"  },  // blue
+    { edge: "rgb(63,142,79)",   face: "rgba(63,142,79,0.30)"   },  // green
+    { edge: "rgb(122,79,163)",  face: "rgba(122,79,163,0.30)"  },  // purple
+    { edge: "rgb(194,90,60)",   face: "rgba(194,90,60,0.30)"   },  // orange-red
+    { edge: "rgb(46,139,139)",  face: "rgba(46,139,139,0.30)"  },  // teal
+    { edge: "rgb(163,60,122)",  face: "rgba(163,60,122,0.30)"  }   // magenta
+];
+
 export function parseColor(val: string | number, dfault: string, bgcolor: string) : string {
     // Handle numeric 0 (from IConstructionInfo where vertexColor: 0)
     if (val === 0) return null;

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -100,7 +100,9 @@ export enum PolygonConstructions {
 
 export enum SectorConstructions {
     sector = 401,
-    arc = 402
+    arc = 402,
+    angleMarker = 403,
+    angleMarkerReflex = 404
 }
 
 export enum PlaneConstructions {

--- a/src/elements/sector/AngleMarkerElement.ts
+++ b/src/elements/sector/AngleMarkerElement.ts
@@ -74,6 +74,12 @@ export class AngleMarkerElement extends SectorElement {
         return !this.reflex;
     }
 
+    // Angle markers flash their whole wedge during a transition (the
+    // emphasis bump), not just the edge.
+    protected _flashFace(): boolean {
+        return true;
+    }
+
     radius() : number {
         const a1 = this._Center.distance(this._arm1);
         const a2 = this._Center.distance(this._arm2);

--- a/src/elements/sector/AngleMarkerElement.ts
+++ b/src/elements/sector/AngleMarkerElement.ts
@@ -1,0 +1,121 @@
+/*----------------------------------------------------------------------+
+|    Title:	AngleMarkerElement.ts                                       |
+|    Part of the geomlib port of David E. Joyce's Geometry Applet.       |
+|    TypeScript: 2026, Nelson Brown, brownnrl@gmail.com                  |
++----------------------------------------------------------------------*/
+
+import {SectorElement} from "./SectorElement";
+import {PointElement} from "../point/PointElement";
+import {PlaneElement} from "../plane/PlaneElement";
+
+// A small sector drawn at a vertex to mark the interior angle between
+// two arms. Unlike a plain `sector;sector` (whose radius is the
+// vertex-to-arm distance, so it swings with arm length), an angle
+// marker computes its OWN fixed radius — a sensible px default,
+// clamped to a fraction of the shorter arm so it never overshoots.
+// It also auto-orients to the interior arc, removing the per-marker
+// arm-order sign-check the old midpoint-chain pattern needed (#91).
+//
+// The vertex (_Center) and the two arm points are real slate elements
+// (drags follow them automatically). _A / _B are INTERNAL points,
+// recomputed each update() at the marker radius along each arm — they
+// are never registered on the slate. The inherited SectorElement
+// drawEdge / drawFace then render the wedge, with drawProgress,
+// emphasisAmount, and faceAlpha all working unchanged.
+export const DEFAULT_ANGLE_MARKER_RADIUS_PX = 22;
+export const ANGLE_MARKER_MAX_ARM_FRACTION = 0.45;
+export const ANGLE_MARKER_RING_STEP = 9;
+
+export class AngleMarkerElement extends SectorElement {
+
+    private _arm1 : PointElement;
+    private _arm2 : PointElement;
+    private _radiusOverride : number;
+
+    // Concentric-ring index for same-vertex markers. 0.8.1 will assign
+    // this automatically so overlapping markers nest; for now it
+    // defaults to 0 and can be set by hand. Each step bumps the radius
+    // by ANGLE_MARKER_RING_STEP.
+    public ringIndex : number = 0;
+
+    // Draw the major (reflex, > 180°) arc instead of the interior
+    // minor one. Default false — interior is the faithful Euclidean
+    // case (his angles live in 0..180°). Set via the
+    // `angleMarkerReflex` construction for the rare reflex marking
+    // (e.g. a III.20-style central angle).
+    public reflex : boolean = false;
+
+    constructor(vertex: PointElement, arm1: PointElement, arm2: PointElement,
+                plane: PlaneElement, radiusOverride?: number, reflex?: boolean) {
+        super();
+        this.dimension = 2;
+        this._Center = vertex;
+        this._arm1 = arm1;
+        this._arm2 = arm2;
+        this._P = plane;
+        this._radiusOverride = radiusOverride != null ? radiusOverride : null;
+        this.reflex = reflex === true;
+        // Internal arc endpoints — placed in update().
+        this._A = new PointElement();
+        this._B = new PointElement();
+    }
+
+    // update() orders _A/_B so the inherited minor angle is negative
+    // (interior, drawn with the default anticlockwise=true). A reflex
+    // marker draws the MAJOR arc between the same two rays — same
+    // endpoints, opposite side — which is the magnitude 2π−|minor| with
+    // the anticlockwise flag flipped (see _anticlockwise).
+    protected _arcAngle(): number {
+        const minor = this._Center.angle(this._A, this._B, this._P);
+        return this.reflex ? (2 * Math.PI - Math.abs(minor)) : minor;
+    }
+
+    protected _anticlockwise(): boolean {
+        return !this.reflex;
+    }
+
+    radius() : number {
+        const a1 = this._Center.distance(this._arm1);
+        const a2 = this._Center.distance(this._arm2);
+        const shorter = Math.min(a1, a2);
+        const base = this._radiusOverride != null
+            ? this._radiusOverride
+            : DEFAULT_ANGLE_MARKER_RADIUS_PX;
+        const clamped = Math.min(base, shorter * ANGLE_MARKER_MAX_ARM_FRACTION);
+        return clamped + this.ringIndex * ANGLE_MARKER_RING_STEP;
+    }
+
+    // Place an internal endpoint at distance r from the vertex along
+    // the direction of `arm`.
+    private _place(target: PointElement, arm: PointElement, r: number) : void {
+        const dx = arm.x - this._Center.x;
+        const dy = arm.y - this._Center.y;
+        const dz = arm.z - this._Center.z;
+        const len = Math.sqrt(dx*dx + dy*dy + dz*dz);
+        if (len === 0) {
+            target.x = this._Center.x;
+            target.y = this._Center.y;
+            target.z = this._Center.z;
+            return;
+        }
+        target.x = this._Center.x + dx / len * r;
+        target.y = this._Center.y + dy / len * r;
+        target.z = this._Center.z + dz / len * r;
+    }
+
+    update() : void {
+        const r = this.radius();
+        this._place(this._A, this._arm1, r);
+        this._place(this._B, this._arm2, r);
+        // Auto-interior: PointElement.angle is signed (−π..π) and atan2
+        // already returns the short way, so the magnitude is the
+        // interior angle; only the rendered sweep direction matters.
+        // The empirically-interior case (matching the old sign-checks)
+        // is angle(_A, _B) < 0 — if it's positive, swap the arms.
+        const ang = this._Center.angle(this._A, this._B, this._P);
+        if (ang > 0) {
+            this._place(this._A, this._arm2, r);
+            this._place(this._B, this._arm1, r);
+        }
+    }
+}

--- a/src/elements/sector/SectorAnimations.ts
+++ b/src/elements/sector/SectorAnimations.ts
@@ -29,8 +29,9 @@ export class SectorSweepAnimation extends Animation {
 
     public build(target: GeomElement, slate: Slate, args: any): IAnimationStep[] {
         const sector = target as SectorElement;
-        const arcAngle = Math.abs(
-            sector._Center.angle(sector._A, sector._B, sector._P));
+        // arcSpan() reflects what's actually drawn (the major arc for a
+        // reflex marker), so the duration matches the visible sweep.
+        const arcAngle = sector.arcSpan();
         const sweepMs = Math.max(MIN_SWEEP_MS, arcAngle / this.defaultRate);
         const fullRestore = () => {
             sector.faceAlpha = 1;

--- a/src/elements/sector/SectorConstructions.ts
+++ b/src/elements/sector/SectorConstructions.ts
@@ -10,6 +10,7 @@ import {PlaneElement} from "../plane/PlaneElement";
 import {PointElement} from "../point/PointElement";
 import {SectorElement} from "./SectorElement";
 import {ArcElement} from "./ArcElement";
+import {AngleMarkerElement} from "./AngleMarkerElement";
 
 // sector — points A, B, C [, plane D = screen]
 // 2D: 3 points, 0 elements — uses screen plane
@@ -49,7 +50,72 @@ export class ArcConstruction extends Construction {
     }
 }
 
+// angleMarker — vertex V, arm points P1, P2 [, int radiusPx]
+// Marks the interior angle P1-V-P2 with a small fixed-radius sector
+// (radius computed by the element, not the arm length). The optional
+// integer overrides the default px radius. 2D screen-plane only for
+// v1. (#91)
+export class AngleMarkerConstruction extends Construction {
+    constructionMethod: AllConstructions = SectorConstructionsEnum.angleMarker;
+    signature: ConstructionSignature = { points: 3, elements: 0, integers: 0 };
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 3 && sp.N.length === 0 && sp.E.length === 0;
+    }
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new AngleMarkerElement(P[0], P[1], P[2], screen);
+        return [[g], g];
+    }
+}
+
+// angleMarker with an explicit px radius override.
+export class AngleMarkerRadiusConstruction extends Construction {
+    constructionMethod: AllConstructions = SectorConstructionsEnum.angleMarker;
+    signature: ConstructionSignature = { points: 3, elements: 0, integers: 1 };
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 3 && sp.N.length === 1 && sp.E.length === 0;
+    }
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new AngleMarkerElement(P[0], P[1], P[2], screen, N[0]);
+        return [[g], g];
+    }
+}
+
+// angleMarkerReflex — same as angleMarker but draws the major (reflex,
+// > 180°) arc. Rare; Euclid avoids reflex angles, so this is for the
+// occasional teaching case (a III.20-style central angle). (#91)
+export class AngleMarkerReflexConstruction extends Construction {
+    constructionMethod: AllConstructions = SectorConstructionsEnum.angleMarkerReflex;
+    signature: ConstructionSignature = { points: 3, elements: 0, integers: 0 };
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 3 && sp.N.length === 0 && sp.E.length === 0;
+    }
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new AngleMarkerElement(P[0], P[1], P[2], screen, undefined, true);
+        return [[g], g];
+    }
+}
+
+export class AngleMarkerReflexRadiusConstruction extends Construction {
+    constructionMethod: AllConstructions = SectorConstructionsEnum.angleMarkerReflex;
+    signature: ConstructionSignature = { points: 3, elements: 0, integers: 1 };
+    public validateSignature(cm: AllConstructions, sp: SortedParams): boolean {
+        if (cm !== this.constructionMethod) return false;
+        return sp.P.length === 3 && sp.N.length === 1 && sp.E.length === 0;
+    }
+    construct(screen: PlaneElement, P: PointElement[], E: GeomElement[], N: number[]): [GeomElementsForUpdate, GeomElement] {
+        let g = new AngleMarkerElement(P[0], P[1], P[2], screen, N[0], true);
+        return [[g], g];
+    }
+}
+
 export const sectorConstructions: Construction[] = [
     new SectorConstruction(),
     new ArcConstruction(),
+    new AngleMarkerConstruction(),
+    new AngleMarkerRadiusConstruction(),
+    new AngleMarkerReflexConstruction(),
+    new AngleMarkerReflexRadiusConstruction(),
 ];

--- a/src/elements/sector/SectorElement.ts
+++ b/src/elements/sector/SectorElement.ts
@@ -138,24 +138,16 @@ export class SectorElement extends GeomElement {
         return Math.abs(this._arcAngle());
     }
 
-    drawFace(c: SlateCanvas): void {
-        if (!this.visible) return;
-        if (this.faceColor == null || !this.defined()) return;
-        // Face is independent of the edge sweep — always the full
-        // sector wedge, with alpha driven by the dedicated faceAlpha
-        // field (mirrors Circle/Polygon, #86). Default 1 preserves
-        // the fully-opaque behaviour for every non-animating consumer.
-        let a = this.faceAlpha;
-        if (a <= 0) return;
-        let ctx = c.getContext("2d") as CanvasRenderingContext2D;
-        ctx.fillStyle = this.faceColor;
-        ctx.beginPath();
-        let r = this.radius();
+    // Trace the closed wedge path (arc + the two radii back to centre)
+    // into the current ctx path. Shared by the face fill and the flash
+    // overlay so they cover exactly the same region.
+    protected _traceWedge(ctx: CanvasRenderingContext2D, r: number): void {
         let startAngle = Math.atan2(
             this._A.y - this._Center.y,
             this._A.x - this._Center.x);
         let arcAngle = this._arcAngle();
         let endAngle = startAngle + arcAngle;
+        ctx.beginPath();
         ctx.arc(this._Center.x, this._Center.y, r, startAngle, endAngle, this._anticlockwise());
         ctx.moveTo(this._Center.x, this._Center.y);
         if(arcAngle <= 180.) {
@@ -166,6 +158,28 @@ export class SectorElement extends GeomElement {
             ctx.lineTo(this._A.x, this._A.y);
         }
         ctx.lineTo(this._Center.x, this._Center.y);
+    }
+
+    // Whether the whole wedge should flash (fill with the highlight
+    // color) while emphasised. False for plain sectors/arcs — only
+    // angle markers light up their fill during a slide transition.
+    protected _flashFace(): boolean {
+        return false;
+    }
+
+    drawFace(c: SlateCanvas): void {
+        if (!this.visible) return;
+        if (this.faceColor == null || !this.defined()) return;
+        // Face is independent of the edge sweep — always the full
+        // sector wedge, with alpha driven by the dedicated faceAlpha
+        // field (mirrors Circle/Polygon, #86). Default 1 preserves
+        // the fully-opaque behaviour for every non-animating consumer.
+        let a = this.faceAlpha;
+        if (a <= 0) return;
+        let ctx = c.getContext("2d") as CanvasRenderingContext2D;
+        let r = this.radius();
+        ctx.fillStyle = this.faceColor;
+        this._traceWedge(ctx, r);
         if (a < 1) {
             ctx.save();
             ctx.globalAlpha = a;
@@ -173,6 +187,19 @@ export class SectorElement extends GeomElement {
             ctx.restore();
         } else {
             ctx.fill();
+        }
+        // Transition flash: while emphasised (the animator bumps
+        // emphasisAmount to 1 during a sweep and fades it 1 → 0
+        // afterward), light the ENTIRE wedge with the highlight color,
+        // fading with the emphasis. Edge-only emphasis (stroke width /
+        // gold) already happens in drawEdge; this fills the area too.
+        if (this._flashFace() && this.emphasisAmount > 0) {
+            ctx.save();
+            ctx.fillStyle = this.faceHighlightColor;
+            ctx.globalAlpha = 0.55 * this.emphasisAmount;
+            this._traceWedge(ctx, r);
+            ctx.fill();
+            ctx.restore();
         }
     }
 

--- a/src/elements/sector/SectorElement.ts
+++ b/src/elements/sector/SectorElement.ts
@@ -107,13 +107,35 @@ export class SectorElement extends GeomElement {
         let startAngle = Math.atan2(
             this._A.y - this._Center.y,
             this._A.x - this._Center.x);
-        let arcAngle = this._Center.angle(this._A, this._B, this._P);
+        let arcAngle = this._arcAngle();
         // Partial sweep for slide-transition animation: the arc grows
         // from the A arm toward the B arm as drawProgress goes 0 → 1.
         // Default progress = 1 reproduces the full arc bit-for-bit.
         let endAngle = startAngle + arcAngle * this.drawProgress;
-        ctx.arc(this._Center.x, this._Center.y, r, startAngle, endAngle, true);
+        ctx.arc(this._Center.x, this._Center.y, r, startAngle, endAngle, this._anticlockwise());
         ctx.stroke();
+    }
+
+    // The signed arc to sweep from the A arm to the B arm, in radians.
+    // Default is the minor signed angle (−π..π). AngleMarkerElement
+    // overrides this to optionally sweep the major (reflex) arc.
+    protected _arcAngle(): number {
+        return this._Center.angle(this._A, this._B, this._P);
+    }
+
+    // Sweep direction passed to ctx.arc. Fixed true for plain sectors /
+    // arcs (their authors order _A/_B for that). AngleMarkerElement
+    // flips it to draw the major arc between the same two rays for a
+    // reflex marker.
+    protected _anticlockwise(): boolean {
+        return true;
+    }
+
+    // Magnitude of the swept arc — used by A.Sector.sweep to size the
+    // animation duration to what's actually drawn (so a reflex marker
+    // doesn't sweep a big arc in a tiny time).
+    public arcSpan(): number {
+        return Math.abs(this._arcAngle());
     }
 
     drawFace(c: SlateCanvas): void {
@@ -132,9 +154,9 @@ export class SectorElement extends GeomElement {
         let startAngle = Math.atan2(
             this._A.y - this._Center.y,
             this._A.x - this._Center.x);
-        let arcAngle = this._Center.angle(this._A, this._B, this._P);
+        let arcAngle = this._arcAngle();
         let endAngle = startAngle + arcAngle;
-        ctx.arc(this._Center.x, this._Center.y, r, startAngle, endAngle, true);
+        ctx.arc(this._Center.x, this._Center.y, r, startAngle, endAngle, this._anticlockwise());
         ctx.moveTo(this._Center.x, this._Center.y);
         if(arcAngle <= 180.) {
             ctx.lineTo(this._A.x, this._A.y);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,8 @@ import "./elements/sector/SectorAnimations";
 import {PointElement} from "./elements/point/PointElement";
 import {Slate} from "./Slate";
 import {PlaneSlider} from "./elements/point/PlaneSlider";
-import {colors, randomColor, lighten, darken, parseColor} from "./Colors";
+import {AngleMarkerElement} from "./elements/sector/AngleMarkerElement";
+import {colors, randomColor, lighten, darken, parseColor, anglePalette} from "./Colors";
 import {createControls} from "./SlateControls";
 
 export type IndexAllConstructions = AllConstructions;
@@ -271,11 +272,32 @@ function initInner(i: IInitialization, canvas: HTMLCanvasElement) {
     // Parse background through parseColor so HSB triples like "35,19,100"
     // are converted to valid CSS rgb() strings for ctx.fillStyle.
     slate.bgcolor = parseColor(i.background, "#ffffff", "#ffffff");
+    // Cycles the angle-marker palette in construction order (#91) so
+    // concurrent markers get distinct colors.
+    let angleMarkerCount = 0;
     for(let raw of i.elements) {
         let param: IConstructionInfo = typeof raw === "string" ? parseParam(raw) : raw;
         let element = slate.createElement(param.construction, param.params, param.name);
 
         element.align = defaultAlign;
+
+        // Angle markers default to a translucent palette fill + solid
+        // colored edge instead of the dim2 lighten-bg face / black edge.
+        // The rgba face is set directly (it wouldn't survive parseColor)
+        // unless the author supplies an explicit faceColor param.
+        if (element instanceof AngleMarkerElement) {
+            const swatch = anglePalette[angleMarkerCount % anglePalette.length];
+            angleMarkerCount++;
+            element.nameColor = parseColor(param.nameColor, null, slate.bgcolor);
+            element.vertexColor = parseColor(param.vertexColor, null, slate.bgcolor);
+            element.edgeColor = parseColor(param.edgeColor, swatch.edge, slate.bgcolor);
+            if (param.faceColor != null) {
+                element.faceColor = parseColor(param.faceColor, swatch.edge, slate.bgcolor);
+            } else {
+                element.faceColor = swatch.face;
+            }
+            continue;
+        }
 
         // Name string
         let defaultNameColor = element instanceof PointElement ? "black" : null;

--- a/tests/SectorTest.ts
+++ b/tests/SectorTest.ts
@@ -1,9 +1,12 @@
 import "mocha";
 import * as assert from "assert";
 import {Slate} from "../src/Slate";
-import {E, IConstructionInfo} from "../src/index";
+import {E, IConstructionInfo, init, slates} from "../src/index";
 import {PointElement} from "../src/elements/point/PointElement";
 import {ArcElement} from "../src/elements/sector/ArcElement";
+import {AngleMarkerElement, DEFAULT_ANGLE_MARKER_RADIUS_PX,
+        ANGLE_MARKER_RING_STEP} from "../src/elements/sector/AngleMarkerElement";
+import {anglePalette} from "../src/Colors";
 import {createCanvas} from "canvas";
 import {almostEqual, toElements} from "./shared/testHelpers";
 
@@ -85,5 +88,182 @@ describe("sector", () => {
         slate.elements.forEach(e => e.update());
         let arc = slate.lookupElement("arc");
         assert.ok(arc != null);
+    });
+});
+
+// Issue #91 — angle markers compute their own fixed radius (not the
+// vertex-to-arm distance), auto-orient to the interior arc, and take a
+// translucent palette color by default.
+describe("angle marker (issue #91)", () => {
+
+    // Vertex B at origin-ish, one short arm and one long arm, so a
+    // distance-based radius would differ wildly between markers.
+    function markerSlate(extra: IConstructionInfo[] = []): Slate {
+        const data: IConstructionInfo[] = [
+            { name: "A",     construction: E.Point.free, params: [100, 60] },   // up
+            { name: "B",     construction: E.Point.free, params: [100, 260] },  // vertex
+            { name: "Cnear", construction: E.Point.free, params: [160, 260] },  // 60px arm
+            { name: "Cfar",  construction: E.Point.free, params: [560, 260] },  // 460px arm
+            ...extra,
+        ];
+        const slate = new Slate(createCanvas(600, 320));
+        toElements(slate, data);
+        slate.elements.forEach(e => e.update());
+        return slate;
+    }
+
+    it("radius is the fixed default, independent of arm length", () => {
+        const slate = markerSlate([
+            { name: "mNear", construction: E.Sector.angleMarker, params: ["B", "A", "Cnear"] },
+            { name: "mFar",  construction: E.Sector.angleMarker, params: ["B", "A", "Cfar"] },
+        ]);
+        const mNear = slate.lookupElement("mNear") as AngleMarkerElement;
+        const mFar  = slate.lookupElement("mFar")  as AngleMarkerElement;
+        // Both arms are >= 60px, so 0.45*shorter (>=27) doesn't clamp
+        // below the 22px default. A distance radius would be 200 vs 460.
+        almostEqual(mNear.radius(), DEFAULT_ANGLE_MARKER_RADIUS_PX, 0.001);
+        almostEqual(mFar.radius(),  DEFAULT_ANGLE_MARKER_RADIUS_PX, 0.001);
+    });
+
+    it("clamps to 0.45x the shorter arm when arms are short", () => {
+        // Vertex P with a tiny 20px arm → 0.45*20 = 9 < 22 default.
+        const slate = new Slate(createCanvas(200, 200));
+        toElements(slate, [
+            { name: "P",  construction: E.Point.free, params: [100, 100] },
+            { name: "Q",  construction: E.Point.free, params: [120, 100] },  // 20px
+            { name: "R",  construction: E.Point.free, params: [100, 160] },  // 60px
+            { name: "m",  construction: E.Sector.angleMarker, params: ["P", "Q", "R"] },
+        ]);
+        slate.elements.forEach(e => e.update());
+        const m = slate.lookupElement("m") as AngleMarkerElement;
+        almostEqual(m.radius(), 20 * 0.45, 0.001);
+    });
+
+    it("respects an explicit px radius override", () => {
+        const slate = markerSlate([
+            { name: "m", construction: E.Sector.angleMarker, params: ["B", "A", "Cfar", 14] },
+        ]);
+        const m = slate.lookupElement("m") as AngleMarkerElement;
+        almostEqual(m.radius(), 14, 0.001);
+    });
+
+    it("auto-orients to the interior arc regardless of arm order", () => {
+        const slate = markerSlate([
+            { name: "m1", construction: E.Sector.angleMarker, params: ["B", "A", "Cnear"] },
+            { name: "m2", construction: E.Sector.angleMarker, params: ["B", "Cnear", "A"] },
+        ]);
+        const interior = (name: string): number => {
+            const m = slate.lookupElement(name) as any;
+            return m._Center.angle(m._A, m._B, m._P);  // signed; < 0 = interior
+        };
+        // A is straight up from B, Cnear straight right: interior = 90°.
+        assert.ok(interior("m1") < 0, "m1 should render the interior arc");
+        assert.ok(interior("m2") < 0, "m2 (arms swapped) should too");
+        almostEqual(Math.abs(interior("m1")), Math.PI / 2, 1e-6);
+        almostEqual(Math.abs(interior("m2")), Math.PI / 2, 1e-6);
+    });
+
+    it("recomputes the arc endpoints onto the radius when an arm moves", () => {
+        const slate = markerSlate([
+            { name: "m", construction: E.Sector.angleMarker, params: ["B", "A", "Cnear"] },
+        ]);
+        const m = slate.lookupElement("m") as any;
+        const B = slate.lookupElement("B") as PointElement;
+        // _A sits at radius along the B→A direction (straight up).
+        almostEqual(B.distance(m._A), m.radius(), 1e-6);
+        almostEqual(B.distance(m._B), m.radius(), 1e-6);
+        // Move the vertex; after update the endpoints follow it.
+        B.x = 150; B.y = 250;
+        slate.elements.forEach((e: any) => e.update());
+        almostEqual(B.distance(m._A), m.radius(), 1e-6);
+    });
+
+    it("reflex markers sweep the major arc (2pi minus the interior)", () => {
+        const slate = markerSlate([
+            { name: "mi", construction: E.Sector.angleMarker,       params: ["B", "A", "Cnear"] },
+            { name: "mr", construction: E.Sector.angleMarkerReflex, params: ["B", "A", "Cnear"] },
+        ]);
+        const mi = slate.lookupElement("mi") as AngleMarkerElement;
+        const mr = slate.lookupElement("mr") as AngleMarkerElement;
+        // Interior here is 90°; the reflex twin spans 270°.
+        almostEqual(mi.arcSpan(), Math.PI / 2, 1e-6);
+        almostEqual(mr.arcSpan(), 2 * Math.PI - Math.PI / 2, 1e-6);
+        assert.strictEqual(mr.reflex, true);
+        assert.strictEqual(mi.reflex, false);
+    });
+
+    it("ringIndex bumps the radius by the ring step", () => {
+        const slate = markerSlate([
+            { name: "m", construction: E.Sector.angleMarker, params: ["B", "A", "Cfar"] },
+        ]);
+        const m = slate.lookupElement("m") as AngleMarkerElement;
+        const base = m.radius();
+        m.ringIndex = 2;
+        almostEqual(m.radius(), base + 2 * ANGLE_MARKER_RING_STEP, 0.001);
+    });
+
+    // Palette defaults are applied by init() (not the bare toElements
+    // helper), so these drive the real init() path with a fake DOM.
+    function withFakeDOM<T>(fn: (canvasId: string) => T): T {
+        const canvasId = "amk_canvas";
+        const fake = createCanvas(600, 320) as any;
+        fake.id = canvasId;
+        fake.style = {};
+        fake.getBoundingClientRect = () => ({ width: 600, height: 320 });
+        fake.addEventListener = () => {};
+        (global as any).window = global;
+        (global as any).document = {
+            getElementById: (id: string) => (id === canvasId ? fake : null),
+        };
+        (global as any).HTMLCanvasElement = function() {};
+        try { return fn(canvasId); }
+        finally {
+            delete (global as any).window;
+            delete (global as any).document;
+            delete (global as any).HTMLCanvasElement;
+        }
+    }
+
+    const baseMarkerElements = [
+        "A;point;free;100,60",
+        "B;point;free;100,260",
+        "Cnear;point;free;160,260",
+        "Cfar;point;free;560,260",
+    ];
+
+    it("assigns translucent palette colors in construction order", () => {
+        withFakeDOM((canvasid) => {
+            slates.length = 0;
+            init({
+                canvasid, background: "0,0,100", title: "t",
+                elements: [
+                    ...baseMarkerElements,
+                    "m0;sector;angleMarker;B,A,Cnear",
+                    "m1;sector;angleMarker;B,Cnear,Cfar",
+                ],
+            });
+            const slate = slates[0];
+            const m0 = slate.lookupElement("m0") as AngleMarkerElement;
+            const m1 = slate.lookupElement("m1") as AngleMarkerElement;
+            assert.strictEqual(m0.edgeColor, anglePalette[0].edge);
+            assert.strictEqual(m0.faceColor, anglePalette[0].face);
+            assert.strictEqual(m1.edgeColor, anglePalette[1].edge);
+            assert.strictEqual(m1.faceColor, anglePalette[1].face);
+        });
+    });
+
+    it("lets an author override the marker face color", () => {
+        withFakeDOM((canvasid) => {
+            slates.length = 0;
+            init({
+                canvasid, background: "0,0,100", title: "t",
+                elements: [
+                    ...baseMarkerElements,
+                    "m;sector;angleMarker;B,A,Cnear;0;0;0;red",
+                ],
+            });
+            const m = slates[0].lookupElement("m") as AngleMarkerElement;
+            assert.strictEqual(m.faceColor, "rgb(255,0,0)");
+        });
     });
 });

--- a/tests/SectorTest.ts
+++ b/tests/SectorTest.ts
@@ -178,6 +178,65 @@ describe("angle marker (issue #91)", () => {
         almostEqual(B.distance(m._A), m.radius(), 1e-6);
     });
 
+    // Records the fillStyle + globalAlpha at each fill() call so we can
+    // see the transition flash add a second (gold) fill over the wedge.
+    function fillRecordingCanvas(slate: Slate) {
+        const real = (slate as any).canvas;
+        const fills: Array<{style: any, alpha: number}> = [];
+        const ctx: any = new Proxy(real.getContext("2d"), {
+            get(t, p) {
+                if (p === "fill") return () => fills.push({ style: t.fillStyle, alpha: t.globalAlpha });
+                const v = t[p];
+                return typeof v === "function" ? v.bind(t) : v;
+            },
+            set(t, p, v) { t[p] = v; return true; },
+        });
+        return { canvas: { getContext: () => ctx } as any, fills };
+    }
+
+    it("flashes the whole wedge with the highlight color while emphasised", () => {
+        const slate = markerSlate([
+            { name: "m", construction: E.Sector.angleMarker, params: ["B", "A", "Cnear"] },
+        ]);
+        const m = slate.lookupElement("m") as AngleMarkerElement;
+        m.faceColor = "rgb(59,110,165)";
+
+        // Not emphasised: one fill (the palette face), no flash.
+        m.emphasisAmount = 0;
+        let r = fillRecordingCanvas(slate);
+        m.drawFace(r.canvas);
+        assert.strictEqual(r.fills.length, 1);
+
+        // Emphasised: a second fill with the gold highlight color,
+        // alpha scaling with emphasisAmount.
+        m.emphasisAmount = 1;
+        r = fillRecordingCanvas(slate);
+        m.drawFace(r.canvas);
+        assert.strictEqual(r.fills.length, 2);
+        // node-canvas echoes fillStyle back lowercased.
+        assert.strictEqual(
+            String(r.fills[1].style).toLowerCase(),
+            m.faceHighlightColor.toLowerCase());
+        assert.ok(r.fills[1].alpha > 0 && r.fills[1].alpha <= 1);
+    });
+
+    it("plain sectors do not flash their face", () => {
+        const slate = new Slate(createCanvas(300, 300));
+        toElements(slate, [
+            { name: "O", construction: E.Point.free, params: [100, 100] },
+            { name: "U", construction: E.Point.free, params: [180, 100] },
+            { name: "V", construction: E.Point.free, params: [100, 180] },
+            { name: "S", construction: E.Sector.sector, params: ["O", "U", "V"] },
+        ]);
+        slate.elements.forEach(e => e.update());
+        const s = slate.lookupElement("S") as any;
+        s.faceColor = "rgb(0,0,255)";
+        s.emphasisAmount = 1;
+        const r = fillRecordingCanvas(slate);
+        s.drawFace(r.canvas);
+        assert.strictEqual(r.fills.length, 1);  // no flash overlay
+    });
+
     it("reflex markers sweep the major arc (2pi minus the interior)", () => {
         const slate = markerSlate([
             { name: "mi", construction: E.Sector.angleMarker,       params: ["B", "A", "Cnear"] },

--- a/view/test/sector/angle-marker.html
+++ b/view/test/sector/angle-marker.html
@@ -1,0 +1,81 @@
+<html>
+<head>
+    <title>Test View - Sector.angleMarker (#91)</title>
+</head>
+<body>
+<h3 style="font-family: sans-serif;">angle markers (#91)</h3>
+<p style="font-family: sans-serif; max-width: 640px; color: #444;">
+Each marker computes its own fixed radius (default 22px, clamped to
+0.45&times; the shorter arm) and auto-orients to the interior angle —
+so they're consistently sized no matter how long the arms are, and the
+arm order doesn't matter. Default colors come from a translucent
+palette. Drag any vertex: markers track and stay interior. Hover the
+caption refs to brighten a marker to gold. Two markers on a shared
+vertex still overlap at the same radius (the 0.8.1 nesting gap) — use
+the px-radius override or different palette slots as a stopgap.
+</p>
+<canvas id="canvasId" style="width:640px; height: 420px;" tabindex="0"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    let A = geomlib.A;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "angleMarker",
+        canvasid: "canvasId",
+        elements: [
+            // A scalene triangle PQR — the three interior angles get
+            // markers. P has a short arm to one side and a long arm to
+            // the other, which would wreck a distance-based radius.
+            { name: "P", construction: E.Point.free, params: [120, 110] },
+            { name: "Q", construction: E.Point.free, params: [90, 330] },
+            { name: "R", construction: E.Point.free, params: [430, 300] },
+            { name: "PQR", construction: E.Polygon.triangle, params: ["P", "Q", "R"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black", faceColor: "rgba(120,180,210,0.18)" },
+            // Interior angle markers (vertex, arm1, arm2). Palette-colored.
+            { name: "angP", construction: E.Sector.angleMarker, params: ["P", "Q", "R"] },
+            { name: "angQ", construction: E.Sector.angleMarker, params: ["Q", "P", "R"] },
+            { name: "angR", construction: E.Sector.angleMarker, params: ["R", "P", "Q"] },
+
+            // A far-flung second figure sharing vertex Q's style: an angle
+            // whose arm reaches way off to prove the radius doesn't grow.
+            { name: "S", construction: E.Point.free, params: [600, 120] },
+            { name: "QS", construction: E.Line.connect, params: ["Q", "S"],
+              nameColor: 0, vertexColor: 0, edgeColor: "darkGray" },
+            { name: "angQS", construction: E.Sector.angleMarker, params: ["Q", "R", "S"] },
+
+            // Same vertex P, a second marker between R and a new ray —
+            // demonstrates the same-vertex overlap (0.8.1 gap) and the
+            // radius override used to separate them by hand.
+            { name: "T", construction: E.Point.free, params: [300, 70] },
+            { name: "PT", construction: E.Line.connect, params: ["P", "T"],
+              nameColor: 0, vertexColor: 0, edgeColor: "darkGray" },
+            { name: "angP2", construction: E.Sector.angleMarker, params: ["P", "R", "T", 38] },
+
+            // Reflex marker at R — the MAJOR (>180°) arc between the
+            // same two arms. Euclid avoids reflex angles, so this is for
+            // the rare teaching case; default markers stay interior.
+            { name: "angRreflex", construction: E.Sector.angleMarkerReflex, params: ["R", "P", "Q", 40] },
+        ],
+        slides: [
+            { text: "Three interior angles of triangle {PQR}: {angP|angP}, {angQ|angQ}, {angR|angR}.",
+              visible: ["PQR","angP","angQ","angR"],
+              transition: { mode: "parallel", animations: [
+                  { elem: "angP", name: A.Sector.sweep },
+                  { elem: "angQ", name: A.Sector.sweep },
+                  { elem: "angR", name: A.Sector.sweep }
+              ] } },
+            { text: "A long arm {QS} doesn't grow the marker {angQS|angQS} — radius is fixed.",
+              visible: ["PQR","angP","angQ","angR","QS","S","angQS"],
+              transition: { animations: [ { elem: "angQS", name: A.Sector.sweep } ] } },
+            { text: "Same vertex {P}: a second marker {angP2|angP2} at an overridden 38px radius so it nests outside {angP|angP}.",
+              visible: ["PQR","angP","angQ","angR","QS","S","angQS","PT","T","angP2"],
+              transition: { animations: [ { elem: "angP2", name: A.Sector.sweep } ] } },
+            { text: "Reflex marker at {R}: the major (>180°) arc {angRreflex|angRreflex}. Euclid avoids these — interior is the default.",
+              visible: ["PQR","angP","angQ","angR","QS","S","angQS","PT","T","angP2","angRreflex"],
+              transition: { animations: [ { elem: "angRreflex", name: A.Sector.sweep } ] } }
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Fixes #91.

## What

A dedicated angle-marker construction that fixes the ugliness of the old midpoint-chain `sector;sector` pattern (where the arc radius *was* the vertex-to-arm distance, so markers swung wildly in size and needed per-marker sign-checks).

- **`E.Sector.angleMarker`** (`sector;angleMarker;V,P1,P2[,radiusPx]`) — marks the **interior** angle P1-V-P2 with a small wedge whose radius the element chooses: default 22px, clamped to 0.45× the shorter arm. Consistent size regardless of arm length, and auto-oriented to the interior so arm order doesn't matter (no more sign-check). One line per marker, no midpoint-chain helpers.
- **Translucent palette fills** — markers default to a distinct translucent color from a 6-hue palette (cycled per marker, gold-avoiding so highlight still contrasts) plus a solid colored edge; overridable per element.
- **`E.Sector.angleMarkerReflex`** — same arms, draws the **major (>180°)** arc. Euclid avoids reflex angles, so this is for rare teaching cases (a III.20-style central angle); interior is the default. The major arc is drawn by flipping the canvas `anticlockwise` flag between the same two rays.
- **Wedge-flash on transitions** — while a marker is emphasised (the animator bumps `emphasisAmount` to 1 during a sweep and fades it 1→0 after), the **whole wedge** lights up with the highlight color, not just the edge. Gated to angle markers via a `_flashFace()` hook; plain sectors/arcs are untouched.

## Implementation notes

- `AngleMarkerElement extends SectorElement` with internal `_A/_B` recomputed each `update()` at the marker radius along each arm (the vertex + arm points are real slate elements; drags follow them).
- `SectorElement` gained overridable hooks — `_arcAngle()`, `_anticlockwise()`, `_traceWedge()`, `_flashFace()` — so the reflex/flash behavior is isolated to the marker subclass. The refactor is bit-for-bit for plain sectors/arcs.
- `A.Sector.sweep` sizes its duration to `arcSpan()` so a reflex marker's bigger arc sweeps over proportionally more time.
- init() assigns palette colors in construction order; the rgba face is set directly (it wouldn't survive parseColor).

## Test plan

- [x] `npm run test:unit` — 236 passing (11 new angle-marker cases: fixed radius, arm-length independence, clamp, override, auto-interior either arm order, endpoint recompute on drag, ringIndex, palette assignment + override, reflex major arc, wedge-flash on/off, plain-sector no-flash)
- [x] `npm run test:snapshot` — 700 passing (existing sector/arc fixtures bit-for-bit unchanged)
- [x] `view/test/sector/angle-marker.html` — interior trio, long-arm radius constancy, same-vertex overlap (the 0.8.1 nesting gap), a reflex marker, and the wedge-flash, all walked

## Deferred to 0.8.1

Same-vertex auto-nesting (radius-step + color de-clash). A `ringIndex` field lands now (forward-compatible); for now overlapping markers at one vertex use the px-radius override as a stopgap.