### PR TITLE
A.Point.slide: glide to a target element (#122)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Library is **post-porting, publish-ready**. There is no longer a
 "next construction to port" backlog or session-startup ritual.
 
 - All 69 construction methods (with 19 3D variants) are implemented.
-- 305 unit tests + 700 snapshot tests pass.
+- 311 unit tests + 700 snapshot tests pass.
 - 0.4.0 shipped cross-highlighting (`emphasized` / `emphasisAmount`
   + `lookupElement`); 0.5.0 shipped the slideshow surface
   (`slides`, `setVisibleNames`, `addAlias`, `resolveJustification`,
@@ -96,7 +96,7 @@ dist/                     Webpack output (gitignored, shipped to npm)
 ```sh
 npm install              # one-time
 npm run build            # tsc --noEmit (typecheck only)
-npm run test:unit        # 305 unit tests (~110 ms)
+npm run test:unit        # 311 unit tests (~110 ms)
 npm run test:snapshot    # 700 snapshot tests; auto-creates goldens on first run
 npm test                 # both
 npm run bundle           # dev-mode bundle to dist/bundle.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ That's it.
 ## Running tests
 
 ```sh
-npm run test:unit      # 305 unit tests — fast (~100 ms)
+npm run test:unit      # 311 unit tests — fast (~100 ms)
 npm run test:snapshot  # 700 visual-regression tests against snapshot goldens
 npm test               # both (snapshot then unit)
 ```

--- a/doc/animations-reference.md
+++ b/doc/animations-reference.md
@@ -52,7 +52,7 @@ Rates are in `px/ms` for linear traces and `rad/ms` for arc sweeps.
 | Name | Status | Target | Args | Default | Visual |
 |---|---|---|---|---|---|
 | `A.Point.appear` | **IMPL** | `PointElement` | — | `350 ms` | Marker radius scales from 0 to its final value. The simplest reveal — used for points constructed at an intersection ("the point C at which the circles cut"). |
-| `A.Point.slide` | **IMPL** | `LineSlider` | `{ to: number }` | `650 ms` | Glide a slider point along its line to the target parameter `t` (`A + t·(B−A)`; an infinite `lineSlider` accepts `t < 0` / `t > 1`), its dependents following each frame — the scripted counterpart of a reader dragging the slider. `finalise()` leaves the point at the target. Non-slider targets warn + fall through. |
+| `A.Point.slide` | **IMPL** | `LineSlider` | `{ to: number }` or `{ to: "E" }` / `{ toElement: "E" }` | `650 ms` | Glide a slider point along its line, its dependents following each frame — the scripted counterpart of a reader dragging the slider. **Numeric `to`:** the target parameter `t` (`A + t·(B−A)`; an infinite `lineSlider` accepts `t < 0` / `t > 1`). **Element `to`/`toElement` (#122):** a target **point**, resolved via `lookupElement` **at setup** and projected onto the slider's line (nearest point, clamped to a segment slider's domain) — so it lands on a *derived* point (e.g. an intersection) and still tracks it after the reader drags the givens. `finalise()` leaves the point at the target. A non-resolvable / non-point name warns and stays put; a non-slider target warns + falls through. |
 | `A.Point.intersect` | TBD | `PointElement` | — | — | Reserved. Brief flash on the intersecting curves before the dot lands. Will use ephemerals to render the flash. |
 
 ## Line animations

--- a/src/elements/point/PointAnimations.ts
+++ b/src/elements/point/PointAnimations.ts
@@ -32,12 +32,22 @@ export class PointAppearAnimation extends Animation {
 }
 
 // A.Point.slide — glide a slider point along its line to a target
-// parameter `t` (the scripted counterpart of a reader dragging it).
-// The point really travels its constraint and its dependents follow.
-// Args: { to: number } — the target parameter along A→B (0 = A, 1 = B;
-// for a segment slider it's clamped to [0,1] by the slider's own
-// projection). Optional durationMs; default ~ a standard transition
-// glide, resolved through the usual chain.
+// (the scripted counterpart of a reader dragging it). The point really
+// travels its constraint and its dependents follow.
+//
+// Args (one of):
+//   { to: number }       — a target parameter along A→B (0 = A, 1 = B;
+//                          for a segment slider it's clamped to [0,1] by
+//                          the slider's own projection). Default 1.
+//   { to: "E" } / { toElement: "E" }  — a target ELEMENT (#122). At setup
+//                          the named point is resolved via lookupElement,
+//                          projected onto the slider's line (nearest point,
+//                          clamped to the segment domain), and the slider
+//                          glides there. Resolved at runtime, so it tracks
+//                          a derived point (e.g. an intersection) even after
+//                          the reader drags the givens. A non-resolvable /
+//                          non-point name warns and stays put.
+// Optional durationMs; default ~ a standard transition glide.
 //
 // elementType is LineSlider — covers both `lineSlider` and
 // `lineSegmentSlider`. A non-slider target warns + falls through to
@@ -50,13 +60,18 @@ export class PointSlideAnimation extends Animation {
 
     public build(target: GeomElement, slate: Slate, args: any): IAnimationStep[] {
         const slider = target as LineSlider;
-        const to = args && typeof args.to === "number" ? args.to : 1;
+        const toNum = args && typeof args.to === "number" ? args.to : null;
+        // A string `to` (or the explicit `toElement`) names a target point.
+        const toName: string | null = args
+            ? (typeof args.to === "string" ? args.to
+              : (typeof args.toElement === "string" ? args.toElement : null))
+            : null;
         // Start + target positions are captured at setup time (after
         // any earlier-slide motion has settled), both on the line A→B,
         // so the lerp between them stays collinear and the slider's own
         // re-projection in update() is a no-op.
         let sx = 0, sy = 0, sz = 0;   // start
-        let tx = 0, ty = 0, tz = 0;   // target = A + t·(B−A)
+        let tx = 0, ty = 0, tz = 0;   // target = A + factor·(B−A)
         const apply = (p: number) => {
             slider.x = sx + (tx - sx) * p;
             slider.y = sy + (ty - sy) * p;
@@ -74,9 +89,29 @@ export class PointSlideAnimation extends Animation {
                 sx = slider.x; sy = slider.y; sz = slider.z;
                 const A = (slider as any)._A as PointElement;
                 const B = (slider as any)._B as PointElement;
-                tx = A.x + (B.x - A.x) * to;
-                ty = A.y + (B.y - A.y) * to;
-                tz = A.z + (B.z - A.z) * to;
+                const segment = !!(slider as any)._segment;
+                const dx = B.x - A.x, dy = B.y - A.y, dz = B.z - A.z;
+                // factor along A→B that the slider will lerp to.
+                let factor: number;
+                if (toName != null) {
+                    // Resolve the target element and project it onto the line.
+                    const tgt = slate.lookupElement(toName) as PointElement;
+                    if (tgt == null || !(tgt instanceof PointElement)) {
+                        console.warn(`[geomlib] Point.slide: target "${toName}" is not a resolvable point — staying put`);
+                        tx = sx; ty = sy; tz = sz;
+                        return;
+                    }
+                    const denom = dx * dx + dy * dy + dz * dz;
+                    factor = denom > 1e-9
+                        ? ((tgt.x - A.x) * dx + (tgt.y - A.y) * dy + (tgt.z - A.z) * dz) / denom
+                        : 0;
+                    if (segment) factor = Math.max(0, Math.min(1, factor));
+                } else {
+                    factor = toNum != null ? toNum : 1;
+                }
+                tx = A.x + dx * factor;
+                ty = A.y + dy * factor;
+                tz = A.z + dz * factor;
             },
             tick: (progress) => { apply(progress); },
             finalise: () => {

--- a/tests/AnimationTest.ts
+++ b/tests/AnimationTest.ts
@@ -725,6 +725,74 @@ describe("point slide + polygon translate-aside (issues #95, #94)", () => {
             const anim = findAnimation(A.Point.slide)!;
             assert.notStrictEqual(A_free.constructor, anim.elementType);
         });
+
+        // #122 — slide to a target ELEMENT (resolved + projected at setup).
+        // A=(0,100), B=(200,100) (horizontal); E=(130,40) projects to x=130.
+        function targetSlate(segment = false): [Slate, PointElement] {
+            const slate = new Slate(createCanvas(400, 200));
+            slate.inTest = true;
+            toElements(slate, [
+                { construction: E.Point.free, name: "A", params: [0, 100] },
+                { construction: E.Point.free, name: "B", params: [200, 100] },
+                { construction: segment ? E.Point.lineSegmentSlider : E.Point.lineSlider,
+                  name: "D", params: ["A", "B", 40, 100] },
+                { construction: E.Point.free, name: "E", params: [130, 40] },
+            ]);
+            slate.elements.forEach(e => e.update());
+            return [slate, slate.lookupElement("D") as PointElement];
+        }
+
+        it("slides to a target element — projects it onto the line (#122)", () => {
+            const [slate, D] = targetSlate();
+            const steps = findAnimation(A.Point.slide)!.build(D, slate, { to: "E" });
+            steps[0].setup!();
+            steps[0].tick(0.5, 8, steps[0].durationMs);   // halfway 40→130
+            assert.ok(approx(D.x, 85), `mid x ${D.x}`);
+            steps[0].finalise();
+            assert.ok(approx(D.x, 130) && approx(D.y, 100), `landed (${D.x},${D.y})`);
+        });
+
+        it("accepts the explicit { toElement } form (#122)", () => {
+            const [slate, D] = targetSlate();
+            const steps = findAnimation(A.Point.slide)!.build(D, slate, { toElement: "E" });
+            steps[0].setup!(); steps[0].finalise();
+            assert.ok(approx(D.x, 130), `landed x ${D.x}`);
+        });
+
+        it("resolves the target at setup — tracks a point moved after build (#122)", () => {
+            const [slate, D] = targetSlate();
+            const Ept = slate.lookupElement("E") as PointElement;
+            const steps = findAnimation(A.Point.slide)!.build(D, slate, { to: "E" });
+            Ept.x = 170; slate.update();   // reader drags E after build
+            steps[0].setup!(); steps[0].finalise();
+            assert.ok(approx(D.x, 170), `tracked to x ${D.x}`);
+        });
+
+        it("clamps the projection to a segment slider's domain (#122)", () => {
+            const [slate, D] = targetSlate(true);   // lineSegmentSlider
+            const Ept = slate.lookupElement("E") as PointElement;
+            Ept.x = 300; slate.update();            // projects to factor 1.5 → clamp to B
+            const steps = findAnimation(A.Point.slide)!.build(D, slate, { to: "E" });
+            steps[0].setup!(); steps[0].finalise();
+            assert.ok(approx(D.x, 200), `clamped to B x ${D.x}`);
+        });
+
+        it("an infinite-line slider follows the projection past B (#122)", () => {
+            const [slate, D] = targetSlate(false);  // lineSlider (unbounded)
+            const Ept = slate.lookupElement("E") as PointElement;
+            Ept.x = 300; slate.update();
+            const steps = findAnimation(A.Point.slide)!.build(D, slate, { to: "E" });
+            steps[0].setup!(); steps[0].finalise();
+            assert.ok(approx(D.x, 300), `past B x ${D.x}`);
+        });
+
+        it("warns + stays put on an unresolvable target (#122)", () => {
+            const [slate, D] = targetSlate();
+            const x0 = D.x;
+            const steps = findAnimation(A.Point.slide)!.build(D, slate, { to: "Nonexistent" });
+            steps[0].setup!(); steps[0].finalise();
+            assert.ok(approx(D.x, x0), `stayed at ${D.x}`);
+        });
     });
 
     describe("A.Group.cloneAside", () => {

--- a/view/test/overview.html
+++ b/view/test/overview.html
@@ -63,6 +63,8 @@ individually.</p>
       <td>Bidirectional <code>geomlib:highlight</code> binding — prose ⇄ canvas hover/pin.</td><td>#108</td></tr>
   <tr><td><a href="deferred-point-reveal.html">deferred-point-reveal.html</a></td>
       <td>A deferred <code>Point.appear</code> target stays dark until its step; the label snaps in at full reveal.</td><td>#126</td></tr>
+  <tr><td><a href="slide-to-point.html">slide-to-point.html</a></td>
+      <td><code>A.Point.slide { to: "E" }</code> — a slider glides to a <b>derived point</b> (an intersection), resolved at runtime so it tracks E when the givens are dragged. I.20 Heron's "land on E".</td><td>#122</td></tr>
 </table>
 
 <h2>Responsive / 3D</h2>

--- a/view/test/slide-to-point.html
+++ b/view/test/slide-to-point.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Test View — A.Point.slide to a target point (#122)</title>
+<style>
+    body { font-family: sans-serif; color: #333; background: #fff; margin: 0; }
+    main { max-width: 44rem; margin: 0 auto; padding: 16px; }
+    canvas { background: #fff; border: 1px solid #eee; }
+    .note { background:#faf7ef; border:1px solid #e3d6c2; border-radius:6px; padding:10px 12px; font-size:.9rem; color:#555; }
+    kbd { background:#eee; border:1px solid #ccc; border-radius:3px; padding:0 4px; }
+    code { background:#f3f3f3; padding:0 3px; border-radius:3px; }
+</style>
+</head>
+<body>
+<main>
+<h2>Slider gliding to a derived point — <code>A.Point.slide { to: "E" }</code> (#122)</h2>
+<p class="note">
+<b>P</b> is a <code>lineSlider</code> on <b>CD</b>; <b>E</b> is the derived
+intersection of <b>AB</b> and <b>CD</b>. Press <kbd>p</kbd> to present,
+<kbd>→</kbd> to walk: P hunts along the line, then slides <b>to the element E</b>
+— resolved + projected at runtime, so it lands exactly on the intersection.
+The key test: <b>drag A, B, C, or D, then present again</b> — E moves, and P
+still lands on it (no hand-computed parameter to go stale). This is the I.20
+Heron "search → land on E" motion.
+</p>
+<canvas id="canvas_1" width="380" height="320" tabindex="0"></canvas>
+
+<script src="../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    const A = geomlib.A;
+    geomlib.init({
+        canvasid: "canvas_1",
+        background: "0,0,100",
+        title: "Point.slide → E",
+        initiallyHidden: ["E"],
+        elements: [
+            "C;point;free;60,70;black;black",
+            "D;point;free;330,260;black;black",
+            "CD;line;connect;C,D;0;0;black",
+            "A;point;free;70,255;black;black",
+            "B;point;free;345,95;black;black",
+            "AB;line;connect;A,B;0;0;808080",
+            "E;point;intersection;AB,CD;dc143c;dc143c",
+            "P;point;lineSlider;C,D,100,95;black;orange",
+        ],
+        slides: [
+            { text: "P slides along CD. E (hidden) is where AB crosses CD.",
+              visible: ["C","D","CD","A","B","AB","P"],
+              highlighted: ["P"] },
+            { text: "P hunts up and down the line, looking for the right spot…",
+              visible: ["C","D","CD","A","B","AB","P"],
+              highlighted: ["P"],
+              transition: { animations: [ { elem: "P", name: A.Point.slide, args: { to: 0.9 } } ] } },
+            { text: "…and lands exactly on E, the intersection — at runtime, so it tracks E however the givens are dragged.",
+              visible: ["C","D","CD","A","B","AB","P","E"],
+              highlighted: ["E","P"],
+              transition: { mode: "cascade", animations: [
+                  { elem: "P", name: A.Point.slide, args: { to: "E" } },
+                  { elem: "E", name: A.Point.appear } ] } },
+        ],
+    });
+</script>
+</main>
+</body>
+</html>


### PR DESCRIPTION
Closes #122.

## What

`A.Point.slide` now accepts an **element target** as an alternative to the numeric parameter:

```js
{ elem: "P", name: A.Point.slide, args: { to: "E" } }      // or { toElement: "E" }
```

At setup the named point is resolved via `lookupElement`, **projected onto the slider's line** (nearest point, clamped to a segment slider's domain), and the slider glides there. Because it resolves **at runtime**, the slider lands on a *derived* point — e.g. an `intersection` — and keeps tracking it after the reader drags the givens, instead of an author hand-computing a parameter that silently goes stale.

The numeric `{ to: number }` form is unchanged (additive, default-off). A non-resolvable / non-point name warns and stays put; a non-slider target still warns + falls through via the registry's `elementType` guard.

## Use case

I.20 Heron's minimum-distance slideshow: P hunts along CD, then `slide` to `E` (the reflection-optimal intersection) so it lands exactly on E however A/B/C/D are dragged.

## How

The projection reuses the slider's own `drag()` math — `factor = ((E−A)·(B−A)) / |B−A|²`, clamped to `[0,1]` for a `lineSegmentSlider` (`_segment`), free for an infinite `lineSlider`. Target = `A + factor·(B−A)`, captured in `setup()` so it tracks settled givens; the per-frame lerp stays collinear (the slider's `update()` re-projection is a no-op).

## Tests & demo

- **+6 unit** (311 total): projects a target onto the line; `{ toElement }` alias; **re-resolves at setup** (tracks a point moved after `build`); **clamps** to a segment slider's domain; an infinite slider follows the projection **past B**; unresolvable name → warn + stay put.
- **700 snapshot byte-identical** (additive).
- `doc/animations-reference.md` row updated. Demo: **`view/test/slide-to-point.html`** (validated headless — P lands exactly on AB∩CD, collinear residual 0).