### PR TITLE
0.9.0: A.Point.slide + A.Group.cloneAside + element initial-visibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Library is **post-porting, publish-ready**. There is no longer a
 "next construction to port" backlog or session-startup ritual.
 
 - All 69 construction methods (with 19 3D variants) are implemented.
-- 245 unit tests + 700 snapshot tests pass.
+- 249 unit tests + 700 snapshot tests pass.
 - 0.4.0 shipped cross-highlighting (`emphasized` / `emphasisAmount`
   + `lookupElement`); 0.5.0 shipped the slideshow surface
   (`slides`, `setVisibleNames`, `addAlias`, `resolveJustification`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Library is **post-porting, publish-ready**. There is no longer a
 "next construction to port" backlog or session-startup ritual.
 
 - All 69 construction methods (with 19 3D variants) are implemented.
-- 236 unit tests + 700 snapshot tests pass.
+- 245 unit tests + 700 snapshot tests pass.
 - 0.4.0 shipped cross-highlighting (`emphasized` / `emphasisAmount`
   + `lookupElement`); 0.5.0 shipped the slideshow surface
   (`slides`, `setVisibleNames`, `addAlias`, `resolveJustification`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ That's it.
 ## Running tests
 
 ```sh
-npm run test:unit      # 236 unit tests — fast (~100 ms)
+npm run test:unit      # 245 unit tests — fast (~100 ms)
 npm run test:snapshot  # 700 visual-regression tests against snapshot goldens
 npm test               # both (snapshot then unit)
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ That's it.
 ## Running tests
 
 ```sh
-npm run test:unit      # 245 unit tests — fast (~100 ms)
+npm run test:unit      # 249 unit tests — fast (~100 ms)
 npm run test:snapshot  # 700 visual-regression tests against snapshot goldens
 npm test               # both (snapshot then unit)
 ```

--- a/doc/animations-reference.md
+++ b/doc/animations-reference.md
@@ -52,6 +52,7 @@ Rates are in `px/ms` for linear traces and `rad/ms` for arc sweeps.
 | Name | Status | Target | Args | Default | Visual |
 |---|---|---|---|---|---|
 | `A.Point.appear` | **IMPL** | `PointElement` | — | `350 ms` | Marker radius scales from 0 to its final value. The simplest reveal — used for points constructed at an intersection ("the point C at which the circles cut"). |
+| `A.Point.slide` | **IMPL** | `LineSlider` | `{ to: number }` | `650 ms` | Glide a slider point along its line to the target parameter `t` (`A + t·(B−A)`; an infinite `lineSlider` accepts `t < 0` / `t > 1`), its dependents following each frame — the scripted counterpart of a reader dragging the slider. `finalise()` leaves the point at the target. Non-slider targets warn + fall through. |
 | `A.Point.intersect` | TBD | `PointElement` | — | — | Reserved. Brief flash on the intersecting curves before the dot lands. Will use ephemerals to render the flash. |
 
 ## Line animations
@@ -82,6 +83,12 @@ Rates are in `px/ms` for linear traces and `rad/ms` for arc sweeps.
 | Name | Status | Target | Args | Default | Visual |
 |---|---|---|---|---|---|
 | `A.Sector.sweep` | **IMPL** | `SectorElement` (incl. `ArcElement`) | — | rate `0.003 rad/ms`, min `250 ms`, fill cap `500 ms` | The arc grows from the A arm toward the B arm (`drawProgress: 0 → 1`) — the angle-marker reveal. Two-step (sweep then face fade) when the sector has a face; a face-less sector skips the fill step. Zero-color sectors render in the gold emphasis stroke only while animating — the invisible angle-marker pattern. |
+
+## Group animations
+
+| Name | Status | Target | Args | Default | Visual |
+|---|---|---|---|---|---|
+| `A.Group.cloneAside` | **IMPL** | `GeomElement` (anchor; clone set comes from args) | `{ dx, dy, include?, vary? }` | translate `0.4 px/ms`, min `200 ms` | Clone a sub-figure (`include: "all"` or a name list of elements) into displaced bare render-copies that slide aside and **persist** for the slide (cleared on the next advance / on presentation exit). Optional `vary: { elem, to }` sets a slider point to parameter `t` before snapshotting, so each copy shows a different case (a trichotomy's "one of them is greater"). The real figure never moves; the anchor stays fully drawn. v1 snapshots point / line / polygon (others skipped with a warn). Copies clamp to the canvas and are **skipped below a ≈520px viewport** — case-variants are a desktop affordance for now (see #99 auto-placement, #71 scale-to-fit). |
 
 ## Reserved / no-namespace
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -469,6 +469,7 @@ A.Line       // LineAnimations
 A.Circle     // CircleAnimations
 A.Polygon    // PolygonAnimations
 A.Sector     // SectorAnimations (0.7.0+)
+A.Group      // cross-type group animations (0.9.0+)
 A.instant    // no-op finalise (suppress an inherited animation)
 ```
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -98,6 +98,10 @@ interface IInitialization {
     animationConfig?: IAnimationConfig;
     // 0.7.1+ — draggables exempt from the slideshow auto-union
     deferDraggables?: string[];
+    // 0.9.0+ — elements that start hidden in the static figure
+    initiallyHidden?: string[];
+    // 0.9.0+ — show angle markers in the static figure (default: hidden)
+    showAngles?: boolean;
 }
 ```
 
@@ -113,6 +117,8 @@ interface IInitialization {
 | `elements` | `e[1]`, `e[2]`, … | (required) | Ordered list of element specs. May mix `IConstructionInfo` objects and Java param strings. |
 | `aliases` | — | `{}` | Secondary element names that resolve to a canonical element. See [Slides & visibility](#slides--visibility). |
 | `deferDraggables` | — | `[]` | 0.7.1+. Draggable element names excluded from the slideshow's every-slide auto-union — they follow slide `visible` sets like any other element. For draggables the proof introduces mid-walk. |
+| `initiallyHidden` | — | `[]` | 0.9.0+. Element names that start hidden (`visible = false`) in the static figure. Revealed by a slide's `visible` set, or when the element is slide-highlighted / its `{NAME}` ref is hovered. `clearVisibility()` (presentation exit) restores this baseline. |
+| `showAngles` | — | `false` | 0.9.0+. Show angle markers (`E.Sector.angleMarker` / `angleMarkerReflex`) in the static figure. Default `false`: markers are hidden initially — Euclid's source diagram draws no angle arcs — and appear during the slide walk or on hover. |
 | `slides` | — | `[]` | Optional slideshow walk-through. When present, SlateControls shows a "▶ Present" button. See [Slides & visibility](#slides--visibility). |
 | `resolveJustification` | — | `null` | Callback that maps a symbolic justification ref (e.g. `"I.Post.3"`) to a URL string. See [Slides & visibility](#slides--visibility). |
 | `animationConfig` | — | `{}` | Per-animation rate / duration overrides, `speedMultiplier`, `reducedMotion`. See [Animation](#animation). |

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -261,12 +261,19 @@ Two surfaces, the raw primitive and the slideshow on top of it.
 
 **Raw visibility primitive.** Every `GeomElement` carries a `visible:
 boolean` flag (default `true`). Each per-type `draw{Face,Edge,Vertex,Name}`
-method short-circuits at the top when the flag is false, so a hidden
-element stops drawing without leaving the slate's `_elements` list —
-dependents that read its coordinates still work. `Slate.setVisibleNames(names)`
-flips every *named* element's flag according to set membership;
-`clearVisibility()` resets them all to true. Unnamed intermediate
-construction outputs are never touched by `setVisibleNames`.
+method short-circuits at the top when the flag is false — **unless the
+element is slide-highlighted or emphasised (its `{NAME}` ref hovered)**,
+in which case it still draws (0.9.0+), so a referenced-but-hidden
+element is never completely unseeable. The element stays in the slate's
+`_elements` list either way, so dependents that read its coordinates
+still work. `Slate.setVisibleNames(names)` flips every *named* element's
+flag according to set membership. Some elements **start hidden**: angle
+markers by default (`init({ showAngles: true })` reveals them) and
+anything in `init({ initiallyHidden: [...] })`; `clearVisibility()`
+restores that **baseline** (visible except the initially-hidden set),
+not blanket true, so hidden elements stay hidden after a presentation
+walk. Unnamed intermediate construction outputs are never touched by
+`setVisibleNames`.
 
 **Name aliases.** `Slate.addAlias("CDB", "BCD")` registers a synonym.
 After a direct-name miss in `lookupElement`, the alias map is followed

--- a/src/Slate.ts
+++ b/src/Slate.ts
@@ -324,11 +324,33 @@ export class Slate {
         }
     }
 
-    // Restore every element's visible flag to true. Counterpart to
+    // Names of elements that start hidden (angle markers by default, or
+    // anything in init's `initiallyHidden`). clearVisibility restores to
+    // this baseline rather than blanket-true, so hidden elements stay
+    // hidden after a presentation walk. (#100)
+    private _initiallyHidden : Set<string> = new Set();
+
+    get initiallyHidden() : Set<string> {
+        return this._initiallyHidden;
+    }
+
+    // Mark a named element hidden in the initial figure: flips its
+    // visible flag off now and remembers it for clearVisibility.
+    setInitiallyHidden(name: string) : void {
+        if (name == null) return;
+        this._initiallyHidden.add(name);
+        const elem = this.lookupElement(name);
+        if (elem != null) elem.visible = false;
+    }
+
+    // Restore every element's visible flag to its initial baseline —
+    // true, except names registered as initially hidden. Counterpart to
     // setVisibleNames; called on presentation exit so the canvas
     // returns to its inline default.
     clearVisibility() : void {
-        for (let elem of this._elements) elem.visible = true;
+        for (let elem of this._elements) {
+            elem.visible = !(elem.name != null && this._initiallyHidden.has(elem.name));
+        }
     }
 
     // Sort params into P[] (points), E[] (other elements), N[] (integers),

--- a/src/SlateControls.ts
+++ b/src/SlateControls.ts
@@ -399,6 +399,11 @@ class SlateControls {
         this.unbindPresentationKeys();
         this.clearStickyRef();
         this.removePresentationOverlay();
+        // Cancel any in-flight transition and drop any parked ephemerals
+        // (e.g. a cloneAside case-variant clone) so the static figure is
+        // clean on exit.
+        if (this._slate.animator != null) this._slate.animator.cancel();
+        this._slate.clearEphemerals();
         this._slate.clearVisibility();
         for (let e of this._slate.elements) {
             e.shouldHighlight = false;
@@ -553,6 +558,12 @@ class SlateControls {
         // belongs to the prior caption and is about to be replaced
         // anyway.
         this.clearStickyRef();
+        // Wipe any ephemerals a prior slide left parked (e.g. a
+        // translateAside case-variant clone that persisted for its
+        // slide). The animated branch's animateTo→cancel also clears
+        // ephemerals, but an instant transition wouldn't — so clear
+        // here on every advance.
+        this._slate.clearEphemerals();
 
         const slide = slides[clamped];
         const transition = slide.transition;

--- a/src/elements/Animations.ts
+++ b/src/elements/Animations.ts
@@ -24,6 +24,7 @@ export enum AllAnimations {
     INSTANT,
     POINT_APPEAR,
     POINT_INTERSECT,                 // future
+    POINT_SLIDE,
     LINE_STRAIGHT_EDGE_CONNECT,
     LINE_STRAIGHT_EDGE_EXTEND,
     LINE_COMPASS_TRANSFER,           // future
@@ -33,6 +34,7 @@ export enum AllAnimations {
     POLYGON_OUTLINE_AND_FILL,
     POLYGON_SUPERPOSE,
     SECTOR_SWEEP,
+    GROUP_CLONE_ASIDE,
 }
 
 // Typed constants object, mirroring E for constructions. Authors
@@ -41,6 +43,7 @@ export const A = {
     Point: {
         appear:              AllAnimations.POINT_APPEAR,
         intersect:           AllAnimations.POINT_INTERSECT,           // future
+        slide:               AllAnimations.POINT_SLIDE,
     },
     Line: {
         straightEdgeConnect: AllAnimations.LINE_STRAIGHT_EDGE_CONNECT,
@@ -58,6 +61,9 @@ export const A = {
     },
     Sector: {
         sweep:               AllAnimations.SECTOR_SWEEP,
+    },
+    Group: {
+        cloneAside:          AllAnimations.GROUP_CLONE_ASIDE,
     },
     instant:                 AllAnimations.INSTANT,
 };

--- a/src/elements/circle/CircleElement.ts
+++ b/src/elements/circle/CircleElement.ts
@@ -135,7 +135,7 @@ export class CircleElement extends GeomElement {
     }
 
     public drawEdge(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         // Pick the highlight color BEFORE the null bail, matching
         // LineElement / PolygonElement (#81). A circle with a null
         // edgeColor can still render in the highlight stroke while
@@ -165,7 +165,7 @@ export class CircleElement extends GeomElement {
     }
 
     public drawFace(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (this.faceColor == null || !this.defined()) return;
         // Face is independent of the edge sweep — always fills the
         // full circle (filling a partial arc would render a pie wedge
@@ -190,7 +190,7 @@ export class CircleElement extends GeomElement {
     }
 
     public drawName(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (this.nameColor != null && this.name != null) {
             let ctx = c.getContext("2d") as CanvasRenderingContext2D;
             ctx.strokeStyle = this.nameColor;

--- a/src/elements/group/GroupAnimations.ts
+++ b/src/elements/group/GroupAnimations.ts
@@ -1,0 +1,235 @@
+// Cross-type group animations. See ../Animations.ts for the abstract
+// base + registry mechanics.
+
+import {Animation, AllAnimations, IAnimationStep, registerAnimation} from "../Animations";
+import {GeomElement} from "../GeomElement";
+import {Slate} from "../../Slate";
+import {PointElement} from "../point/PointElement";
+import {LineElement} from "../line/LineElement";
+import {PolygonElement} from "../polygon/PolygonElement";
+import {LineSlider} from "../point/LineSlider";
+
+const CLONE_ASIDE_RATE_PX_PER_MS = 0.4;
+const CLONE_ASIDE_MIN_MS = 200;
+// Below this canvas (≈ viewport, in presentation mode) width, skip the
+// case-variant copies entirely — they're a desktop affordance for now.
+// Phones in portrait fall under this; #99 will auto-place them where
+// there is room and #71's scale-to-fit will make mobile viable.
+const CLONE_ASIDE_DESKTOP_MIN_WIDTH = 520;
+
+// A mutable clone vertex tracked against its snapshot base, so the
+// animation can slide every clone point by the same offset.
+interface ClonePoint { pt: PointElement; bx: number; by: number; }
+
+// Snapshot one element into a bare render-copy (no construction refs;
+// update() is a no-op) at its current geometry, returning the ghost
+// plus the list of its mutable points. Supported v1 types: point,
+// line, polygon. Unsupported types return null (skipped with a warn).
+function snapshotElement(el: GeomElement): { ghost: GeomElement, pts: ClonePoint[] } | null {
+    const bare = (src: PointElement): PointElement => {
+        const p = new PointElement();
+        p.x = src.x; p.y = src.y; p.z = src.z;
+        return p;
+    };
+    // PolygonElement extends nothing point-like but has V[]; check it
+    // before LineElement / PointElement so a polygon isn't mis-typed.
+    if (el instanceof PolygonElement) {
+        const ghost = new PolygonElement();
+        const pts: ClonePoint[] = [];
+        for (const v of el.V) {
+            const p = bare(v);
+            ghost.V.push(p);
+            pts.push({ pt: p, bx: p.x, by: p.y });
+        }
+        ghost.edgeColor = el.edgeColor;
+        ghost.faceColor = el.faceColor;
+        ghost.faceAlpha = el.faceAlpha;
+        ghost.nameColor = el.nameColor;
+        ghost.vertexColor = el.vertexColor;
+        return { ghost, pts };
+    }
+    if (el instanceof LineElement) {
+        const a = bare(el.A);
+        const b = bare(el.B);
+        const ghost = new LineElement({ A: a, B: b });
+        ghost.edgeColor = el.edgeColor;
+        ghost.nameColor = el.nameColor;
+        return { ghost, pts: [{ pt: a, bx: a.x, by: a.y }, { pt: b, bx: b.x, by: b.y }] };
+    }
+    if (el instanceof PointElement) {
+        const p = bare(el);
+        p.vertexColor = el.vertexColor;
+        p.nameColor = el.nameColor;
+        if (el.name != null) p.name = el.name;
+        return { ghost: p, pts: [{ pt: p, bx: p.x, by: p.y }] };
+    }
+    return null;   // circle / sector / other — deferred
+}
+
+// A.Group.cloneAside — clone a sub-figure (a named set of elements, or
+// "all") into displaced bare copies and slide them aside, where they
+// PERSIST for the slide. Optionally vary a slider point first so each
+// copy shows a different case (e.g. a trichotomy's "one of them is
+// greater"). The real figure never moves.
+//
+// args:
+//   dx, dy          pixel offset to displace the clone by
+//   include         "all" (default) or an array of element names
+//   vary?           { elem, to } — set a slider point to parameter t
+//                   (A + t·(B−A); infinite-slider t can be < 0) before
+//                   snapshotting, so the clone shows the varied figure;
+//                   the real slider is restored afterward
+//
+// Lifecycle: the clones are ephemerals this animation does NOT remove —
+// they stay until the next slide advance clears them (SlateControls
+// .showSlide wipes leftover ephemerals on every transition). A
+// fade-out on dismissal is a future polish (#94/#98).
+//
+// elementType is GeomElement: the entry's `elem` is a nominal anchor;
+// the clone set comes from args.include.
+export class GroupCloneAsideAnimation extends Animation {
+    public animationMethod = AllAnimations.GROUP_CLONE_ASIDE;
+    public name = "Group.cloneAside";
+    public elementType = GeomElement;
+
+    public build(target: GeomElement, slate: Slate, args: any): IAnimationStep[] {
+        const dx = args && typeof args.dx === "number" ? args.dx : 0;
+        const dy = args && typeof args.dy === "number" ? args.dy : 0;
+        const include = args && args.include;
+        const vary = args && args.vary;
+        const durationMs = Math.max(CLONE_ASIDE_MIN_MS,
+            Math.hypot(dx, dy) / CLONE_ASIDE_RATE_PX_PER_MS);
+
+        // Resolve the elements to clone. "all" / missing → every named,
+        // visible, non-screen element; otherwise the explicit name list.
+        const sources: GeomElement[] = [];
+        if (Array.isArray(include)) {
+            for (const nm of include) {
+                const e = slate.lookupElement(String(nm));
+                if (e != null) sources.push(e);
+            }
+        } else {
+            for (const e of slate.elements) {
+                if (e.name != null && e.visible && !e.name.startsWith("screen")) {
+                    sources.push(e);
+                }
+            }
+        }
+
+        let cloned: ClonePoint[] = [];
+        // Effective offset — clamped in setup to keep the clone's
+        // bounding box within the canvas so a copy never slides out of
+        // the visible extents.
+        let edx = dx, edy = dy;
+
+        const setOffset = (p: number) => {
+            for (const c of cloned) {
+                c.pt.x = c.bx + edx * p;
+                c.pt.y = c.by + edy * p;
+            }
+        };
+
+        return [{
+            durationMs,
+            setup: () => {
+                // The real figure stays fully on stage — cloneAside is
+                // not a reveal. Undo the animator's pre-zeroing of the
+                // anchor target (it sets drawProgress = 0 on every
+                // animated target's element).
+                target.drawProgress = 1;
+                target.visible = true;
+                // Optionally vary a slider, recompute the real figure,
+                // snapshot, then restore — so the clone captures the
+                // varied geometry without disturbing the live figure.
+                let slider: LineSlider | null = null;
+                let sx = 0, sy = 0, sz = 0;
+                if (vary && vary.elem != null && typeof vary.to === "number") {
+                    const s = slate.lookupElement(String(vary.elem));
+                    if (s instanceof LineSlider) {
+                        slider = s;
+                        sx = s.x; sy = s.y; sz = s.z;
+                        const A = (s as any)._A as PointElement;
+                        const B = (s as any)._B as PointElement;
+                        s.x = A.x + (B.x - A.x) * vary.to;
+                        s.y = A.y + (B.y - A.y) * vary.to;
+                        s.z = A.z + (B.z - A.z) * vary.to;
+                        slate.update();
+                    }
+                }
+
+                // Snapshot into a temp set first (don't commit yet — the
+                // desktop-only fit check below decides whether to show).
+                const temp: { ghost: GeomElement, pts: ClonePoint[] }[] = [];
+                let warnedSkip = false;
+                for (const el of sources) {
+                    const snap = snapshotElement(el);
+                    if (snap == null) {
+                        if (!warnedSkip && typeof console !== "undefined" && console.warn) {
+                            console.warn("[geomlib] Group.cloneAside: skipping "
+                                + "unsupported element type (" + el.name + ")");
+                            warnedSkip = true;
+                        }
+                        continue;
+                    }
+                    temp.push(snap);
+                }
+
+                if (slider != null) {
+                    slider.x = sx; slider.y = sy; slider.z = sz;
+                    slate.update();
+                }
+
+                // Figure bbox (clone base coords == figure coords).
+                let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+                for (const t of temp) for (const c of t.pts) {
+                    if (c.bx < minX) minX = c.bx; if (c.bx > maxX) maxX = c.bx;
+                    if (c.by < minY) minY = c.by; if (c.by > maxY) maxY = c.by;
+                }
+                const bw = maxX - minX, bh = maxY - minY;
+
+                const MARGIN = 6;
+                const canvas: any = (slate as any).canvas;
+                const W = canvas ? canvas.width : 0;
+                const H = canvas ? canvas.height : 0;
+
+                // Desktop-only: skip case-variant copies on a narrow
+                // (mobile) viewport — there isn't room to lay them out.
+                if (W && W < CLONE_ASIDE_DESKTOP_MIN_WIDTH) return;
+
+                // Clamp the requested offset so the copy stays inside the
+                // canvas (respect direction; only reduce magnitude).
+                edx = dx; edy = dy;
+                if (W && H && temp.length > 0) {
+                    if (minX + edx < MARGIN) edx = MARGIN - minX;
+                    if (maxX + edx > W - MARGIN) edx = (W - MARGIN) - maxX;
+                    if (minY + edy < MARGIN) edy = MARGIN - minY;
+                    if (maxY + edy > H - MARGIN) edy = (H - MARGIN) - maxY;
+                }
+
+                // Desktop-only fit guard: only show the copy if, after
+                // clamping, it clears the original figure (no overlap) on
+                // at least one axis. On a canvas too narrow to place it
+                // clear (mobile), skip the copy entirely — case-variants
+                // are a desktop affordance for now (#99 will auto-place
+                // them in the available area). A single point always
+                // clears (bw/bh = 0).
+                const CLEAR_GAP = 8;
+                const clears = temp.length === 0
+                    || Math.abs(edx) >= bw + CLEAR_GAP
+                    || Math.abs(edy) >= bh + CLEAR_GAP
+                    || (bw === 0 && bh === 0);
+                if (!clears) return;   // no room — skip
+
+                for (const t of temp) {
+                    slate.addEphemeral(t.ghost);
+                    cloned = cloned.concat(t.pts);
+                }
+            },
+            tick: (p) => { setOffset(p); },
+            // Persist parked at the offset; the next slide advance clears.
+            finalise: () => { setOffset(1); },
+        }];
+    }
+}
+
+registerAnimation(new GroupCloneAsideAnimation());

--- a/src/elements/line/LineElement.ts
+++ b/src/elements/line/LineElement.ts
@@ -41,7 +41,7 @@ export class LineElement extends GeomElement {
     }
 
     public drawEdge(c: HTMLCanvasElement, color?: string): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (color == null) {
             if (this.emphasized || this.shouldHighlight) {
                 color = this.edgeHighlightColor;
@@ -77,7 +77,7 @@ export class LineElement extends GeomElement {
     }
 
     public drawName(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (this.nameColor == null || this.name == null) return;
         if (this._A == null || !this._A.defined()) return;
         if (this._B == null || !this._B.defined()) return;

--- a/src/elements/plane/PlaneElement.ts
+++ b/src/elements/plane/PlaneElement.ts
@@ -68,7 +68,7 @@ export class PlaneElement extends GeomElement {
     // where D = B + C - A (the 4th corner in the plane of A, B, C).
 
     public drawEdge(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (this.edgeColor == null || !this.defined()) return;
         let ctx = c.getContext("2d") as CanvasRenderingContext2D;
         ctx.save();
@@ -86,7 +86,7 @@ export class PlaneElement extends GeomElement {
     }
 
     public drawFace(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (this.faceColor == null || !this.defined()) return;
         let ctx = c.getContext("2d") as CanvasRenderingContext2D;
         ctx.save();
@@ -104,7 +104,7 @@ export class PlaneElement extends GeomElement {
     }
 
     public drawName(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (this.nameColor == null || this.name == null || !this.defined()) return;
         // Label placed at midpoint of BC, matching Java PlaneElement.drawName
         let ix = Math.round((this.B.x + this.C.x) / 2.0);
@@ -113,7 +113,7 @@ export class PlaneElement extends GeomElement {
     }
 
     public drawVertex(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (this.vertexColor == null || !this.defined()) return;
         // Draw vertex at D = B + C - A (the 4th parallelogram corner).
         // A, B, C are drawn by their own drawVertex calls in Slate.

--- a/src/elements/point/PointAnimations.ts
+++ b/src/elements/point/PointAnimations.ts
@@ -5,6 +5,7 @@ import {Animation, AllAnimations, IAnimationStep, registerAnimation} from "../An
 import {GeomElement} from "../GeomElement";
 import {Slate} from "../../Slate";
 import {PointElement} from "./PointElement";
+import {LineSlider} from "./LineSlider";
 
 // A.Point.appear — the marker radius scales from 0 to its final value
 // over a short duration. Args: none. Used as the simplest reveal for a
@@ -30,4 +31,62 @@ export class PointAppearAnimation extends Animation {
     }
 }
 
+// A.Point.slide — glide a slider point along its line to a target
+// parameter `t` (the scripted counterpart of a reader dragging it).
+// The point really travels its constraint and its dependents follow.
+// Args: { to: number } — the target parameter along A→B (0 = A, 1 = B;
+// for a segment slider it's clamped to [0,1] by the slider's own
+// projection). Optional durationMs; default ~ a standard transition
+// glide, resolved through the usual chain.
+//
+// elementType is LineSlider — covers both `lineSlider` and
+// `lineSegmentSlider`. A non-slider target warns + falls through to
+// instant (the registry contract).
+export class PointSlideAnimation extends Animation {
+    public animationMethod = AllAnimations.POINT_SLIDE;
+    public name = "Point.slide";
+    public elementType = LineSlider;
+    public defaultDurationMs = 650;
+
+    public build(target: GeomElement, slate: Slate, args: any): IAnimationStep[] {
+        const slider = target as LineSlider;
+        const to = args && typeof args.to === "number" ? args.to : 1;
+        // Start + target positions are captured at setup time (after
+        // any earlier-slide motion has settled), both on the line A→B,
+        // so the lerp between them stays collinear and the slider's own
+        // re-projection in update() is a no-op.
+        let sx = 0, sy = 0, sz = 0;   // start
+        let tx = 0, ty = 0, tz = 0;   // target = A + t·(B−A)
+        const apply = (p: number) => {
+            slider.x = sx + (tx - sx) * p;
+            slider.y = sy + (ty - sy) * p;
+            slider.z = sz + (tz - sz) * p;
+            // Drive dependents from the new position this frame.
+            slate.update();
+        };
+        return [{
+            durationMs: this.defaultDurationMs,
+            setup: () => {
+                // A slide is not a reveal — the point is already on
+                // stage; undo the animator's reveal pre-zeroing.
+                slider.drawProgress = 1;
+                slider.visible = true;
+                sx = slider.x; sy = slider.y; sz = slider.z;
+                const A = (slider as any)._A as PointElement;
+                const B = (slider as any)._B as PointElement;
+                tx = A.x + (B.x - A.x) * to;
+                ty = A.y + (B.y - A.y) * to;
+                tz = A.z + (B.z - A.z) * to;
+            },
+            tick: (progress) => { apply(progress); },
+            finalise: () => {
+                apply(1);
+                slider.drawProgress = 1;
+                slider.visible = true;
+            },
+        }];
+    }
+}
+
 registerAnimation(new PointAppearAnimation());
+registerAnimation(new PointSlideAnimation());

--- a/src/elements/point/PointElement.ts
+++ b/src/elements/point/PointElement.ts
@@ -369,14 +369,14 @@ export class PointElement extends GeomElement {
     }
 
     public drawName(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (this.nameColor != null && this.name != null && this.defined()) {
             this.drawString(Math.round(this.x), Math.round(this.y), c)
         }
     }
 
     public drawVertex(c: SlateCanvas, color?: string): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         let ctx : CanvasRenderingContext2D = c.getContext("2d") as CanvasRenderingContext2D;
         if (color == null) {
             if (this.emphasized || this.shouldHighlight) {

--- a/src/elements/polygon/PolygonElement.ts
+++ b/src/elements/polygon/PolygonElement.ts
@@ -59,7 +59,7 @@ export class PolygonElement extends GeomElement {
     }
 
     public drawEdge(c: HTMLCanvasElement, color?: string): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (color == null) {
             if (this.emphasized || this.shouldHighlight) {
                 color = this.edgeHighlightColor;
@@ -117,7 +117,7 @@ export class PolygonElement extends GeomElement {
     }
 
     public drawFace(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if(this.faceColor != null && this.defined() && this.V.length > 2) {
             let ctx : CanvasRenderingContext2D = c.getContext("2d") as CanvasRenderingContext2D;
             ctx.beginPath();
@@ -148,7 +148,7 @@ export class PolygonElement extends GeomElement {
     }
 
     public drawName(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (this.nameColor != null && this.name != null && this.defined()) {
             let x : number = 0;
             let y : number = 0;
@@ -168,7 +168,7 @@ export class PolygonElement extends GeomElement {
     }
 
     public drawVertex(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (this.vertexColor != null && this.defined() ) {
             for(let v of this.V) {
                 v.drawVertex(c, this.vertexColor);

--- a/src/elements/polyhedron/PolyhedronElement.ts
+++ b/src/elements/polyhedron/PolyhedronElement.ts
@@ -38,7 +38,7 @@ export class PolyhedronElement extends GeomElement {
     }
 
     public drawName(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (this.nameColor != null && this.name != null && this.defined()) {
             let x = 0, y = 0, ct = 0;
             for (let j = 0; j < this.P.length; ++j) {
@@ -55,7 +55,7 @@ export class PolyhedronElement extends GeomElement {
     }
 
     public drawVertex(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (this.vertexColor != null && this.defined()) {
             for (let j = 0; j < this.P.length; ++j) {
                 for (let i = 0; i < this.P[j].V.length; ++i) {
@@ -66,7 +66,7 @@ export class PolyhedronElement extends GeomElement {
     }
 
     public drawEdge(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (this.edgeColor != null && this.defined()) {
             let ctx = c.getContext("2d") as CanvasRenderingContext2D;
             ctx.strokeStyle = this.edgeColor;
@@ -84,7 +84,7 @@ export class PolyhedronElement extends GeomElement {
     }
 
     public drawFace(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (this.faceColor != null && this.defined()) {
             for (let j = 0; j < this.P.length; ++j) {
                 // Pass the polyhedron's faceColor to each face polygon,

--- a/src/elements/sector/SectorElement.ts
+++ b/src/elements/sector/SectorElement.ts
@@ -86,7 +86,7 @@ export class SectorElement extends GeomElement {
     }
 
     drawEdge(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         // Pick the highlight color BEFORE the null bail, matching the
         // other element types (#81 / #86) — a zero-color sector can
         // still render in the highlight stroke while emphasized or
@@ -168,7 +168,7 @@ export class SectorElement extends GeomElement {
     }
 
     drawFace(c: SlateCanvas): void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (this.faceColor == null || !this.defined()) return;
         // Face is independent of the edge sweep — always the full
         // sector wedge, with alpha driven by the dedicated faceAlpha

--- a/src/elements/sphere/SphereElement.ts
+++ b/src/elements/sphere/SphereElement.ts
@@ -43,7 +43,7 @@ export class SphereElement extends GeomElement {
     }
 
     public drawName(c: SlateCanvas) : void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if(this.nameColor != null && this.name != null && this.defined()) {
             this.drawString(Math.round(this._Center.x), Math.round(this._Center.y), c, Align.CENTRAL);
         }
@@ -54,7 +54,7 @@ export class SphereElement extends GeomElement {
     }
 
     public drawEdge(c: SlateCanvas) : void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (this.edgeColor == null || !this.defined()) return;
         let ctx = c.getContext("2d") as CanvasRenderingContext2D;
         ctx.save();
@@ -75,7 +75,7 @@ export class SphereElement extends GeomElement {
     }
 
     public drawFace(c: SlateCanvas) : void {
-        if (!this.visible) return;
+        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
         if (this.faceColor == null || !this.defined()) return;
         let ctx = c.getContext("2d") as CanvasRenderingContext2D;
         ctx.save();

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,16 @@ export interface IInitialization {
     // fully draggable whenever shown. No effect outside presentation
     // mode.
     deferDraggables?: string[];
+    // 0.9.0+ — element names that start hidden in the static figure
+    // (visible = false). Revealed by a slide's visible set, or when the
+    // element is highlighted / its {NAME} ref is hovered. clearVisibility
+    // (presentation exit) restores to this baseline. (#100)
+    initiallyHidden?: string[];
+    // 0.9.0+ — show angle markers (E.Sector.angleMarker /
+    // angleMarkerReflex) in the static figure. Default false: markers
+    // are hidden initially (Euclid's source diagram draws no angle arcs)
+    // and appear during the slide walk or on hover. (#100)
+    showAngles?: boolean;
     // Optional slideshow walk-through. When provided + non-empty,
     // SlateControls renders a "▶ Present" button that opens the
     // Presentation overlay. Stays empty (no button, no behaviour
@@ -323,6 +333,21 @@ function initInner(i: IInitialization, canvas: HTMLCanvasElement) {
 
     if (i.deferDraggables != null) {
         slate.deferDraggables(i.deferDraggables);
+    }
+
+    // Angle markers are hidden in the static figure by default (Euclid's
+    // diagram draws no angle arcs); init({ showAngles: true }) reveals
+    // them. Plus any explicit initiallyHidden names. clearVisibility
+    // restores to this baseline. (#100)
+    if (!i.showAngles) {
+        for (let elem of slate.elements) {
+            if (elem instanceof AngleMarkerElement && elem.name != null) {
+                slate.setInitiallyHidden(elem.name);
+            }
+        }
+    }
+    if (i.initiallyHidden != null) {
+        for (let name of i.initiallyHidden) slate.setInitiallyHidden(name);
     }
 
     if (i.slides != null && i.slides.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import "./elements/line/LineAnimations";
 import "./elements/circle/CircleAnimations";
 import "./elements/polygon/PolygonAnimations";
 import "./elements/sector/SectorAnimations";
+import "./elements/group/GroupAnimations";
 import {PointElement} from "./elements/point/PointElement";
 import {Slate} from "./Slate";
 import {PlaneSlider} from "./elements/point/PlaneSlider";

--- a/tests/AnimationTest.ts
+++ b/tests/AnimationTest.ts
@@ -662,3 +662,175 @@ describe("sector sweep + polygon superposition (issue #86)", () => {
         });
     });
 });
+
+// Issue #95 — A.Point.slide glides a slider point along its line to a
+// target parameter t, dragging its dependents. Issue #94 —
+// A.Polygon.translateAside spawns a persistent displaced clone.
+describe("point slide + polygon translate-aside (issues #95, #94)", () => {
+
+    const slider_data: IConstructionInfo[] = [
+        { construction: E.Point.free,       name: "A", params: [0, 100] },
+        { construction: E.Point.free,       name: "B", params: [200, 100] },
+        { construction: E.Point.lineSlider, name: "D", params: ["A", "B", 40, 100] },
+        // A dependent line so we can confirm dependents follow the slide.
+        { construction: E.Line.connect,     name: "BD", params: ["B", "D"] },
+    ];
+
+    const tri_data: IConstructionInfo[] = [
+        { construction: E.Point.free,        name: "A",   params: [50, 50] },
+        { construction: E.Point.free,        name: "B",   params: [150, 50] },
+        { construction: E.Point.free,        name: "C",   params: [100, 130] },
+        { construction: E.Polygon.triangle,  name: "ABC", params: ["A", "B", "C"] },
+    ];
+
+    describe("A.Point.slide", () => {
+        function sliderSlate(): [Slate, PointElement] {
+            const slate = new Slate(createCanvas(300, 200));
+            slate.inTest = true;
+            toElements(slate, slider_data);
+            slate.elements.forEach(e => e.update());
+            return [slate, slate.lookupElement("D") as PointElement];
+        }
+
+        it("glides D from its start to the target parameter t", () => {
+            const [slate, D] = sliderSlate();
+            // D projects onto AB (y=100) at x=40.
+            assert.ok(approx(D.x, 40) && approx(D.y, 100));
+            const anim = findAnimation(A.Point.slide)!;
+            const steps = anim.build(D, slate, { to: 0.75 });   // → x = 150
+            steps[0].setup!();
+            steps[0].tick(0.5, 8, steps[0].durationMs);         // halfway 40→150
+            assert.ok(approx(D.x, 95), `mid x ${D.x}`);
+            steps[0].finalise();
+            assert.ok(approx(D.x, 150), `final x ${D.x}`);
+            assert.ok(approx(D.y, 100));
+        });
+
+        it("dependents follow the slide", () => {
+            const [slate, D] = sliderSlate();
+            const BD = slate.lookupElement("BD") as LineElement;
+            const anim = findAnimation(A.Point.slide)!;
+            const steps = anim.build(D, slate, { to: 0 });       // D → A at x=0
+            steps[0].setup!();
+            steps[0].finalise();
+            // BD's D-endpoint should now sit at x≈0 (D moved to A).
+            assert.ok(approx((BD as any)._B.x, 0), `BD endpoint ${(BD as any)._B.x}`);
+        });
+
+        it("warns + falls through to instant on a non-slider point", () => {
+            const [slate] = sliderSlate();
+            const A_free = slate.lookupElement("A") as PointElement;
+            // findAnimation resolves; animateTo would reject the type —
+            // here we just confirm A.Point.slide's elementType guards it.
+            const anim = findAnimation(A.Point.slide)!;
+            assert.notStrictEqual(A_free.constructor, anim.elementType);
+        });
+    });
+
+    describe("A.Group.cloneAside", () => {
+        // A small triangle (≈80px wide), an infinite-slider point D on
+        // AB, and a line CD that depends on D — small enough that a
+        // clone clears the original on a wide test canvas.
+        const figure_data: IConstructionInfo[] = [
+            { construction: E.Point.free,       name: "A",   params: [40, 50] },
+            { construction: E.Point.free,       name: "B",   params: [120, 50] },
+            { construction: E.Point.free,       name: "C",   params: [80, 140] },
+            { construction: E.Polygon.triangle, name: "ABC", params: ["A", "B", "C"] },
+            { construction: E.Point.lineSlider, name: "D",   params: ["A", "B", 80, 50] },
+            { construction: E.Line.connect,     name: "CD",  params: ["C", "D"] },
+        ];
+
+        // Wide canvas so a 200px offset clears the ~80px figure.
+        function figSlate(w: number = 600): Slate {
+            const slate = new Slate(createCanvas(w, 300));
+            slate.inTest = true;
+            toElements(slate, figure_data);
+            slate.elements.forEach(e => e.update());
+            return slate;
+        }
+
+        it("single-element include: one clone, offset lerps, original unmoved", () => {
+            const slate = figSlate();
+            const abc = slate.lookupElement("ABC") as PolygonElement;
+            const a0x = abc.V[0].x;
+            const anim = findAnimation(A.Group.cloneAside)!;
+            const steps = anim.build(abc, slate, { dx: 200, dy: 0, include: ["ABC"] });
+            assert.strictEqual(slate.ephemerals.length, 0);
+            steps[0].setup!();
+            assert.strictEqual(slate.ephemerals.length, 1);
+            const ghost = slate.ephemerals[0] as PolygonElement;
+            steps[0].tick(0.5, 8, steps[0].durationMs);
+            assert.ok(approx(ghost.V[0].x, a0x + 100), `mid ${ghost.V[0].x}`);
+            steps[0].finalise();
+            assert.ok(approx(ghost.V[0].x, a0x + 200), `final ${ghost.V[0].x}`);
+            assert.ok(approx(abc.V[0].x, a0x), "real polygon unmoved");
+        });
+
+        it("include 'all' clones every named visible element (point+line+polygon)", () => {
+            const slate = figSlate();
+            const abc = slate.lookupElement("ABC") as PolygonElement;
+            const anim = findAnimation(A.Group.cloneAside)!;
+            const steps = anim.build(abc, slate, { dx: 200, dy: 0 });  // include defaults to all
+            steps[0].setup!();
+            // A, B, C, D (points) + ABC (polygon) + CD (line) = 6 ghosts.
+            assert.strictEqual(slate.ephemerals.length, 6);
+        });
+
+        it("vary places the cloned slider at A + t·(B−A) and restores the real one", () => {
+            const slate = figSlate();
+            const D = slate.lookupElement("D") as PointElement;
+            const ptA = slate.lookupElement("A") as PointElement;
+            const ptB = slate.lookupElement("B") as PointElement;
+            const d0x = D.x, d0y = D.y;
+            const anim = findAnimation(A.Group.cloneAside)!;
+            const steps = anim.build(slate.lookupElement("ABC")!, slate, {
+                dx: 250, dy: 0, include: ["D"],   // a lone point always clears
+                vary: { elem: "D", to: -0.3 },     // past A
+            });
+            steps[0].setup!();
+            // Real D restored to its original position.
+            assert.ok(approx(D.x, d0x) && approx(D.y, d0y), "real D restored");
+            // Cloned D (offset not yet applied — that happens in tick)
+            // sits at the varied parameter, past A.
+            const ghostD = slate.ephemerals[0] as PointElement;
+            const expX = ptA.x + (ptB.x - ptA.x) * -0.3;
+            assert.ok(approx(ghostD.x, expX), `cloned D ${ghostD.x} vs ${expX}`);
+        });
+
+        it("clones copy colors; unsupported types are skipped", () => {
+            const slate = figSlate();
+            const abc = slate.lookupElement("ABC") as PolygonElement;
+            abc.edgeColor = "#123456";
+            abc.faceColor = "rgba(1,2,3,0.3)";
+            const anim = findAnimation(A.Group.cloneAside)!;
+            const steps = anim.build(abc, slate, { dx: 200, dy: 0, include: ["ABC"] });
+            steps[0].setup!();
+            const ghost = slate.ephemerals[0] as PolygonElement;
+            assert.strictEqual(ghost.edgeColor, "#123456");
+            assert.strictEqual(ghost.faceColor, "rgba(1,2,3,0.3)");
+        });
+
+        it("persists past finalise; cleared by the slide-advance wipe", () => {
+            const slate = figSlate();
+            const abc = slate.lookupElement("ABC")!;
+            const anim = findAnimation(A.Group.cloneAside)!;
+            const steps = anim.build(abc, slate, { dx: 200, dy: 0, include: ["ABC"] });
+            steps[0].setup!();
+            steps[0].finalise();
+            assert.strictEqual(slate.ephemerals.length, 1);
+            slate.clearEphemerals();
+            assert.strictEqual(slate.ephemerals.length, 0);
+        });
+
+        it("desktop-only guard: skips a copy that can't clear the original on a narrow canvas", () => {
+            // 150px-wide canvas can't fit the ~80px figure plus a clone
+            // clear of it → no clone spawned.
+            const slate = figSlate(150);
+            const abc = slate.lookupElement("ABC")!;
+            const anim = findAnimation(A.Group.cloneAside)!;
+            const steps = anim.build(abc, slate, { dx: 200, dy: 0, include: ["ABC"] });
+            steps[0].setup!();
+            assert.strictEqual(slate.ephemerals.length, 0);
+        });
+    });
+});

--- a/tests/SectorTest.ts
+++ b/tests/SectorTest.ts
@@ -325,4 +325,94 @@ describe("angle marker (issue #91)", () => {
             assert.strictEqual(m.faceColor, "rgb(255,0,0)");
         });
     });
+
+    // #100 — marker initial visibility.
+    it("hides angle markers in the static figure by default", () => {
+        withFakeDOM((canvasid) => {
+            slates.length = 0;
+            init({
+                canvasid, background: "0,0,100", title: "t",
+                elements: [...baseMarkerElements, "m;sector;angleMarker;B,A,Cnear"],
+            });
+            const m = slates[0].lookupElement("m") as AngleMarkerElement;
+            assert.strictEqual(m.visible, false);
+            assert.ok(slates[0].initiallyHidden.has("m"));
+        });
+    });
+
+    it("shows angle markers when init({ showAngles: true })", () => {
+        withFakeDOM((canvasid) => {
+            slates.length = 0;
+            init({
+                canvasid, background: "0,0,100", title: "t", showAngles: true,
+                elements: [...baseMarkerElements, "m;sector;angleMarker;B,A,Cnear"],
+            } as any);
+            const m = slates[0].lookupElement("m") as AngleMarkerElement;
+            assert.strictEqual(m.visible, true);
+            assert.ok(!slates[0].initiallyHidden.has("m"));
+        });
+    });
+
+    it("initiallyHidden hides any named element; clearVisibility keeps it hidden", () => {
+        withFakeDOM((canvasid) => {
+            slates.length = 0;
+            init({
+                canvasid, background: "0,0,100", title: "t", showAngles: true,
+                initiallyHidden: ["Cfar"],
+                elements: [...baseMarkerElements, "m;sector;angleMarker;B,A,Cnear"],
+            } as any);
+            const slate = slates[0];
+            const cfar = slate.lookupElement("Cfar")!;
+            const m = slate.lookupElement("m")!;
+            assert.strictEqual(cfar.visible, false);  // explicitly hidden
+            assert.strictEqual(m.visible, true);       // showAngles on
+            // Presentation makes everything visible, then exit restores
+            // the baseline: Cfar hidden again, m still shown.
+            slate.setVisibleNames(slate.elements.map(e => e.name!).filter(Boolean));
+            assert.strictEqual(cfar.visible, true);
+            slate.clearVisibility();
+            assert.strictEqual(cfar.visible, false);
+            assert.strictEqual(m.visible, true);
+        });
+    });
+
+    it("a hidden element still renders when highlighted/emphasised (#100 hover-reveal)", () => {
+        const slate = new Slate(createCanvas(400, 400));
+        toElements(slate, [
+            { name: "O", construction: E.Point.free, params: [100, 100] },
+            { name: "P", construction: E.Point.free, params: [180, 100] },
+            { name: "Q", construction: E.Point.free, params: [100, 180] },
+            { name: "S", construction: E.Sector.sector, params: ["O", "P", "Q"] },
+        ]);
+        slate.elements.forEach(e => e.update());
+        const s = slate.lookupElement("S") as any;
+        s.edgeColor = "#000000";
+        s.visible = false;
+
+        // Hidden + not lit → no draw.
+        let r = recordingArcs(slate);
+        s.drawEdge(r.canvas);
+        assert.strictEqual(r.arcs.length, 0);
+
+        // Hidden but highlighted (hovered) → draws.
+        s.shouldHighlight = true;
+        r = recordingArcs(slate);
+        s.drawEdge(r.canvas);
+        assert.strictEqual(r.arcs.length, 1);
+    });
 });
+
+// Minimal arc recorder for the hover-reveal test.
+function recordingArcs(slate: Slate) {
+    const real = (slate as any).canvas;
+    const arcs: any[] = [];
+    const ctx: any = new Proxy(real.getContext("2d"), {
+        get(t, p) {
+            if (p === "arc") return () => arcs.push(1);
+            const v = t[p];
+            return typeof v === "function" ? v.bind(t) : v;
+        },
+        set(t, p, v) { t[p] = v; return true; },
+    });
+    return { canvas: { getContext: () => ctx } as any, arcs };
+}

--- a/view/test/sector/angle-marker.html
+++ b/view/test/sector/angle-marker.html
@@ -23,6 +23,9 @@ the px-radius override or different palette slots as a stopgap.
         background: '#ffe9cd',
         title: "angleMarker",
         canvasid: "canvasId",
+        // Markers are hidden in the static figure by default (0.9.0); show
+        // them here so this demo renders the markers without presenting.
+        showAngles: true,
         elements: [
             // A scalene triangle PQR — the three interior angles get
             // markers. P has a short arm to one side and a long arm to

--- a/view/test/slideshow/translate-slide.html
+++ b/view/test/slideshow/translate-slide.html
@@ -1,0 +1,58 @@
+<html>
+<head>
+    <title>Test View - A.Group.cloneAside + A.Point.slide (#98, #95)</title>
+</head>
+<body>
+<h3 style="font-family: sans-serif;">case-variant figure clones + point slide (#98, #95)</h3>
+<p style="font-family: sans-serif; max-width: 700px; color: #444;">
+Press <b>p</b> (or ▶ Present) and walk the slides.
+<b>#98 A.Group.cloneAside</b> clones the WHOLE figure (triangle + the
+slider point D + the line CD) aside, with D in a different position in
+each copy — three versions of D: the centre (real figure), one with D
+<b>past A</b> (off the segment, t&lt;0), one with D <b>between A and B</b>.
+<b>#95 A.Point.slide</b> then glides the real D along AB to its place.
+D is an infinite lineSlider so it can travel past A.
+</p>
+<canvas id="canvasId" style="width:720px; height: 380px;" tabindex="0"></canvas>
+<script src="../../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E, A = geomlib.A;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "cloneAside + slide",
+        canvasid: "canvasId",
+        elements: [
+            { name: "A", construction: E.Point.free, params: [330, 110] },
+            { name: "B", construction: E.Point.free, params: [430, 300] },
+            { name: "C", construction: E.Point.free, params: [300, 300] },
+            { name: "ABC", construction: E.Polygon.triangle, params: ["A", "B", "C"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black", faceColor: "rgba(120,180,210,0.25)" },
+            // D is an INFINITE lineSlider on AB (not a segment) so a
+            // case-variant can place it past A (t < 0).
+            { name: "D", construction: E.Point.lineSlider, params: ["A", "B", 380, 205],
+              vertexColor: "orange", nameColor: "black" },
+            { name: "CD", construction: E.Line.connect, params: ["C", "D"],
+              nameColor: 0, vertexColor: 0, edgeColor: "darkGray" },
+        ],
+        deferDraggables: ["D"],
+        slides: [
+            { text: "The figure: triangle {ABC}, with {D} on line {AB} and {CD} joined.",
+              visible: ["ABC","D","CD"] },
+            { text: "If the sides are unequal, one is greater — consider both cases (clones slide aside, each with {D} placed differently).",
+              visible: ["ABC","D","CD"],
+              transition: { mode: "parallel", animations: [
+                  { elem: "ABC", name: A.Group.cloneAside,
+                    args: { dx: -250, dy: 0, include: "all", vary: { elem: "D", to: -0.35 } } },
+                  { elem: "ABC", name: A.Group.cloneAside,
+                    args: { dx:  250, dy: 0, include: "all", vary: { elem: "D", to:  0.55 } } }
+              ] } },
+            { text: "Take the case where {D} lies between {A} and {B}: the copies clear and {D} slides to place.",
+              visible: ["ABC","D","CD"],
+              transition: { animations: [
+                  { elem: "D", name: A.Point.slide, args: { to: 0.55 } }
+              ] } }
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Closes #94, #95, #98, #100.

## New animations

- **`A.Point.slide`** (#95) — glide a slider point (`LineSlider`) along its line to a target parameter `t` (`A + t·(B−A)`; infinite sliders accept `t<0`/`t>1`), dependents following each frame. The scripted counterpart of a reader dragging the slider. Optional `durationMs`.
- **`A.Group.cloneAside`** (#98, subsumes #94) — clone a sub-figure (`include: "all"` or a name list) into displaced bare copies that slide aside and persist for the slide. Optional `vary: { elem, to }` places a slider point at parameter `t` before snapshotting, so each copy shows a different case (a trichotomy's "one of them is greater" → three versions of the point). Architecture: snapshot the real figure (move the slider, `slate.update()`, snapshot all elements displaced, restore) — the construction engine computes the varied geometry, no graph deep-clone. Copies clamp to the canvas and are skipped below a ≈520px viewport (desktop-only for now; #99 auto-placement + #71 scale-to-fit are follow-ups). Cleared on slide advance / presentation exit.

## Element visibility (#100)

- **Angle markers hidden by default** in the static figure (Euclid's diagram draws no angle arcs); **`init({ showAngles: true })`** reveals them.
- **`init({ initiallyHidden: [...] })`** — general name list to start any element hidden.
- **`clearVisibility()` restores the initial baseline** (not blanket-true), so hidden elements stay hidden after a presentation walk.
- **Hidden elements reveal on highlight/hover** — every element type's draw guard now also draws when slide-highlighted or emphasised, so a hovered `{NAME}` ref reveals a referenced-but-hidden element.

## Fixes folded in

- cloneAside's anchor stays fully drawn (the real figure's lines no longer vanish during the case-variant slide).
- Presentation exit cancels any in-flight transition and clears ephemerals (no leftover clones over the static figure).

## Test plan

- [x] `npm run test:unit` — 249 passing (new: slide glide + dependents, cloneAside single/all/vary/colors/persist/desktop-guard, marker default-hidden / showAngles / initiallyHidden / clearVisibility baseline / hover-reveal)
- [x] `npm run test:snapshot` — 700 passing (the 24-site draw-guard change is snapshot-safe; snapshots don't highlight)
- [x] `view/test/slideshow/translate-slide.html` walked: three D-versions slide out, original keeps its lines, advance clears, exit clean, narrow viewport drops the case-variants
- [x] `view/test/sector/angle-marker.html` (`showAngles: true`) renders markers

## Deferred (follow-ups noted on issues)

- #99 — auto-place case-variants in available area (horizontal then vertical)
- #71 — presentation scale-to-fit for mobile
- 0.8.1 — same-vertex angle-marker auto radius-stepping
- cloneAside circle/sector snapshot; fade-out on clone dismissal