### PR TITLE
0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brownnrl/geomlib",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Interactive Euclidean geometry constructions in the browser — a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
   "keywords": [
     "euclid",


### PR DESCRIPTION
Release 0.10.0 — cloneAside autoPlace + atomic variant layout (#99), Slate view offset, reduced-motion ephemeral persistence fix. Merged from #109.