### PR TITLE
Remove the new-window control (#59)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ src/                      TypeScript library source (54 files)
   Constructions.ts        Enums, abstract Construction base, registration array
   elements/{type}/        Per-type element classes + Constructions
   Slate.ts                Canvas manager, dispatch, drag pipeline
-  SlateControls.ts        UI overlay (reset/maximize/new-window)
+  SlateControls.ts        UI overlay (reset/maximize/present)
   Colors.ts               parseColor(), brighter/darker/HSB/hex
   index.ts                Public API — init(), parseParam(), E, Align, Color
 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ geomlib.init({
 ```
 
 Drag **A** or **B** and the triangle ABC follows. Press `r` (or the
-spacebar) to reset the diagram, `m` to maximize the canvas, `u` to pop
-the figure into a new window. For a step-by-step walkthrough of this
-example, see [doc/quickstart.md](doc/quickstart.md).
+spacebar) to reset the diagram and `m` to maximize the canvas. For a
+step-by-step walkthrough of this example, see
+[doc/quickstart.md](doc/quickstart.md).
 
 ## Documentation
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -108,7 +108,7 @@ interface IInitialization {
 | Field | Java applet param | Default | Description |
 |---|---|---|---|
 | `background` | `background` | `"#ffffff"` | Canvas fill. Same string grammar as element colors — see [Colors](#colors). HSB triples like `"35,19,100"` are valid. |
-| `title` | `title` | `""` | Title shown when the diagram is opened in a separate window via the new-window button. Stored on the Slate; not currently rendered on the canvas itself (open platform TODO). |
+| `title` | `title` | `""` | A label for the diagram. Stored on the Slate; not currently rendered on the canvas itself. |
 | `align` | `align` | `Align.CENTRAL` | Default label placement applied to every element. CENTRAL chooses ABOVE/BELOW/LEFT/RIGHT dynamically based on the label's quadrant relative to the canvas center. |
 | `canvasid` | (none — applet's host element) | `"canvasid"` | DOM `id` of the `<canvas>` to draw into. |
 | `pivot` | `pivot` | (no pivot) | Name of a point used as the rotation/scale center when the user drags a non-draggable point. Two-part form `"P,plane"` pivots on a non-screen plane (3D). See [Drag pipeline](architecture.md#drag-pipeline-movepick--translatecoordinates--rotatecoordinates). |
@@ -861,7 +861,6 @@ buttons at the top-right:
 |---|---|---|
 | Reset (circular arrow) | `r` or `space` | `slate.reset()`. |
 | Maximize (expand arrows) | `m` | Toggle: fill the viewport (position fixed, 100vw / 100vh, z-index 9999) or restore. |
-| New window (box-with-arrow) | `u` or `return` | Open a new browser window with the same scene maximized. |
 
 Keyboard shortcuts only fire when the canvas itself has focus. The
 overlay can be skipped (e.g. for headless rendering) by passing a

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -45,8 +45,7 @@ can drag them (matching the Java applet's behavior):
 
 The `r` / `space` keyboard shortcut (also exposed as a SlateControls
 button) calls `Slate.reset()` to restore every element to its
-construction-time position. `m` toggles maximize, `u` / `return`
-opens the same scene in a new window.
+construction-time position. `m` toggles maximize.
 
 ### Element schema (one HTML param ↔ one `IConstructionInfo`)
 
@@ -86,7 +85,7 @@ applet's `debug` flag is not implemented in the TS port.
 | `PlaneElement.java` (+ ParallelP, PerpendicularPL) | `src/elements/plane/*.ts` |
 | `SphereElement.java` | `src/elements/sphere/SphereElement.ts` |
 | `PolyhedronElement.java` (+ Prism, Pyramid) | `src/elements/polyhedron/*.ts` |
-| `ClientFrame.java` (Java AWT detached frame) | replaced by SlateControls' "new window" button (`src/SlateControls.ts`) |
+| `ClientFrame.java` (Java AWT detached frame) | not ported |
 | `Remote.java` (applet remote-control) | not ported |
 
 The full porting status is recorded in
@@ -103,7 +102,7 @@ euclid/
 ├── src/
 │   ├── index.ts                  # Public API: init(), parseParam(), E enum, A enum, Align
 │   ├── Slate.ts                  # Canvas manager, element orchestration, mouse events, animateTo
-│   ├── SlateControls.ts          # UI overlay: reset, maximize, new window, presentation
+│   ├── SlateControls.ts          # UI overlay: reset, maximize, presentation
 │   ├── SlateAnimator.ts          # 0.6.0+ rAF loop for slide-transition animations
 │   ├── Colors.ts                 # Color parsing: parseColor(), brighter(), darker()
 │   └── elements/
@@ -172,7 +171,7 @@ geomlib.init({ canvasid, elements: [...], pivot?, background?, title?, … })
   │          │    elem.drawFace() → elem.drawEdge() → elem.drawVertex() → elem.drawName()
   │          └─ for each elem in _ephemerals: same four-layer pass on top
   │                                            (animation-local helpers; 0.6.0+)
-  └─ createControls(slate, canvas, config)   ← injects reset/maximize/new-window
+  └─ createControls(slate, canvas, config)   ← injects reset/maximize
                                                 buttons + keyboard shortcuts on top
                                                 of the canvas (src/SlateControls.ts).
                                                 When slate.slides.length > 0, also
@@ -300,8 +299,8 @@ maps a symbolic ref to a URL at render time, so refs don't go stale
 when target pages move.
 
 **SlateControls overlay.** When `slate.slides.length > 0`, the existing
-reset/maximize/new-window button strip grows a fourth play-triangle
-button. Pressing it (or the `p` keyboard shortcut) maximises the canvas
+reset/maximize button strip grows a play-triangle button. Pressing it
+(or the `p` keyboard shortcut) maximises the canvas
 and floats a soft white caption panel at the bottom of the viewport
 with prev / counter / next / exit controls; arrow keys and `Esc` do
 what you'd expect. Caption `{NAME}` tokens become clickable bold-italic
@@ -667,6 +666,6 @@ ordered list. Each element entry can be a structured object —
 `parseParam(s)` is the public converter.
 
 `init()` also calls `createControls()` from `src/SlateControls.ts`,
-which wraps the canvas and adds the reset / maximize / new-window
-button overlay plus keyboard shortcuts (`r`/`space`, `u`/`return`,
-`m`). See [api.md § SlateControls](api.md#slatecontrols-ui-overlay).
+which wraps the canvas and adds the reset / maximize button overlay
+plus keyboard shortcuts (`r`/`space`, `m`). See
+[api.md § SlateControls](api.md#slatecontrols-ui-overlay).

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -165,10 +165,9 @@ With the page loaded:
 | Drag a non-free point (the line, a circle) | The diagram rotates/scales around the pivot **C**. |
 | Press **r** or **space** | Reset to the initial configuration. |
 | Press **m** | Maximize the canvas to fill the viewport. |
-| Press **u** or **return** | Pop the figure into a new browser window. |
 
-The reset/maximize/new-window controls also appear as small icon
-buttons at the top-right of the canvas.
+The reset/maximize controls also appear as small icon buttons at the
+top-right of the canvas.
 
 ## What about the other shorter form?
 

--- a/src/SlateControls.ts
+++ b/src/SlateControls.ts
@@ -1,11 +1,11 @@
 /*----------------------------------------------------------------------+
 |    Title:  SlateControls.ts                                           |
-|    UI overlay for geometry diagrams: reset, maximize, new window.     |
+|    UI overlay for geometry diagrams: reset, maximize, present.        |
 |    Buttons are canvas-drawn icons overlaid on each Slate canvas.      |
-|    Keyboard shortcuts match the original Java applet:                 |
+|    Keyboard shortcuts:                                                 |
 |      r / space  → reset                                               |
-|      u / return → new window                                          |
 |      m          → maximize/minimize                                   |
+|      p          → present (when the slate has slides)                 |
 +----------------------------------------------------------------------*/
 
 import {Slate} from "./Slate";
@@ -153,7 +153,6 @@ class SlateControls {
         let buttons = [
             { draw: drawResetIcon, action: () => this.onReset(), title: "Reset (r)" },
             { draw: drawMaximizeIcon, action: () => this.onMaximize(), title: "Maximize (m)" },
-            { draw: drawNewWindowIcon, action: () => this.onNewWindow(), title: "New Window (u)" },
         ];
 
         // Conditionally append a "▶ Present" button when the slate
@@ -222,12 +221,6 @@ class SlateControls {
                 case " ":
                     e.preventDefault();
                     this.onReset();
-                    break;
-                case "u":
-                case "U":
-                case "Enter":
-                    e.preventDefault();
-                    this.onNewWindow();
                     break;
                 case "m":
                 case "M":
@@ -381,43 +374,6 @@ class SlateControls {
         } else {
             drawMaximizeIcon(ctx, BTN_SIZE);
             btn.title = "Maximize (m)";
-        }
-    }
-
-    private onNewWindow(): void {
-        // Find the bundle.js script path from the current page
-        let scripts = document.querySelectorAll("script[src]");
-        let bundleSrc = "bundle.js";
-        for (let i = 0; i < scripts.length; i++) {
-            let src = (scripts[i] as HTMLScriptElement).src;
-            if (src.indexOf("bundle.js") >= 0) {
-                bundleSrc = src;
-                break;
-            }
-        }
-
-        // Override the config's canvasid so geomlib.init() targets the
-        // new window's canvas (id="canvasId"), not the source page's canvas
-        // which doesn't exist in the new document. Without the override,
-        // init() would look up this._config.canvasid (e.g. "canvas_0") in
-        // the new document, get null, and throw in resizeCanvasToDisplaySize.
-        let newWinConfig = Object.assign({}, this._config, { canvasid: "canvasId" });
-        let configJSON = JSON.stringify(newWinConfig);
-        let title = this._config.title || "Geometry";
-
-        // Open maximized: use full screen dimensions, canvas fills viewport
-        let html = `<!DOCTYPE html>
-<html><head><title>${title}</title></head>
-<body style="margin:0;padding:0;overflow:hidden;">
-<canvas id="canvasId" style="width:100vw;height:100vh;"></canvas>
-<script src="${bundleSrc}"><\/script>
-<script>geomlib.init(${configJSON});<\/script>
-</body></html>`;
-
-        let newWin = window.open("", "_blank");
-        if (newWin) {
-            newWin.document.write(html);
-            newWin.document.close();
         }
     }
 
@@ -913,40 +869,6 @@ function drawMinimizeIcon(ctx: CanvasRenderingContext2D, size: number): void {
     ctx.moveTo(bx, by);
     ctx.lineTo(bx - 5, by);
     ctx.lineTo(bx, by + 5);
-    ctx.closePath();
-    ctx.fill();
-}
-
-function drawNewWindowIcon(ctx: CanvasRenderingContext2D, size: number): void {
-    let pad = 4;
-    let s = size - pad * 2;
-
-    ctx.strokeStyle = "rgba(0,0,0,0.7)";
-    ctx.fillStyle = "rgba(0,0,0,0.7)";
-    ctx.lineWidth = 1.5;
-
-    // Small rectangle (the window)
-    let rx = pad;
-    let ry = pad + s * 0.3;
-    let rw = s * 0.65;
-    let rh = s * 0.7;
-    ctx.strokeRect(rx, ry, rw, rh);
-
-    // Arrow pointing up-right out of the rectangle
-    let arrowStartX = pad + s * 0.4;
-    let arrowStartY = pad + s * 0.6;
-    let arrowEndX = pad + s;
-    let arrowEndY = pad;
-    ctx.beginPath();
-    ctx.moveTo(arrowStartX, arrowStartY);
-    ctx.lineTo(arrowEndX, arrowEndY);
-    ctx.stroke();
-
-    // Arrowhead
-    ctx.beginPath();
-    ctx.moveTo(arrowEndX, arrowEndY);
-    ctx.lineTo(arrowEndX - 5, arrowEndY);
-    ctx.lineTo(arrowEndX, arrowEndY + 5);
     ctx.closePath();
     ctx.fill();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -405,7 +405,7 @@ function initInner(i: IInitialization, canvas: HTMLCanvasElement) {
     slate.update();
     slate.updateCoordinates(0);
 
-    // Add UI controls (reset, maximize, new window) if running in browser
+    // Add UI controls (reset, maximize, present) if running in browser
     if (canvas && canvas.parentElement) {
         createControls(slate, canvas, i);
     }


### PR DESCRIPTION
Closes #59.

The new-window button's `onNewWindow()` built an HTML document from the init config and `document.write()`'d it into a popup — the source of the CodeQL **js/xss-through-dom** finding (#59). The feature is also unused; opening a second window and maximizing covers the use case.

## Removed
- The box-with-arrow **new-window button** (`drawNewWindowIcon`, the button entry).
- The `u` / `U` / `return` keyboard shortcut.
- `onNewWindow()` (the `document.write` sink).
- Header/comment references; docs scrubbed (quickstart, api, architecture, README, AGENTS).

Reset / maximize / present and their shortcuts (`r`/`space`, `m`, `p`) are unchanged. The maximize button is still index 1 (its `_maxBtn` ref is intact). The `title` init field stays (now just a stored label).

## Tests
272 unit + 700 snapshots green; `tsc` + webpack bundle clean. SlateControls is browser-only (not exercised by the node-canvas suite); verified no dangling `NewWindow`/`onNewWindow` refs remain in `src/`.

Content note: the geomlib *site* docs (separate lektor repo) also mention this control — flagged to the content session to scrub on the pin bump. Opening for review only; not part of a release.