### PR TITLE
0.9.1: fix cascade pre-render regression (#104) + same-vertex marker auto-nesting (#103)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Library is **post-porting, publish-ready**. There is no longer a
 "next construction to port" backlog or session-startup ritual.
 
 - All 69 construction methods (with 19 3D variants) are implemented.
-- 249 unit tests + 700 snapshot tests pass.
+- 252 unit tests + 700 snapshot tests pass.
 - 0.4.0 shipped cross-highlighting (`emphasized` / `emphasisAmount`
   + `lookupElement`); 0.5.0 shipped the slideshow surface
   (`slides`, `setVisibleNames`, `addAlias`, `resolveJustification`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ That's it.
 ## Running tests
 
 ```sh
-npm run test:unit      # 249 unit tests — fast (~100 ms)
+npm run test:unit      # 252 unit tests — fast (~100 ms)
 npm run test:snapshot  # 700 visual-regression tests against snapshot goldens
 npm test               # both (snapshot then unit)
 ```

--- a/src/SlateAnimator.ts
+++ b/src/SlateAnimator.ts
@@ -193,13 +193,12 @@ export class SlateAnimator {
             return Promise.resolve();
         }
 
-        // Mark every animating target as emphasized so its render pops
-        // over any slide-highlighted underlying elements that share a
-        // path (e.g. the polygon ABC animating over highlighted lines
-        // AB / AC / BC). Cleared in _allFinalised / cancel().
-        for (const g of groups) {
-            g.target.emphasized = true;
-        }
+        // NOTE: targets are emphasised in _startStep when their own step
+        // begins (not here at run start), so an un-started cascade target
+        // stays hidden until its turn — otherwise, since #100, a
+        // hidden-but-emphasised target would draw fully from t=0 (#104).
+        // The emphasis still makes the target's render pop over any
+        // slide-highlighted siblings throughout its own animation.
 
         this.groups = groups;
         this.mode = mode;
@@ -278,10 +277,16 @@ export class SlateAnimator {
         if (as.started) return;
         // Deferred reveal (#83): the target was held invisible through
         // any earlier cascade steps; it appears the moment its own
-        // first step begins. setup() runs after this, so an animation
-        // that hides the target to render ephemeral proxies instead
-        // can still do so.
-        if (stepIdx === 0) g.target.visible = true;
+        // first step begins. The emphasis bump is applied here too (not
+        // at run start) so an un-started cascade target stays hidden —
+        // since #100 a hidden-but-emphasised element would otherwise
+        // draw fully from t=0 (#104). setup() runs after this, so an
+        // animation that hides the target to render ephemeral proxies
+        // instead can still do so.
+        if (stepIdx === 0) {
+            g.target.visible = true;
+            g.target.emphasized = true;
+        }
         if (as.step.setup) as.step.setup();
         as.started = true;
         g.currentIndex = stepIdx;

--- a/src/elements/sector/AngleMarkerElement.ts
+++ b/src/elements/sector/AngleMarkerElement.ts
@@ -60,6 +60,22 @@ export class AngleMarkerElement extends SectorElement {
         this._B = new PointElement();
     }
 
+    // The vertex this marker sits at — used to group same-vertex
+    // markers for auto radius-stepping (#103).
+    get vertex() : PointElement { return this._Center; }
+
+    // Whether the author pinned an explicit radius (opts the marker out
+    // of auto radius-stepping).
+    get hasRadiusOverride() : boolean { return this._radiusOverride != null; }
+
+    // The interior angle magnitude (radians) between the two arms,
+    // computed directly from the arm points so it's available before
+    // update() places _A/_B. Used to order a same-vertex group
+    // (smallest angle innermost).
+    spanRadians() : number {
+        return Math.abs(this._Center.angle(this._arm1, this._arm2, this._P));
+    }
+
     // update() orders _A/_B so the inherited minor angle is negative
     // (interior, drawn with the default anticlockwise=true). A reflex
     // marker draws the MAJOR arc between the same two rays — same

--- a/src/index.ts
+++ b/src/index.ts
@@ -350,6 +350,42 @@ function initInner(i: IInitialization, canvas: HTMLCanvasElement) {
         for (let name of i.initiallyHidden) slate.setInitiallyHidden(name);
     }
 
+    // Same-vertex angle markers auto-nest: group by shared vertex and
+    // step each one's radius into a concentric ring (smallest interior
+    // angle innermost), with distinct palette colors within the group,
+    // so they don't overlap. Author radiusPx overrides opt out of the
+    // ring-stepping. Runs before update() places the arc endpoints. (#103)
+    {
+        const byVertex = new Map<PointElement, AngleMarkerElement[]>();
+        for (let elem of slate.elements) {
+            if (elem instanceof AngleMarkerElement) {
+                let g = byVertex.get(elem.vertex);
+                if (g == null) { g = []; byVertex.set(elem.vertex, g); }
+                g.push(elem);
+            }
+        }
+        byVertex.forEach((group: AngleMarkerElement[]) => {
+            if (group.length <= 1) return;
+            // Smallest angle innermost so a tight wedge nests inside a
+            // wider one sharing the vertex.
+            group.sort((a, b) => a.spanRadians() - b.spanRadians());
+            let ring = 0;
+            group.forEach((m, idx) => {
+                // Distinct color per group member (de-clash by group
+                // position). Author param-color overrides are left alone.
+                const isDefault = anglePalette.some(p => p.face === m.faceColor);
+                if (isDefault) {
+                    const sw = anglePalette[idx % anglePalette.length];
+                    m.edgeColor = sw.edge;
+                    m.faceColor = sw.face;
+                }
+                // Pinned-radius markers keep their explicit radius (ring
+                // 0); only auto-radius markers step outward, consecutively.
+                if (!m.hasRadiusOverride) { m.ringIndex = ring; ring++; }
+            });
+        });
+    }
+
     if (i.slides != null && i.slides.length > 0) {
         slate.slides = i.slides;
     }

--- a/tests/SectorTest.ts
+++ b/tests/SectorTest.ts
@@ -293,12 +293,14 @@ describe("angle marker (issue #91)", () => {
     it("assigns translucent palette colors in construction order", () => {
         withFakeDOM((canvasid) => {
             slates.length = 0;
+            // Different vertices so they stay singletons (#103 nesting
+            // only recolors same-vertex groups).
             init({
                 canvasid, background: "0,0,100", title: "t",
                 elements: [
                     ...baseMarkerElements,
                     "m0;sector;angleMarker;B,A,Cnear",
-                    "m1;sector;angleMarker;B,Cnear,Cfar",
+                    "m1;sector;angleMarker;Cnear,A,B",
                 ],
             });
             const slate = slates[0];
@@ -399,6 +401,68 @@ describe("angle marker (issue #91)", () => {
         r = recordingArcs(slate);
         s.drawEdge(r.canvas);
         assert.strictEqual(r.arcs.length, 1);
+    });
+
+    // #103 — same-vertex auto radius-stepping.
+    it("nests same-vertex markers with stepped rings + distinct colors", () => {
+        withFakeDOM((canvasid) => {
+            slates.length = 0;
+            init({
+                canvasid, background: "0,0,100", title: "t", showAngles: true,
+                elements: [
+                    ...baseMarkerElements,
+                    "m1;sector;angleMarker;B,A,Cnear",
+                    "m2;sector;angleMarker;B,A,Cfar",
+                    "m3;sector;angleMarker;B,Cnear,Cfar",
+                ],
+            } as any);
+            const slate = slates[0];
+            const ms = ["m1", "m2", "m3"].map(n => slate.lookupElement(n) as AngleMarkerElement);
+            // Distinct consecutive rings, and distinct palette faces.
+            assert.deepStrictEqual(ms.map(m => m.ringIndex).sort(), [0, 1, 2]);
+            assert.strictEqual(new Set(ms.map(m => m.faceColor)).size, 3);
+        });
+    });
+
+    it("does not nest markers at different vertices", () => {
+        withFakeDOM((canvasid) => {
+            slates.length = 0;
+            init({
+                canvasid, background: "0,0,100", title: "t", showAngles: true,
+                elements: [
+                    ...baseMarkerElements,
+                    "atB;sector;angleMarker;B,A,Cnear",
+                    "atC;sector;angleMarker;Cnear,A,B",
+                ],
+            } as any);
+            const slate = slates[0];
+            const atB = slate.lookupElement("atB") as AngleMarkerElement;
+            const atC = slate.lookupElement("atC") as AngleMarkerElement;
+            assert.strictEqual(atB.ringIndex, 0);
+            assert.strictEqual(atC.ringIndex, 0);  // singletons, not stepped
+        });
+    });
+
+    it("a pinned radiusPx marker keeps ring 0; others step around it", () => {
+        withFakeDOM((canvasid) => {
+            slates.length = 0;
+            init({
+                canvasid, background: "0,0,100", title: "t", showAngles: true,
+                elements: [
+                    ...baseMarkerElements,
+                    "pinned;sector;angleMarker;B,A,Cnear,40",   // radiusPx override
+                    "auto1;sector;angleMarker;B,A,Cfar",
+                    "auto2;sector;angleMarker;B,Cnear,Cfar",
+                ],
+            } as any);
+            const slate = slates[0];
+            const pinned = slate.lookupElement("pinned") as AngleMarkerElement;
+            const auto1 = slate.lookupElement("auto1") as AngleMarkerElement;
+            const auto2 = slate.lookupElement("auto2") as AngleMarkerElement;
+            assert.strictEqual(pinned.ringIndex, 0);   // override opts out
+            // The two auto markers get consecutive rings 0 and 1.
+            assert.deepStrictEqual([auto1.ringIndex, auto2.ringIndex].sort(), [0, 1]);
+        });
     });
 });
 

--- a/tests/SlateAnimatorTest.ts
+++ b/tests/SlateAnimatorTest.ts
@@ -182,6 +182,11 @@ describe("SlateAnimator (issue #78)", () => {
             // not render while AB is still tracing.
             assert.strictEqual(ab.visible, true, "active target should be revealed");
             assert.strictEqual(bcd.visible, false, "pending target should stay hidden");
+            // #104: a pending cascade target must NOT be emphasised yet —
+            // since #100 a hidden-but-emphasised element draws fully from
+            // t=0. AB (started) is emphasised; BCD (pending) is not.
+            assert.ok(ab.emphasisAmount > 0, "active target should be emphasised");
+            assert.strictEqual(bcd.emphasisAmount, 0, "pending target must not be emphasised");
             slate.animator!.cancel();
             await p;
             // Cancel finalises everything — both end visible.


### PR DESCRIPTION
Fixes #103, #104.

## #104 — cascade pre-render regression (0.9.0, priority)

In a cascaded `transition`, every animated element rendered fully from t=0 — only the first cascade step was clean (reported across I.2/I.6/I.9/I.10). Root cause: `SlateAnimator` emphasised **all** targets at run start, and #100's draw guard (draw a hidden element when highlighted/emphasised) made every deferred cascade target draw immediately, at `drawProgress=1`/`faceAlpha=1` (its `setup()` hadn't run).

Fix: emphasise a target only when its **own step starts** (in `_startStep`), not at run start. Un-started cascade targets stay `visible=false` + `emphasisAmount=0` → hidden until their turn; the draw-over-highlighted-siblings behaviour is preserved (target is emphasised throughout its own animation). Consumer decks can drop the parallel/split/edge-only/slow-appear workarounds.

## #103 — same-vertex angle-marker auto radius-stepping

The deferred-from-#91 nesting. At init, group `angleMarker`s by shared vertex; within a group, sort by interior span (smallest innermost) and assign consecutive `ringIndex` so radius steps outward, with a distinct palette color per member. Author `radiusPx` overrides opt out of stepping; author color overrides are left alone; singletons and different-vertex markers are untouched. Cleans up I.5 (4@B/4@C) and I.9 (3@A) with zero deck changes.

## Test plan

- [x] `npm run test:unit` — 252 passing (new: cascade pending-target not emphasised; marker nest rings/colors, different-vertex no-nest, pinned-radius opt-out)
- [x] `npm run test:snapshot` — 700 passing
- [x] `npm run bundle` — clean (webpack target is stricter than `tsc`)
- [x] Headless before/after renders confirm: pending cascade circle/triangle hidden until their step; three same-vertex markers nest concentric with distinct colors