### PR TITLE
0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brownnrl/geomlib",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Interactive Euclidean geometry constructions in the browser — a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
   "keywords": [
     "euclid",


### PR DESCRIPTION
Minor release 0.8.0.

## New since 0.7.1

- #91 — angle markers: `E.Sector.angleMarker` (fixed-radius interior markers, auto-orient, translucent palette fills) + `E.Sector.angleMarkerReflex` (major-arc variant) + whole-wedge flash on transitions. Same-vertex auto-nesting deferred to 0.8.1.

## Test plan

- [x] `npm run test:unit` — 236 passing
- [x] `npm run test:snapshot` — 700 passing