### PR TITLE
Centre once on enter; keep maximized on slideshow exit (#114, #115)

### DIFF
--- a/src/SlateControls.ts
+++ b/src/SlateControls.ts
@@ -388,6 +388,10 @@ class SlateControls {
         if (this._presenting) return;
         if (this._slate.slides.length === 0) return;
         if (!this._maximized) this.maximize();
+        // #114 — centre ONCE on entering presentation (covers the case
+        // where we were already maximized, so maximize() didn't run). Slide
+        // advances no longer re-centre.
+        this._applyCentring();
         this.buildPresentationOverlay();
         this.bindPresentationKeys();
         this._presenting = true;
@@ -399,9 +403,12 @@ class SlateControls {
         this.unbindPresentationKeys();
         this.clearStickyRef();
         this.removePresentationOverlay();
-        // Cancel any in-flight transition and drop any parked ephemerals
-        // (e.g. a cloneAside case-variant clone) so the static figure is
-        // clean on exit.
+        // #115 — leave presentation mode but STAY in the maximized view,
+        // keeping the viewer's manipulation. Only the maximize control
+        // un-maximizes (and that's what resets — see minimize()). Drop the
+        // parked case-variant ephemerals + the walk's highlight/visibility
+        // state, but keep the current view offset (the centre set on enter)
+        // and any dragged positions.
         if (this._slate.animator != null) this._slate.animator.cancel();
         this._slate.clearEphemerals();
         this._slate.clearVisibility();
@@ -410,15 +417,7 @@ class SlateControls {
             e.emphasized = false;
         }
         this._presenting = false;
-        // Reset to the inline view on slideshow exit (#107). minimize()
-        // resizes back, clears the view offset, redraws, AND resets the
-        // construction (same as the reset control).
-        if (this._maximized) {
-            this.minimize();
-        } else {
-            this._applyCentring();
-            this._slate.reset();
-        }
+        this._slate.update();
     }
 
     private buildPresentationOverlay(): void {
@@ -572,11 +571,10 @@ class SlateControls {
         // ephemerals, but an instant transition wouldn't — so clear
         // here on every advance.
         this._slate.clearEphemerals();
-        // Reset the view offset to the maximized base centring (#107) so
-        // every slide stays centred; an autoPlace transition (#99) eases
-        // from this base out to its case layout. Off the maximized path
-        // this clears to (0,0).
-        this._applyCentring();
+        // #114 — do NOT re-centre per slide; the figure is centred once on
+        // enter (onPresent / maximize) and stays put so a viewer dragging
+        // mid-walk isn't yanked back. An autoPlace transition (#99) still
+        // eases from the current (centred) offset out to its case layout.
 
         const slide = slides[clamped];
         const transition = slide.transition;

--- a/view/test/recenter-maximize.html
+++ b/view/test/recenter-maximize.html
@@ -6,9 +6,13 @@
 Click the <b>maximize</b> button (top-right of the canvas) — the figure
 slides to the <b>centre</b> of the enlarged canvas (translate only, no
 scaling) instead of sitting in the corner. Resize the window while
-maximized: it stays centred. Minimize: it returns to its authored spot.
-Press <b>p</b> to present: every slide stays centred; the case slide lays
-its copies without a jump. Drag a point while centred — it still tracks.
+maximized: it stays centred. <b>Minimize: returns to the authored spot
+and resets.</b>
+Press <b>p</b> to present: it centres <b>once</b> on enter, then each
+slide advance leaves the figure where it is — <b>drag a point mid-walk
+and the next slide won't yank it back</b>. The case slide lays its copies
+without a jump. <b>Esc leaves the walk but stays maximized</b>, keeping
+your manipulation; click minimize when you want the pristine figure back.
 </p>
 <canvas id="canvasId" style="width:520px; height: 360px;" tabindex="0"></canvas>
 <script src="../../dist/bundle.js" type="text/javascript"></script>


### PR DESCRIPTION
Closes #114, closes #115.

Both come from testing the page and pivoting on the #107 centring/exit behaviour.

## #114 — centre once, not per slide
`_applyCentring()` moved out of `showSlide()` and into `onPresent()` (after the maximize call), so the figure centres **once** on entering presentation / maximizing and **not** on every slide advance. A viewer dragging a point mid-walk is no longer yanked back to centre on the next slide. The autoPlace case slide (#99) still eases from the current (centred) offset out to its case layout — no jump.

## #115 — Esc stays maximized
`exitPresent()` now leaves presentation mode (removes the overlay, drops parked case-variant ephemerals, clears the walk's highlight/visibility state) but **stays maximized and keeps the viewer's manipulation + view offset** — no un-maximize, no reset. Only the **minimize** control un-maximizes, and that remains what resets to the pristine inline figure.

## Tests
SlateControls is browser-only (not exercised by the node-canvas suite); 272 unit + 700 snapshots green, `tsc` + bundle clean. Verified the present → drag mid-walk → case slide → Esc → minimize flow in `view/test/recenter-maximize.html` (instructions updated to match).

Opening for review; not part of a release.