### PR TITLE
Full CSS named-color set in parseColor (#125)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Library is **post-porting, publish-ready**. There is no longer a
 "next construction to port" backlog or session-startup ritual.
 
 - All 69 construction methods (with 19 3D variants) are implemented.
-- 305 unit tests + 700 snapshot tests pass.
+- 309 unit tests + 700 snapshot tests pass.
 - 0.4.0 shipped cross-highlighting (`emphasized` / `emphasisAmount`
   + `lookupElement`); 0.5.0 shipped the slideshow surface
   (`slides`, `setVisibleNames`, `addAlias`, `resolveJustification`,
@@ -96,7 +96,7 @@ dist/                     Webpack output (gitignored, shipped to npm)
 ```sh
 npm install              # one-time
 npm run build            # tsc --noEmit (typecheck only)
-npm run test:unit        # 305 unit tests (~110 ms)
+npm run test:unit        # 309 unit tests (~110 ms)
 npm run test:snapshot    # 700 snapshot tests; auto-creates goldens on first run
 npm test                 # both
 npm run bundle           # dev-mode bundle to dist/bundle.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ That's it.
 ## Running tests
 
 ```sh
-npm run test:unit      # 305 unit tests — fast (~100 ms)
+npm run test:unit      # 309 unit tests — fast (~100 ms)
 npm run test:snapshot  # 700 visual-regression tests against snapshot goldens
 npm test               # both (snapshot then unit)
 ```

--- a/doc/api.md
+++ b/doc/api.md
@@ -298,7 +298,7 @@ has no `align` field). Tracked under platform TODOs in
 
 | Input | Result |
 |---|---|
-| Named CSS color (`"black"`, `"red"`, `"darkGray"`, …) | Java's color table values, exact RGB. Includes the Java additions `"darkGray"`, `"lightGray"`, `"gray"`. |
+| Named color (`"black"`, `"red"`, `"crimson"`, `"teal"`, `"steelblue"`, …) | The full **W3C/CSS** named-color set, looked up **case-insensitively** (0.13.0+, #125). **Five names keep their historical Java AWT values** instead of the CSS ones — `green` (`0,255,0`), `orange` (`255,200,0`), `pink` (`255,175,175`), `darkGray`/`darkgray` (`64,64,64`), `lightGray`/`lightgray` (`192,192,192`). `grey`-spelling aliases are accepted. |
 | 6-hex-digit `#rrggbb` or `rrggbb` | The exact RGB. |
 | Comma-triple `"H,S,B"` (e.g. `"35,19,100"`) | HSB; H ∈ 0–360, S/B ∈ 0–100. Matches the Java applet's `Color.getHSBColor()` semantics. |
 | `"random"` | Random pastel each call. |

--- a/src/Colors.ts
+++ b/src/Colors.ts
@@ -6,12 +6,18 @@
 |      3. "background"                     → bgcolor                    |
 |      4. "brighter"                       → brighter(bgcolor)          |
 |      5. "darker"                         → darker(bgcolor)            |
-|      6. Named color (13 names)           → rgb string                 |
+|      6. Named color (CSS set, case-insensitive; 5 Java exceptions)    |
 |      7. Hex integer "rrggbb"             → rgb string                 |
 |      8. HSB comma triple "h,s,b"         → rgb string                 |
 |      9. Fallback                         → null                       |
 +----------------------------------------------------------------------*/
 
+// The original 13 Java AWT named colors, with their exact (camelCase)
+// spellings. Kept as the back-compat fast path: existing fixtures/decks use
+// these exact names, so every current render resolves here, byte-identically.
+// Five of these DELIBERATELY differ from W3C/CSS and keep the Java values —
+// green, orange, pink, darkGray, lightGray (#125). cssColors below also pins
+// those five (under their lowercase keys) so case-insensitive lookups agree.
 export const colors : {[colorName: string]: string} =
 {
     "black": "rgb(0,0,0)",
@@ -27,6 +33,91 @@ export const colors : {[colorName: string]: string} =
     "red": "rgb(255,0,0)",
     "white": "rgb(255,255,255)",
     "yellow": "rgb(255,255,0)"
+};
+
+// The full W3C/CSS named-color set (CSS Color Module Level 4), lowercase keys,
+// looked up case-insensitively (#125). Static literal — NO runtime dependency.
+// FIVE entries deviate from the CSS value to preserve geomlib/Java AWT history
+// (marked GEOMLIB below); `grey`-spelling aliases are included. New names take
+// their standard CSS rgb. Authors can now write crimson/teal/gold/navy/etc.
+// instead of falling through to silent-null.
+export const cssColors : {[colorName: string]: string} =
+{
+    "aliceblue": "rgb(240,248,255)", "antiquewhite": "rgb(250,235,215)",
+    "aqua": "rgb(0,255,255)", "aquamarine": "rgb(127,255,212)",
+    "azure": "rgb(240,255,255)", "beige": "rgb(245,245,220)",
+    "bisque": "rgb(255,228,196)", "black": "rgb(0,0,0)",
+    "blanchedalmond": "rgb(255,235,205)", "blue": "rgb(0,0,255)",
+    "blueviolet": "rgb(138,43,226)", "brown": "rgb(165,42,42)",
+    "burlywood": "rgb(222,184,135)", "cadetblue": "rgb(95,158,160)",
+    "chartreuse": "rgb(127,255,0)", "chocolate": "rgb(210,105,30)",
+    "coral": "rgb(255,127,80)", "cornflowerblue": "rgb(100,149,237)",
+    "cornsilk": "rgb(255,248,220)", "crimson": "rgb(220,20,60)",
+    "cyan": "rgb(0,255,255)", "darkblue": "rgb(0,0,139)",
+    "darkcyan": "rgb(0,139,139)", "darkgoldenrod": "rgb(184,134,11)",
+    "darkgray": "rgb(64,64,64)", "darkgrey": "rgb(64,64,64)",          // GEOMLIB (CSS: 169,169,169)
+    "darkgreen": "rgb(0,100,0)", "darkkhaki": "rgb(189,183,107)",
+    "darkmagenta": "rgb(139,0,139)", "darkolivegreen": "rgb(85,107,47)",
+    "darkorange": "rgb(255,140,0)", "darkorchid": "rgb(153,50,204)",
+    "darkred": "rgb(139,0,0)", "darksalmon": "rgb(233,150,122)",
+    "darkseagreen": "rgb(143,188,143)", "darkslateblue": "rgb(72,61,139)",
+    "darkslategray": "rgb(47,79,79)", "darkslategrey": "rgb(47,79,79)",
+    "darkturquoise": "rgb(0,206,209)", "darkviolet": "rgb(148,0,211)",
+    "deeppink": "rgb(255,20,147)", "deepskyblue": "rgb(0,191,255)",
+    "dimgray": "rgb(105,105,105)", "dimgrey": "rgb(105,105,105)",
+    "dodgerblue": "rgb(30,144,255)", "firebrick": "rgb(178,34,34)",
+    "floralwhite": "rgb(255,250,240)", "forestgreen": "rgb(34,139,34)",
+    "fuchsia": "rgb(255,0,255)", "gainsboro": "rgb(220,220,220)",
+    "ghostwhite": "rgb(248,248,255)", "gold": "rgb(255,215,0)",
+    "goldenrod": "rgb(218,165,32)", "gray": "rgb(128,128,128)",
+    "grey": "rgb(128,128,128)", "green": "rgb(0,255,0)",              // GEOMLIB (CSS: 0,128,0)
+    "greenyellow": "rgb(173,255,47)", "honeydew": "rgb(240,255,240)",
+    "hotpink": "rgb(255,105,180)", "indianred": "rgb(205,92,92)",
+    "indigo": "rgb(75,0,130)", "ivory": "rgb(255,255,240)",
+    "khaki": "rgb(240,230,140)", "lavender": "rgb(230,230,250)",
+    "lavenderblush": "rgb(255,240,245)", "lawngreen": "rgb(124,252,0)",
+    "lemonchiffon": "rgb(255,250,205)", "lightblue": "rgb(173,216,230)",
+    "lightcoral": "rgb(240,128,128)", "lightcyan": "rgb(224,255,255)",
+    "lightgoldenrodyellow": "rgb(250,250,210)",
+    "lightgray": "rgb(192,192,192)", "lightgrey": "rgb(192,192,192)",  // GEOMLIB (CSS: 211,211,211)
+    "lightgreen": "rgb(144,238,144)", "lightpink": "rgb(255,182,193)",
+    "lightsalmon": "rgb(255,160,122)", "lightseagreen": "rgb(32,178,170)",
+    "lightskyblue": "rgb(135,206,250)", "lightslategray": "rgb(119,136,153)",
+    "lightslategrey": "rgb(119,136,153)", "lightsteelblue": "rgb(176,196,222)",
+    "lightyellow": "rgb(255,255,224)", "lime": "rgb(0,255,0)",
+    "limegreen": "rgb(50,205,50)", "linen": "rgb(250,240,230)",
+    "magenta": "rgb(255,0,255)", "maroon": "rgb(128,0,0)",
+    "mediumaquamarine": "rgb(102,205,170)", "mediumblue": "rgb(0,0,205)",
+    "mediumorchid": "rgb(186,85,211)", "mediumpurple": "rgb(147,112,219)",
+    "mediumseagreen": "rgb(60,179,113)", "mediumslateblue": "rgb(123,104,238)",
+    "mediumspringgreen": "rgb(0,250,154)", "mediumturquoise": "rgb(72,209,204)",
+    "mediumvioletred": "rgb(199,21,133)", "midnightblue": "rgb(25,25,112)",
+    "mintcream": "rgb(245,255,250)", "mistyrose": "rgb(255,228,225)",
+    "moccasin": "rgb(255,228,181)", "navajowhite": "rgb(255,222,173)",
+    "navy": "rgb(0,0,128)", "oldlace": "rgb(253,245,230)",
+    "olive": "rgb(128,128,0)", "olivedrab": "rgb(107,142,35)",
+    "orange": "rgb(255,200,0)",                                       // GEOMLIB (CSS: 255,165,0)
+    "orangered": "rgb(255,69,0)", "orchid": "rgb(218,112,214)",
+    "palegoldenrod": "rgb(238,232,170)", "palegreen": "rgb(152,251,152)",
+    "paleturquoise": "rgb(175,238,238)", "palevioletred": "rgb(219,112,147)",
+    "papayawhip": "rgb(255,239,213)", "peachpuff": "rgb(255,218,185)",
+    "peru": "rgb(205,133,63)", "pink": "rgb(255,175,175)",            // GEOMLIB (CSS: 255,192,203)
+    "plum": "rgb(221,160,221)", "powderblue": "rgb(176,224,230)",
+    "purple": "rgb(128,0,128)", "rebeccapurple": "rgb(102,51,153)",
+    "red": "rgb(255,0,0)", "rosybrown": "rgb(188,143,143)",
+    "royalblue": "rgb(65,105,225)", "saddlebrown": "rgb(139,69,19)",
+    "salmon": "rgb(250,128,114)", "sandybrown": "rgb(244,164,96)",
+    "seagreen": "rgb(46,139,87)", "seashell": "rgb(255,245,238)",
+    "sienna": "rgb(160,82,45)", "silver": "rgb(192,192,192)",
+    "skyblue": "rgb(135,206,235)", "slateblue": "rgb(106,90,205)",
+    "slategray": "rgb(112,128,144)", "slategrey": "rgb(112,128,144)",
+    "snow": "rgb(255,250,250)", "springgreen": "rgb(0,255,127)",
+    "steelblue": "rgb(70,130,180)", "tan": "rgb(210,180,140)",
+    "teal": "rgb(0,128,128)", "thistle": "rgb(216,191,216)",
+    "tomato": "rgb(255,99,71)", "turquoise": "rgb(64,224,208)",
+    "violet": "rgb(238,130,238)", "wheat": "rgb(245,222,179)",
+    "white": "rgb(255,255,255)", "whitesmoke": "rgb(245,245,245)",
+    "yellow": "rgb(255,255,0)", "yellowgreen": "rgb(154,205,50)"
 };
 
 // Default color cycle for angle markers (#91). Each entry pairs a
@@ -59,8 +150,11 @@ export function parseColor(val: string | number, dfault: string, bgcolor: string
     if (str === "background") return bgcolor;
     if (str === "brighter") return brighter(bgcolor);
     if (str === "darker") return darker(bgcolor);
-    // Named color lookup
+    // Named color lookup — exact (the 13 back-compat camelCase spellings)
+    // first, then the full CSS set case-insensitively (#125).
     if (str in colors) return colors[str];
+    let lower = str.toLowerCase();
+    if (lower in cssColors) return cssColors[lower];
     // Hex color (e.g. "ff0000" or "#ffe9cd" → rgb(...))
     // Java does: new Color(Integer.parseInt(str, 16))
     // Also handle CSS #-prefixed hex which Java doesn't use but our

--- a/tests/ColorsTest.ts
+++ b/tests/ColorsTest.ts
@@ -59,6 +59,37 @@ describe("parseColor", () => {
         assert.equal(parseColor("yellow", null, bgcolor), "rgb(255,255,0)");
     });
 
+    // 3b. Full CSS named-color set (#125)
+    it("should resolve newly-added CSS names to their CSS rgb", () => {
+        assert.equal(parseColor("crimson", null, bgcolor), "rgb(220,20,60)");
+        assert.equal(parseColor("teal", null, bgcolor), "rgb(0,128,128)");
+        assert.equal(parseColor("gold", null, bgcolor), "rgb(255,215,0)");
+        assert.equal(parseColor("steelblue", null, bgcolor), "rgb(70,130,180)");
+        assert.equal(parseColor("navy", null, bgcolor), "rgb(0,0,128)");
+        assert.equal(parseColor("rebeccapurple", null, bgcolor), "rgb(102,51,153)");
+    });
+    it("should keep the 5 geomlib/Java exceptions, NOT the CSS values", () => {
+        // these CSS names disagree with Java AWT; geomlib keeps the Java value
+        assert.equal(parseColor("green", null, bgcolor), "rgb(0,255,0)");      // CSS 0,128,0
+        assert.equal(parseColor("orange", null, bgcolor), "rgb(255,200,0)");   // CSS 255,165,0
+        assert.equal(parseColor("pink", null, bgcolor), "rgb(255,175,175)");   // CSS 255,192,203
+        assert.equal(parseColor("darkgray", null, bgcolor), "rgb(64,64,64)");  // CSS 169,169,169
+        assert.equal(parseColor("lightgray", null, bgcolor), "rgb(192,192,192)"); // CSS 211,211,211
+        // grey-spelling aliases agree with their gray twins
+        assert.equal(parseColor("darkgrey", null, bgcolor), "rgb(64,64,64)");
+        assert.equal(parseColor("lightgrey", null, bgcolor), "rgb(192,192,192)");
+    });
+    it("should look up named colors case-insensitively", () => {
+        assert.equal(parseColor("CRIMSON", null, bgcolor), "rgb(220,20,60)");
+        assert.equal(parseColor("SteelBlue", null, bgcolor), "rgb(70,130,180)");
+        // camelCase darkGray and lowercase darkgray resolve identically
+        assert.equal(parseColor("DARKGRAY", null, bgcolor), parseColor("darkGray", null, bgcolor));
+    });
+    it("should still return null for an unknown color name", () => {
+        assert.equal(parseColor("notacolor", null, bgcolor), null);
+        assert.equal(parseColor("chartruse", null, bgcolor), null); // misspelled
+    });
+
     // 4. Hex color parsing
     it("should parse 6-digit hex 'ff0000' as red", () => {
         assert.equal(parseColor("ff0000", null, bgcolor), "rgb(255,0,0)");

--- a/view/test/color-swatches.html
+++ b/view/test/color-swatches.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Test View — CSS named-color swatches (#125)</title>
+<style>
+    body { font-family: sans-serif; color: #333; background: #fff; margin: 0; }
+    header { max-width: 60rem; margin: 0 auto; padding: 16px 16px 0; }
+    .chart { padding: 8px 16px 40px; overflow-x: auto; }
+    canvas { background: #fff; border: 1px solid #eee; display: block; }
+    .note { background:#faf7ef; border:1px solid #e3d6c2; border-radius:6px; padding:10px 12px; font-size:.9rem; color:#555; }
+    code { background:#f3f3f3; padding:0 3px; border-radius:3px; }
+    b.exc { color: #dc143c; }
+</style>
+</head>
+<body>
+<header>
+<h2>CSS named-color swatches (#125)</h2>
+<p class="note">
+Every name <code>parseColor</code> accepts from the W3C/CSS set (0.13.0+),
+drawn as a filled square with its name labelled at the upper-left vertex.
+Names lookup <b>case-insensitively</b>; <code>grey</code>-spelling aliases
+(not shown) mirror their <code>gray</code> twins. The
+<b class="exc">five crimson labels</b> — <code>green</code>, <code>orange</code>,
+<code>pink</code>, <code>darkgray</code>, <code>lightgray</code> — keep their
+historical <b>Java AWT</b> values, which differ from CSS (e.g. this
+<code>green</code> is <code>0,255,0</code>, not CSS's <code>0,128,0</code>;
+this <code>darkgray</code> is the darker <code>64,64,64</code>). Each swatch
+is a <code>polygon;quadrilateral</code> whose <code>faceColor</code> is just
+the name string.
+</p>
+</header>
+<div class="chart">
+<canvas id="swatches" width="1124" height="2392" tabindex="0"></canvas>
+</div>
+
+<script src="../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    const E = geomlib.E, Align = geomlib.Align;
+
+    // The full W3C/CSS named set parseColor resolves (grey-spelling aliases
+    // omitted — they equal their gray twins). Five render their Java AWT value.
+    const NAMES = ("aliceblue antiquewhite aqua aquamarine azure beige bisque black " +
+        "blanchedalmond blue blueviolet brown burlywood cadetblue chartreuse chocolate " +
+        "coral cornflowerblue cornsilk crimson cyan darkblue darkcyan darkgoldenrod " +
+        "darkgray darkgreen darkkhaki darkmagenta darkolivegreen darkorange darkorchid " +
+        "darkred darksalmon darkseagreen darkslateblue darkslategray darkturquoise " +
+        "darkviolet deeppink deepskyblue dimgray dodgerblue firebrick floralwhite " +
+        "forestgreen fuchsia gainsboro ghostwhite gold goldenrod gray green greenyellow " +
+        "honeydew hotpink indianred indigo ivory khaki lavender lavenderblush lawngreen " +
+        "lemonchiffon lightblue lightcoral lightcyan lightgoldenrodyellow lightgray " +
+        "lightgreen lightpink lightsalmon lightseagreen lightskyblue lightslategray " +
+        "lightsteelblue lightyellow lime limegreen linen magenta maroon mediumaquamarine " +
+        "mediumblue mediumorchid mediumpurple mediumseagreen mediumslateblue " +
+        "mediumspringgreen mediumturquoise mediumvioletred midnightblue mintcream " +
+        "mistyrose moccasin navajowhite navy oldlace olive olivedrab orange orangered " +
+        "orchid palegoldenrod palegreen paleturquoise palevioletred papayawhip peachpuff " +
+        "peru pink plum powderblue purple rebeccapurple red rosybrown royalblue " +
+        "saddlebrown salmon sandybrown seagreen seashell sienna silver skyblue slateblue " +
+        "slategray snow springgreen steelblue tan teal thistle tomato turquoise violet " +
+        "wheat white whitesmoke yellow yellowgreen").split(" ");
+    const EXC = new Set(["green", "orange", "pink", "darkgray", "lightgray"]);
+
+    const COLS = 6, SW = 150, SH = 64, HP = 170, VP = 98, X0 = 92, Y0 = 46;
+    const els = [];
+    NAMES.forEach((nm, k) => {
+        const c = k % COLS, r = Math.floor(k / COLS);
+        const x = X0 + c * HP, y = Y0 + r * VP;
+        // upper-left vertex carries the label (crimson if a Java exception),
+        // floated ABOVE so it reads on the page background over any fill.
+        els.push({ name: nm,        construction: E.Point.free, params: [x, y],
+                   vertexColor: 0, nameColor: EXC.has(nm) ? "crimson" : "black", align: Align.ABOVE });
+        els.push({ name: nm + "_b", construction: E.Point.free, params: [x + SW, y],      vertexColor: 0, nameColor: 0 });
+        els.push({ name: nm + "_c", construction: E.Point.free, params: [x + SW, y + SH], vertexColor: 0, nameColor: 0 });
+        els.push({ name: nm + "_d", construction: E.Point.free, params: [x, y + SH],      vertexColor: 0, nameColor: 0 });
+        els.push({ name: nm + "_sq", construction: E.Polygon.quadrilateral,
+                   params: [nm, nm + "_b", nm + "_c", nm + "_d"],
+                   nameColor: 0, vertexColor: 0, edgeColor: "c8c8c8", faceColor: nm });
+    });
+
+    geomlib.init({
+        canvasid: "swatches",
+        background: "0,0,100",
+        title: "CSS named colors",
+        fontsize: 12,
+        elements: els,
+    });
+</script>
+</body>
+</html>

--- a/view/test/overview.html
+++ b/view/test/overview.html
@@ -48,6 +48,8 @@ individually.</p>
       <td>Curved (elliptic) triangle vs the straight-chord stopgap — the I.16 figure, two ways.</td><td>#119</td></tr>
   <tr><td><a href="open-path.html">open-path.html</a></td>
       <td><code>line;path</code> — an open polyline highlighted as one route (Heron's bent line, I.20).</td><td>#121</td></tr>
+  <tr><td><a href="color-swatches.html">color-swatches.html</a></td>
+      <td>Every CSS named color <code>parseColor</code> accepts, as a filled-square grid with the name at each upper-left vertex; the 5 Java-AWT exceptions flagged in crimson.</td><td>#125</td></tr>
   <tr><td><a href="circumcenter_lineperp.html">circumcenter_lineperp.html</a></td>
       <td><code>Point.circumcenter</code> + <code>Line.perpendicular</code> (III.25a).</td><td>—</td></tr>
   <tr><td><a href="quad_line.html">quad_line.html</a></td>


### PR DESCRIPTION
Closes #125.

## What

Extends `parseColor`'s named-color lookup from the original **13** to the full **W3C/CSS** named-color set — a static literal in `Colors.ts`, **no new runtime dependency**. Authors can now write `crimson`, `teal`, `gold`, `steelblue`, `navy`, … instead of falling through to silent-null (the footgun that hid the #121 `crimson` demo element).

## How

- The original 13 stay in `colors` (exact camelCase spellings) as a **back-compat fast path** — every existing fixture/deck resolves there first, byte-identically.
- New `cssColors` table holds the full set, looked up **case-insensitively** (`str.toLowerCase()`), after the exact check.

## The decision the issue left open (case + the 5 conflicts)

Picked: **case-insensitive lookup**, with the **five Java/CSS conflicts pinned to their geomlib (Java AWT) values across every spelling** so a deck never silently shifts hue:

| name | geomlib keeps | (CSS, not adopted) |
|---|---|---|
| `green` | 0,255,0 | 0,128,0 |
| `orange` | 255,200,0 | 255,165,0 |
| `pink` | 255,175,175 | 255,192,203 |
| `darkGray`/`darkgray` | 64,64,64 | 169,169,169 |
| `lightGray`/`lightgray` | 192,192,192 | 211,211,211 |

`grey`-spelling aliases are accepted; all other new names take their standard CSS rgb.

## Out of scope (per the issue)

Unchanged silent-null for genuinely unknown names; no `rgb()`/`hsl()` function-string inputs.

## Tests & docs

- **+4 unit** (309 total): newly-added CSS names → CSS rgb; the 5 exceptions keep Java values (incl. lowercase/grey spellings); case-insensitivity (`CRIMSON`, `SteelBlue`, `DARKGRAY` == `darkGray`); unknown name still → null.
- **700 snapshot byte-identical** — additive; existing fixtures use only the 13 + hex + HSB, all hitting the exact path.
- `doc/api.md` color table + the `Colors.ts` header comment updated.