### PR TITLE
0.12.0

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -469,12 +469,15 @@ no-op — every pre-existing render path is unchanged. `A.Group.cloneAside`'s
 (0.11.0+) is the bbox of *all* named elements regardless of visibility — a
 stable centre that doesn't drift as a presentation reveals/hides elements.
 
-**Maximized-view recenter (#107, 0.11.0+).** When the canvas is maximized
-(via the control or by entering presentation), the figure is centred with
-this offset (translate only); on minimize / presentation exit it restores
-the inline view **and runs `reset()`** (the ⟲ control's behaviour). Every
-presentation slide stays centred; an `autoPlace` case slide eases out from
-that base with no jump.
+**Maximized-view recenter (#107, #114, #115).** When the canvas is
+maximized — via the control or by entering presentation — the figure is
+centred with this offset (translate only). It centres **once** on enter
+and **not** on each slide advance, so a viewer dragging a point mid-walk
+isn't yanked back (#114); an `autoPlace` case slide still eases from the
+centred offset out to its layout with no jump. **Exiting presentation
+(`Esc`) leaves the walk but stays maximized**, keeping the viewer's
+manipulation (#115). Only the **minimize** control un-maximizes, and that
+is what restores the inline view + runs `reset()`.
 
 ### `geomlib:highlight` event (#108, 0.11.0+)
 
@@ -854,17 +857,21 @@ Lower-level methods (`createElement`, `convertParams`, `findConstruction`,
 
 `init()` automatically calls `createControls(slate, canvas, config)`
 from [src/SlateControls.ts](../src/SlateControls.ts), which wraps the
-canvas in a relative-positioned `<div>` and overlays three icon
-buttons at the top-right:
+canvas in a relative-positioned `<div>` and overlays icon buttons at
+the top-right:
 
 | Button | Keyboard | Action |
 |---|---|---|
 | Reset (circular arrow) | `r` or `space` | `slate.reset()`. |
 | Maximize (expand arrows) | `m` | Toggle: fill the viewport (position fixed, 100vw / 100vh, z-index 9999) or restore. |
+| Present (play triangle) | `p` | Only when the slate has slides — step through the slideshow. |
 
-Keyboard shortcuts only fire when the canvas itself has focus. The
-overlay can be skipped (e.g. for headless rendering) by passing a
-canvas whose `parentElement` is `null`.
+The controls are **hidden by default and fade in on canvas hover or
+keyboard focus** (`:hover` / `:focus-within`), so a page of many
+diagrams isn't cluttered with a button row on each (#69). Keyboard
+shortcuts only fire when the canvas itself has focus. The overlay can be
+skipped (e.g. for headless rendering) by passing a canvas whose
+`parentElement` is `null`.
 
 ---
 

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -167,7 +167,8 @@ With the page loaded:
 | Press **m** | Maximize the canvas to fill the viewport. |
 
 The reset/maximize controls also appear as small icon buttons at the
-top-right of the canvas.
+top-right of the canvas — hidden by default, fading in on hover or when
+the canvas has keyboard focus.
 
 ## What about the other shorter form?
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brownnrl/geomlib",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Interactive Euclidean geometry constructions in the browser — a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
   "keywords": [
     "euclid",


### PR DESCRIPTION
Release 0.12.0 — first release since 0.11.0. Rolls up:

- **#59** — removed the new-window control (resolves the CodeQL js/xss-through-dom finding). (#116)
- **#69** — slate controls hidden by default, fade in on canvas hover / focus. (#113)
- **#114** — centre the figure once on present-enter / maximize, not on every slide advance (no mid-walk yank). (#117)
- **#115** — exiting presentation (`Esc`) stays maximized and keeps the viewer's manipulation; only minimize un-maximizes + resets. (#117)
- Docs updated to match (SlateControls hover-reveal, recenter/exit behaviour).

272 unit + 700 snapshots green; `tsc` + prod bundle clean.

Behavior changes + a control removal (pre-1.0), so a minor bump.