### PR TITLE
0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brownnrl/geomlib",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Interactive Euclidean geometry constructions in the browser — a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
   "keywords": [
     "euclid",


### PR DESCRIPTION
Release **0.13.0** — version bump only (`package.json` + `package-lock.json`). Rolls up the seven commits merged since `v0.12.0`:

- **Responsive scale-to-fit + HiDPI canvas** (#71)
- security update
- **Curved triangle** — arc-sided elliptic/hyperbolic triangle (#119)
- **Open path (polyline)** — highlightable multi-segment route (#121)
- **Point highlight** no longer reveals a hidden/deferred point (#126)
- **Cross-canvas highlight** — `geomlib.highlightByName` (#130)
- **Stock I.1 / I.2 construction animations** — `A.Polygon.equilateralBuild` + `A.Circle.compassTransfer` (#127)

All additive and default-off. **305 unit + 700 snapshot** green; `bundle:prod` clean; `npm publish --dry-run` → `brownnrl-geomlib-0.13.0.tgz` (6 files, 194.7 kB).

After merge: tag `v0.13.0` on the release commit, then `npm publish`.