### PR TITLE
0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brownnrl/geomlib",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Interactive Euclidean geometry constructions in the browser — a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
   "keywords": [
     "euclid",


### PR DESCRIPTION
Minor release 0.9.0.

## New since 0.8.0

- #95 `A.Point.slide` — glide a slider point to a target parameter `t`
- #98 `A.Group.cloneAside` (subsumes #94) — clone a sub-figure aside as case-variants, with an optional varied slider point; desktop-only / canvas-clamped
- #100 element initial visibility — angle markers hidden by default + `showAngles` / `initiallyHidden` init flags; hidden elements reveal on highlight/hover; `clearVisibility` restores the baseline

## Test plan

- [x] `npm run test:unit` — 249 passing
- [x] `npm run test:snapshot` — 700 passing