### PR TITLE
0.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brownnrl/geomlib",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Interactive Euclidean geometry constructions in the browser — a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
   "keywords": [
     "euclid",


### PR DESCRIPTION
Patch release 0.9.1.

## Fixes since 0.9.0

- #104 — cascade pre-render regression (from 0.9.0/#100): un-started cascade targets no longer draw from t=0; emphasis applied at step start, not run start.
- #103 — same-vertex angle markers auto-nest into concentric rings with color de-clash (cleans up I.5 4@B/4@C, I.9 3@A; zero deck changes).

## Test plan

- [x] `npm run test:unit` — 252 passing
- [x] `npm run test:snapshot` — 700 passing