### PR TITLE
Point: highlight no longer reveals a hidden/deferred point (#126)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Library is **post-porting, publish-ready**. There is no longer a
 "next construction to port" backlog or session-startup ritual.
 
 - All 69 construction methods (with 19 3D variants) are implemented.
-- 285 unit tests + 700 snapshot tests pass.
+- 289 unit tests + 700 snapshot tests pass.
 - 0.4.0 shipped cross-highlighting (`emphasized` / `emphasisAmount`
   + `lookupElement`); 0.5.0 shipped the slideshow surface
   (`slides`, `setVisibleNames`, `addAlias`, `resolveJustification`,
@@ -96,7 +96,7 @@ dist/                     Webpack output (gitignored, shipped to npm)
 ```sh
 npm install              # one-time
 npm run build            # tsc --noEmit (typecheck only)
-npm run test:unit        # 285 unit tests (~110 ms)
+npm run test:unit        # 289 unit tests (~110 ms)
 npm run test:snapshot    # 700 snapshot tests; auto-creates goldens on first run
 npm test                 # both
 npm run bundle           # dev-mode bundle to dist/bundle.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ That's it.
 ## Running tests
 
 ```sh
-npm run test:unit      # 285 unit tests — fast (~100 ms)
+npm run test:unit      # 289 unit tests — fast (~100 ms)
 npm run test:snapshot  # 700 visual-regression tests against snapshot goldens
 npm test               # both (snapshot then unit)
 ```

--- a/src/elements/point/PointElement.ts
+++ b/src/elements/point/PointElement.ts
@@ -377,6 +377,11 @@ export class PointElement extends GeomElement {
         // (#126; the dot's radius already zeroes at drawProgress=0, but the
         // label had no such guard.)
         if (!this.visible) return;
+        // The label snaps in only once the marker is fully revealed: through a
+        // Point.appear pulse (drawProgress 0→1) the dot grows, then the label
+        // lands at completion — it does not ride the pulse. Static points are
+        // drawProgress = 1, so this is a no-op for them. (#126)
+        if (this.drawProgress < 1) return;
         if (this.nameColor != null && this.name != null && this.defined()) {
             this.drawString(Math.round(this.x), Math.round(this.y), c)
         }

--- a/src/elements/point/PointElement.ts
+++ b/src/elements/point/PointElement.ts
@@ -369,14 +369,21 @@ export class PointElement extends GeomElement {
     }
 
     public drawName(c: SlateCanvas): void {
-        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
+        // A point shows its dot/label only when it is actually revealed
+        // (visible). Highlight / emphasis style a SHOWN point — they must not
+        // force a hidden one to draw: a deferred reveal target (visible=false
+        // until its appear step flips it true) or a point not in the slide's
+        // visible set must stay dark even when it is in the highlighted set.
+        // (#126; the dot's radius already zeroes at drawProgress=0, but the
+        // label had no such guard.)
+        if (!this.visible) return;
         if (this.nameColor != null && this.name != null && this.defined()) {
             this.drawString(Math.round(this.x), Math.round(this.y), c)
         }
     }
 
     public drawVertex(c: SlateCanvas, color?: string): void {
-        if (!this.visible && !this.shouldHighlight && this.emphasisAmount <= 0) return;
+        if (!this.visible) return;   // see drawName — highlight never reveals a hidden point (#126)
         let ctx : CanvasRenderingContext2D = c.getContext("2d") as CanvasRenderingContext2D;
         if (color == null) {
             if (this.emphasized || this.shouldHighlight) {

--- a/tests/VisibilityTest.ts
+++ b/tests/VisibilityTest.ts
@@ -147,6 +147,25 @@ describe("element visibility (issue #75)", () => {
                 "a deferred highlighted point must not draw its label before its reveal");
         });
 
+        it("drawName holds the label until the marker is fully revealed (snap, not fade)", () => {
+            const slate = new Slate(createCanvas(200, 200));
+            toElements(slate, triangle_data);
+            const pt = slate.lookupElement("A") as PointElement;
+            pt.nameColor = "#000000";
+            pt.visible = true;
+            // Mid-appear: marker is pulsing in (drawProgress < 1) — the label
+            // must not ride the pulse.
+            pt.drawProgress = 0.6;
+            let r = recordingCanvas(200, 200);
+            pt.drawName(r.canvas as any);
+            assert.strictEqual(r.recorded.textWrites.length, 0, "no label while the marker is still growing");
+            // Fully revealed → the label lands.
+            pt.drawProgress = 1;
+            r = recordingCanvas(200, 200);
+            pt.drawName(r.canvas as any);
+            assert.strictEqual(r.recorded.textWrites.length, 1, "label snaps in once fully revealed");
+        });
+
         it("drawVertex still draws (in highlight colour) when visible=true and highlighted", () => {
             const slate = new Slate(createCanvas(200, 200));
             toElements(slate, triangle_data);

--- a/tests/VisibilityTest.ts
+++ b/tests/VisibilityTest.ts
@@ -115,6 +115,50 @@ describe("element visibility (issue #75)", () => {
             pt.drawVertex(r.canvas as any);
             assert.ok(r.recorded.arcRadii.length > 0, "visible point should arc its marker");
         });
+
+        // #126 — a hidden point must stay hidden even when highlighted /
+        // emphasised: being in a slide's `highlighted` set (or an alias of
+        // one) must not force a point that is NOT in the visible set, or is a
+        // not-yet-revealed deferred reveal target, to draw its dot or label.
+        it("drawVertex writes nothing when visible=false even if highlighted (out-of-set apex)", () => {
+            const slate = new Slate(createCanvas(200, 200));
+            toElements(slate, triangle_data);
+            const pt = slate.lookupElement("A") as PointElement;
+            pt.vertexColor = "#000000";
+            pt.visible = false;
+            pt.shouldHighlight = true;   // highlighted but not in the visible set
+            const r = recordingCanvas(200, 200);
+            pt.drawVertex(r.canvas as any);
+            assert.ok(!recordedAnyDraw(r.recorded),
+                `hidden+highlighted point should make no canvas writes; got ${JSON.stringify(r.recorded)}`);
+        });
+
+        it("drawName writes nothing when visible=false even if highlighted (deferred reveal)", () => {
+            const slate = new Slate(createCanvas(200, 200));
+            toElements(slate, triangle_data);
+            const pt = slate.lookupElement("A") as PointElement;
+            pt.nameColor = "#000000";
+            pt.visible = false;
+            pt.shouldHighlight = true;
+            pt.drawProgress = 0;         // deferred — not yet revealed by its appear step
+            const r = recordingCanvas(200, 200);
+            pt.drawName(r.canvas as any);
+            assert.strictEqual(r.recorded.textWrites.length, 0,
+                "a deferred highlighted point must not draw its label before its reveal");
+        });
+
+        it("drawVertex still draws (in highlight colour) when visible=true and highlighted", () => {
+            const slate = new Slate(createCanvas(200, 200));
+            toElements(slate, triangle_data);
+            const pt = slate.lookupElement("A") as PointElement;
+            pt.vertexColor = "#000000";
+            pt.visible = true;
+            pt.shouldHighlight = true;   // highlight styles a SHOWN point
+            const r = recordingCanvas(200, 200);
+            pt.drawVertex(r.canvas as any);
+            assert.ok(r.recorded.arcRadii.length > 0, "visible highlighted point still draws its marker");
+            assert.ok(r.recorded.fillStyles.includes("#FFD700"), "and in the highlight colour");
+        });
     });
 
     describe("LineElement", () => {

--- a/view/test/deferred-point-reveal.html
+++ b/view/test/deferred-point-reveal.html
@@ -21,7 +21,8 @@ the cascade. The constructed apex <b>C</b> is in the slide's
 step. The bug (now fixed): C's dot and <b>label</b> used to flash in at the
 <i>start</i> of the slide — a point "hanging in space before any line arrived".
 Now the two sides draw first, and <b>C appears only when its own step runs</b>,
-where the sides meet.
+where the sides meet. During that step the marker pulses in, then the
+<b>label snaps on once the dot is full</b> — it doesn't ride the pulse.
 </p>
 
 <canvas id="canvasId" width="460" height="320" tabindex="0"></canvas>

--- a/view/test/deferred-point-reveal.html
+++ b/view/test/deferred-point-reveal.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Test View — deferred / hidden point reveal (#126)</title>
+<style>
+    body { font-family: sans-serif; color: #333; background: #fff; margin: 0; }
+    main { max-width: 44rem; margin: 0 auto; padding: 16px; }
+    canvas { background: #fff; }
+    .note { background:#faf7ef; border:1px solid #e3d6c2; border-radius:6px; padding:10px 12px; font-size:.9rem; color:#555; }
+    kbd { background:#eee; border:1px solid #ccc; border-radius:3px; padding:0 4px; }
+</style>
+</head>
+<body>
+<main>
+<h2>Deferred / hidden point reveal (#126)</h2>
+<p class="note">
+Press <kbd>p</kbd> to present, then <kbd>→</kbd> to advance. This shows two
+things the fix corrects:
+<ol style="margin:.4rem 0 0; padding-left:1.2rem;">
+  <li><b>Slide 2</b> — the midpoint <b>M</b> is in the slide's
+  <code>highlighted</code> set <i>and</i> appears via <code>Point.appear</code>.
+  Its dot and <b>label</b> stay hidden until the appear step runs — they no
+  longer flash in at the start of the slide.</li>
+  <li><b>Slide 3</b> — the equilateral triangle is highlighted (gold), but its
+  apex <b>T</b> is <i>not</i> in the slide's <code>visible</code> set. Even
+  though T is in the <code>highlighted</code> set, it draws <b>no stray dot or
+  label</b>. Highlight styles a shown point; it never reveals a hidden one.</li>
+</ol>
+</p>
+
+<canvas id="canvasId" width="460" height="320" tabindex="0"></canvas>
+
+<script src="../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E, A = geomlib.A;
+    geomlib.init({
+        background: "#ffffff",
+        title: "deferred point reveal",
+        canvasid: "canvasId",
+        elements: [
+            { name: "A",  construction: E.Point.free,   params: [140, 270],
+              vertexColor: "black", nameColor: "black" },
+            { name: "B",  construction: E.Point.free,   params: [320, 270],
+              vertexColor: "black", nameColor: "black" },
+            { name: "AB", construction: E.Line.connect, params: ["A", "B"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black" },
+            // The constructed point that appears on cue (slide 2).
+            { name: "M",  construction: E.Point.midpoint, params: ["A", "B"],
+              vertexColor: "black", nameColor: "black" },
+            // Equilateral triangle on AB; its apex T is extracted but is left
+            // out of slide 3's visible set (slide 3).
+            { name: "eq", construction: E.Polygon.equilateralTriangle, params: ["A", "B"],
+              nameColor: 0, vertexColor: 0, edgeColor: "#555" },
+            { name: "T",  construction: E.Point.vertex, params: ["eq", 3],
+              vertexColor: "black", nameColor: "black" },
+        ],
+        slides: [
+            { text: "Segment {AB}.",
+              visible: ["A", "B", "AB"], highlighted: ["AB"] },
+            { text: "Its midpoint {M} appears on cue — the label does not flash in early.",
+              visible: ["A", "B", "AB", "M"], highlighted: ["M"],
+              transition: { animations: [ { elem: "M", name: A.Point.appear } ] } },
+            { text: "The equilateral triangle on {AB} is highlighted, but its apex {T} is not in this slide — no stray dot.",
+              visible: ["A", "B", "AB", "eq"], highlighted: ["eq", "T"] },
+        ],
+    });
+</script>
+</main>
+</body>
+</html>

--- a/view/test/deferred-point-reveal.html
+++ b/view/test/deferred-point-reveal.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Test View — deferred / hidden point reveal (#126)</title>
+<title>Test View — deferred point reveal (#126)</title>
 <style>
     body { font-family: sans-serif; color: #333; background: #fff; margin: 0; }
     main { max-width: 44rem; margin: 0 auto; padding: 16px; }
@@ -13,20 +13,15 @@
 </head>
 <body>
 <main>
-<h2>Deferred / hidden point reveal (#126)</h2>
+<h2>Deferred point reveal (#126)</h2>
 <p class="note">
-Press <kbd>p</kbd> to present, then <kbd>→</kbd> to advance. This shows two
-things the fix corrects:
-<ol style="margin:.4rem 0 0; padding-left:1.2rem;">
-  <li><b>Slide 2</b> — the midpoint <b>M</b> is in the slide's
-  <code>highlighted</code> set <i>and</i> appears via <code>Point.appear</code>.
-  Its dot and <b>label</b> stay hidden until the appear step runs — they no
-  longer flash in at the start of the slide.</li>
-  <li><b>Slide 3</b> — the equilateral triangle is highlighted (gold), but its
-  apex <b>T</b> is <i>not</i> in the slide's <code>visible</code> set. Even
-  though T is in the <code>highlighted</code> set, it draws <b>no stray dot or
-  label</b>. Highlight styles a shown point; it never reveals a hidden one.</li>
-</ol>
+Press <kbd>p</kbd> to present, then <kbd>→</kbd> to advance to slide 2 and watch
+the cascade. The constructed apex <b>C</b> is in the slide's
+<code>highlighted</code> set <i>and</i> has a late <code>Point.appear</code>
+step. The bug (now fixed): C's dot and <b>label</b> used to flash in at the
+<i>start</i> of the slide — a point "hanging in space before any line arrived".
+Now the two sides draw first, and <b>C appears only when its own step runs</b>,
+where the sides meet.
 </p>
 
 <canvas id="canvasId" width="460" height="320" tabindex="0"></canvas>
@@ -39,30 +34,33 @@ things the fix corrects:
         title: "deferred point reveal",
         canvasid: "canvasId",
         elements: [
-            { name: "A",  construction: E.Point.free,   params: [140, 270],
+            { name: "A",  construction: E.Point.free,   params: [130, 250],
               vertexColor: "black", nameColor: "black" },
-            { name: "B",  construction: E.Point.free,   params: [320, 270],
+            { name: "B",  construction: E.Point.free,   params: [330, 250],
               vertexColor: "black", nameColor: "black" },
             { name: "AB", construction: E.Line.connect, params: ["A", "B"],
               nameColor: 0, vertexColor: 0, edgeColor: "black" },
-            // The constructed point that appears on cue (slide 2).
-            { name: "M",  construction: E.Point.midpoint, params: ["A", "B"],
-              vertexColor: "black", nameColor: "black" },
-            // Equilateral triangle on AB; its apex T is extracted but is left
-            // out of slide 3's visible set (slide 3).
+            // Invisible scaffold to derive the apex position.
             { name: "eq", construction: E.Polygon.equilateralTriangle, params: ["A", "B"],
-              nameColor: 0, vertexColor: 0, edgeColor: "#555" },
-            { name: "T",  construction: E.Point.vertex, params: ["eq", 3],
+              nameColor: 0, vertexColor: 0, edgeColor: 0 },
+            { name: "C",  construction: E.Point.vertex, params: ["eq", 3],
               vertexColor: "black", nameColor: "black" },
+            // The two sides that arrive at the apex.
+            { name: "AC", construction: E.Line.connect, params: ["A", "C"],
+              nameColor: 0, vertexColor: 0, edgeColor: "#333" },
+            { name: "BC", construction: E.Line.connect, params: ["B", "C"],
+              nameColor: 0, vertexColor: 0, edgeColor: "#333" },
         ],
         slides: [
             { text: "Segment {AB}.",
               visible: ["A", "B", "AB"], highlighted: ["AB"] },
-            { text: "Its midpoint {M} appears on cue — the label does not flash in early.",
-              visible: ["A", "B", "AB", "M"], highlighted: ["M"],
-              transition: { animations: [ { elem: "M", name: A.Point.appear } ] } },
-            { text: "The equilateral triangle on {AB} is highlighted, but its apex {T} is not in this slide — no stray dot.",
-              visible: ["A", "B", "AB", "eq"], highlighted: ["eq", "T"] },
+            { text: "The two sides {AC} and {BC} are drawn; their apex {C} appears where they meet — not before.",
+              visible: ["A", "B", "AB", "AC", "BC", "C"], highlighted: ["AC", "BC", "C"],
+              transition: { animations: [
+                  { elem: "AC", name: A.Line.straightEdgeConnect },
+                  { elem: "BC", name: A.Line.straightEdgeConnect },
+                  { elem: "C",  name: A.Point.appear },
+              ] } },
         ],
     });
 </script>


### PR DESCRIPTION
Closes #126.

## Problem

`PointElement.drawVertex`/`drawName` gated on `visible || shouldHighlight || emphasisAmount > 0`. So a point that is in a slide's `highlighted` set — or an alias of one — drew even when it was a **deferred reveal target** (held `visible=false` until its `A.Point.appear` step runs). The dot's radius already zeroes at `drawProgress=0`, but the **name label had no such guard**, so a constructed point (e.g. the apex **C**) that's highlighted *and* appears late showed its **label at the start of the slide** — "a point hanging in space before its line arrives".

(The issue also mentions an out-of-set "stray apex dot". That turns out to be a *different* mechanism — `computeSlideState` does `highlighted.forEach(n => visible.add(n))`, so **highlighting a point forces it visible**. That's the slideshow's "highlight implies visible" rule, not a point-draw bug; a deck that doesn't want a point's dot shown simply shouldn't highlight it. Left as-is.)

## Fix

Two parts, both in `PointElement`:

1. **Gate the dot and label on `visible` alone.** Highlight/emphasis *style* a shown point — they never force a hidden one to draw. The reveal lifecycle flips `visible=true` in `SlateAnimator._startStep` exactly when a deferred point's step begins, so the marker now syncs to the reveal instead of the highlighted set.

2. **The label snaps in only at full reveal.** `drawName` early-returns while `drawProgress < 1`, so an appearing point reads as two stages — the marker pulses in (dot radius scales `0→full` via `drawProgress`), then the label lands when the dot is full. It does not ride the pulse. (Per review feedback on the reveal feel.)

## Why points only

Circles/lines are deliberately left unchanged: their compass-proxy animations render a `visible=false` target via `emphasisAmount=1` (the "invisible highlight circle" pattern in `_startStep` + `AnimationTest`). Points have no such pattern — `A.Point.appear` sets `visible=true` on reveal — so requiring `visible` is safe for them.

## Tests & demo

- New `VisibilityTest` cases: hidden+highlighted point writes no dot/label (deferred reveal); the label holds until `drawProgress=1` (snap, not fade); regression — a *visible* highlighted point still draws its marker in gold.
- `view/test/deferred-point-reveal.html` — a 2-slide deck: the two sides draw, then the highlighted apex C pulses in where they meet and its label snaps on once the dot is full (no point hanging in space before its line arrives).
- **289 unit + 700 snapshot** green. Snapshot-identical: static figures are `visible=true, drawProgress=1`, so the gates are unchanged there.

No release; PR-only for review.