### PR TITLE
Escape leaves the maximized view, one layer per press (#139)

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -527,8 +527,17 @@ and **not** on each slide advance, so a viewer dragging a point mid-walk
 isn't yanked back (#114); an `autoPlace` case slide still eases from the
 centred offset out to its layout with no jump. **Exiting presentation
 (`Esc`) leaves the walk but stays maximized**, keeping the viewer's
-manipulation (#115). Only the **minimize** control un-maximizes, and that
-is what restores the inline view + runs `reset()`.
+manipulation (#115). Un-maximizing is what restores the inline view +
+runs `reset()`.
+
+**`Esc` peels off one layer per press (#139, 0.14.0+).** In a slideshow the
+first press leaves the walk and stays maximized (#115, unchanged); the next
+press leaves the maximized view — equivalent to the **minimize** control, so
+it restores the inline view and runs `reset()`. On a maximized canvas with no
+slideshow running, one press exits. On an inline canvas `Esc` does nothing.
+The handler is bound on `document` while maximized, so it fires whether focus
+sits on the canvas or on a control button (unlike the canvas-scoped
+`r`/`space`, `m`, `p` shortcuts).
 
 ### Highlight z-order (#140, 0.14.0+)
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -309,7 +309,8 @@ reset/maximize button strip grows a play-triangle button. Pressing it
 (or the `p` keyboard shortcut) maximises the canvas
 and floats a soft white caption panel at the bottom of the viewport
 with prev / counter / next / exit controls; arrow keys and `Esc` do
-what you'd expect. Caption `{NAME}` tokens become clickable bold-italic
+what you'd expect — `Esc` peels off one layer of takeover per press
+(out of the walk, then out of the maximized view; #115 / #139). Caption `{NAME}` tokens become clickable bold-italic
 spans tied to the matching slate element — hover / tap flips
 `element.emphasisAmount` so the element pops with a thicker stroke;
 tapping pins a single sticky reference at a time. The overlay is
@@ -699,5 +700,5 @@ ordered list. Each element entry can be a structured object —
 
 `init()` also calls `createControls()` from `src/SlateControls.ts`,
 which wraps the canvas and adds the reset / maximize button overlay
-plus keyboard shortcuts (`r`/`space`, `m`). See
+plus keyboard shortcuts (`r`/`space`, `m`, and `Esc` while maximized). See
 [api.md § SlateControls](api.md#slatecontrols-ui-overlay).

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -165,6 +165,7 @@ With the page loaded:
 | Drag a non-free point (the line, a circle) | The diagram rotates/scales around the pivot **C**. |
 | Press **r** or **space** | Reset to the initial configuration. |
 | Press **m** | Maximize the canvas to fill the viewport. |
+| Press **Esc** | Leave the maximized view (in a slideshow, the first press leaves the walk and the next leaves the maximized view). |
 
 The reset/maximize controls also appear as small icon buttons at the
 top-right of the canvas — hidden by default, fading in on hover or when

--- a/src/SlateControls.ts
+++ b/src/SlateControls.ts
@@ -6,6 +6,8 @@
 |      r / space  → reset                                               |
 |      m          → maximize/minimize                                   |
 |      p          → present (when the slate has slides)                 |
+|      Escape     → leave presentation, then leave the maximized view   |
+|                   (one layer per press; see escapeAction)             |
 +----------------------------------------------------------------------*/
 
 import {Slate} from "./Slate";
@@ -68,6 +70,18 @@ export function trackWindowResize(target: IResizeTarget, callback: () => void): 
     return () => target.removeEventListener("resize", handler);
 }
 
+// #139 — what one Escape press should do. Escape peels off ONE layer of
+// takeover at a time: a slideshow exits to the maximized view it opened in
+// (#115 — the viewer keeps their manipulation), and a second press leaves
+// the maximized view. Pure so it is testable without a DOM.
+export type EscapeAction = "exitPresent" | "minimize" | "none";
+
+export function escapeAction(state: {presenting: boolean; maximized: boolean}): EscapeAction {
+    if (state.presenting) return "exitPresent";
+    if (state.maximized) return "minimize";
+    return "none";
+}
+
 export function createControls(slate: Slate, canvas: HTMLCanvasElement, config: IInitConfig): void {
     // Skip in headless/test environments
     if (!canvas.parentElement) return;
@@ -96,6 +110,7 @@ class SlateControls {
         canvasAttrHeight: number;
     } = null;
     private _stopTrackingResize: (() => void) | null = null;
+    private _maximizedOnKey: ((e: KeyboardEvent) => void) | null = null;
 
     // Presentation-mode (slideshow) state. Caption + nav float over
     // the maximized canvas; no fullscreen overlay, no background takeover.
@@ -291,8 +306,46 @@ class SlateControls {
         this._maximized = true;
         this.resizeAndRedraw();
         this.updateMaximizeIcon();
+        this.bindMaximizedKeys();
         // Window-resize tracking is persistent (set up in init), so the
         // maximized 100vw × 100vh canvas already re-syncs on viewport change.
+    }
+
+    // #139 — Escape while the canvas owns the viewport. Bound on `document`,
+    // not the canvas: the r/m/p shortcuts only fire when the canvas itself
+    // has focus, and maximizing by CLICKING the control leaves focus on the
+    // button, so a canvas-bound Escape would never fire.
+    //
+    // This handler is the single owner of Escape (bindPresentationKeys
+    // deliberately does not bind it). Two document-level handlers both
+    // matching Escape would fire on one keypress and blow through
+    // presentation AND maximize at once. onPresent() maximizes first, so
+    // presenting implies maximized — this handler is always bound while a
+    // slideshow is running, and escapeAction() decides which layer to peel.
+    private bindMaximizedKeys(): void {
+        if (this._maximizedOnKey) return;
+        const handler = (e: KeyboardEvent) => {
+            if (e.key !== "Escape") return;
+            switch (escapeAction({presenting: this._presenting, maximized: this._maximized})) {
+                case "exitPresent":
+                    e.preventDefault();
+                    this.exitPresent();
+                    break;
+                case "minimize":
+                    e.preventDefault();
+                    this.minimize();
+                    break;
+            }
+        };
+        this._maximizedOnKey = handler;
+        document.addEventListener("keydown", handler);
+    }
+
+    private unbindMaximizedKeys(): void {
+        if (this._maximizedOnKey) {
+            document.removeEventListener("keydown", this._maximizedOnKey);
+            this._maximizedOnKey = null;
+        }
     }
 
     private minimize(): void {
@@ -323,6 +376,7 @@ class SlateControls {
         // Clear the flag BEFORE resizeAndRedraw so its centring pass (#107)
         // restores the figure to its authored position.
         this._maximized = false;
+        this.unbindMaximizedKeys();
         this.resizeAndRedraw();
         this._savedStyles = null;
         this.updateMaximizeIcon();
@@ -561,10 +615,10 @@ class SlateControls {
                     e.preventDefault();
                     this.showSlide(this._presentationIndex + 1);
                     break;
-                case "Escape":
-                    e.preventDefault();
-                    this.exitPresent();
-                    break;
+                // Escape is NOT bound here — the maximized-state handler
+                // (bindMaximizedKeys, #139) owns it and routes the first
+                // press to exitPresent(). Binding it in both places would
+                // exit presentation and minimize on a single keypress.
             }
         };
         this._presentationOnKey = handler;

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -5,7 +5,7 @@ import {E, IConstructionInfo, init, slates, revealNoscriptFallback, parseParam} 
 import {PlaneSlider} from "../src/elements/point/PlaneSlider";
 import {PointElement} from "../src/elements/point/PointElement";
 import {GeomElement} from "../src/elements/GeomElement";
-import {trackWindowResize} from "../src/SlateControls";
+import {trackWindowResize, escapeAction} from "../src/SlateControls";
 import {createCanvas} from "canvas";
 import {almostEqual, toElements} from "./shared/testHelpers";
 import {parseColor} from "../src/Colors";
@@ -699,6 +699,46 @@ describe("slate", () => {
             assert.equal(removed[0].type, "resize");
             assert.equal(removed[0].fn, attached[0].fn,
                 "teardown must pass the original handler so removeEventListener actually unregisters it");
+        });
+    });
+
+    // #139 — Escape peels off ONE layer of viewport takeover per press.
+    // Pure routing decision, so no DOM is needed to pin the semantics.
+    describe("escapeAction", () => {
+        it("exits presentation first, keeping the maximized view (#115)", () => {
+            assert.equal(
+                escapeAction({presenting: true, maximized: true}), "exitPresent",
+                "the first Escape in a slideshow must leave the walk, NOT un-maximize — " +
+                "#115 keeps the viewer's manipulation until they leave the maximized view");
+        });
+
+        it("minimizes on the next press, once the walk is over", () => {
+            assert.equal(
+                escapeAction({presenting: false, maximized: true}), "minimize",
+                "Escape in the maximized view (no slideshow running) should leave it");
+        });
+
+        it("does nothing for an inline canvas", () => {
+            assert.equal(
+                escapeAction({presenting: false, maximized: false}), "none",
+                "Escape must not reset or otherwise disturb a diagram sitting inline");
+        });
+
+        it("takes two presses to leave a slideshow entirely", () => {
+            // Walk the state machine the way the handler drives it: each press
+            // performs its action, which flips the corresponding flag.
+            let presenting = true, maximized = true;
+            const press = () => {
+                const action = escapeAction({presenting, maximized});
+                if (action === "exitPresent") presenting = false;
+                if (action === "minimize") maximized = false;
+                return action;
+            };
+            assert.equal(press(), "exitPresent");
+            assert.ok(maximized, "still maximized after leaving the walk");
+            assert.equal(press(), "minimize");
+            assert.ok(!maximized && !presenting, "fully out after the second press");
+            assert.equal(press(), "none", "further presses are inert");
         });
     });
 

--- a/view/test/escape-exit.html
+++ b/view/test/escape-exit.html
@@ -1,0 +1,56 @@
+<html>
+<head><title>Test View — #139 Escape leaves the maximized view</title></head>
+<body>
+<h3 style="font-family: sans-serif;">Escape leaves the maximized view (#139)</h3>
+<p style="font-family: sans-serif; max-width: 680px; color: #444;">
+<b>Escape peels off one layer of takeover per press.</b>
+</p>
+<ol style="font-family: sans-serif; max-width: 680px; color: #444;">
+<li>Click <b>maximize</b> (top-right of the canvas), then press <b>Esc</b> —
+    the canvas returns to its inline size and resets. Before #139 nothing
+    happened here and you had to find the minimize control or press
+    <b>m</b>.</li>
+<li>Maximize again <b>by clicking the button</b> (so keyboard focus is on the
+    button, not the canvas) and press <b>Esc</b>. It still exits — the
+    handler is bound on <code>document</code>, unlike the canvas-scoped
+    r/m/p shortcuts.</li>
+<li>Press <b>p</b> to present, walk a slide or two, drag point <b>D</b>, then
+    press <b>Esc</b> <u>once</u>: you leave the walk but <b>stay maximized</b>
+    with your drag intact (#115). Press <b>Esc</b> again: now you leave the
+    maximized view and the figure resets.</li>
+<li>Press <b>Esc</b> on the inline canvas — nothing should happen (no reset,
+    no jump).</li>
+</ol>
+<canvas id="canvasId" style="width:520px; height: 360px;" tabindex="0"></canvas>
+<script src="../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E, A = geomlib.A;
+    geomlib.init({
+        background: '#ffe9cd',
+        title: "escape-exit",
+        canvasid: "canvasId",
+        elements: [
+            { name: "A", construction: E.Point.free, params: [120, 90] },
+            { name: "B", construction: E.Point.free, params: [220, 280] },
+            { name: "C", construction: E.Point.free, params: [90, 280] },
+            { name: "ABC", construction: E.Polygon.triangle, params: ["A", "B", "C"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black", faceColor: "rgba(120,180,210,0.25)" },
+            { name: "D", construction: E.Point.lineSlider, params: ["A", "B", 170, 185],
+              vertexColor: "orange", nameColor: "black" },
+            { name: "CD", construction: E.Line.connect, params: ["C", "D"],
+              nameColor: 0, vertexColor: 0, edgeColor: "darkGray" },
+        ],
+        slides: [
+            { text: "Triangle {ABC}, with {D} on {AB}.", visible: ["ABC", "D"] },
+            { text: "Join {CD} — now drag {D}, then press Esc once.", visible: ["ABC", "D", "CD"],
+              highlighted: ["CD"],
+              transition: { animations: [
+                  { elem: "CD", name: A.Line.straightEdgeConnect },
+              ] } },
+            { text: "You should still be maximized, with your drag kept. Esc again to leave.",
+              visible: ["ABC", "D", "CD"] },
+        ],
+    });
+</script>
+</body>
+</html>

--- a/view/test/overview.html
+++ b/view/test/overview.html
@@ -71,6 +71,8 @@ individually.</p>
       <td>Off vs on, two ways: a <b>coincident</b> segment declared over the highlighted one (which buried it entirely), and the subtler <b>crossing</b> case. Promotion also holds through an animation and its fade-out.</td><td>#140</td></tr>
   <tr><td><a href="present-centring-bounds.html">present-centring-bounds.html</a></td>
       <td>Present-centring measures only elements that <b>paint</b>. Invisible zero-colour track anchors 1000px off-canvas no longer define the frame — the shape that rendered I.35 / I.42 / I.43 blank on present.</td><td>#138</td></tr>
+  <tr><td><a href="escape-exit.html">escape-exit.html</a></td>
+      <td><b>Escape</b> peels off one layer of takeover per press: out of the slideshow (staying maximized, #115), then out of the maximized view. Works with focus on the control button, not just the canvas.</td><td>#139</td></tr>
 </table>
 
 <h2>Responsive / 3D</h2>


### PR DESCRIPTION
Closes #139.

Pressing `Escape` while a diagram was in the maximized view did nothing. The
only ways out were the minimize control or the `m` shortcut — neither of which
a reader has reason to guess after the canvas has taken over their whole
viewport (`position: fixed`, `100vw × 100vh`, `z-index: 9999`).

## The change — escalating Escape

One press peels off one layer of takeover:

| State | `Escape` | Result |
|---|---|---|
| Presenting (implies maximized) | 1st press | Leave presentation, **stay maximized** — #115 unchanged |
| Maximized, not presenting | next press | Minimize: restore the inline view + `reset()` |
| Inline | — | No-op |

So a slideshow takes two presses to leave entirely, and a plain maximized
diagram takes one. **#115 is preserved exactly**: exiting the walk still keeps
the viewer's manipulation, and un-maximizing is still what resets.

## Three decisions worth reviewing

**Bound on `document`, not the canvas.** The `r`/`space`, `m`, `p` shortcuts
live on the canvas element, so they only fire when the canvas has focus. If the
viewer maximizes by *clicking* the control, focus is on the button — a
canvas-bound `Escape` would silently never fire. `bindMaximizedKeys` is
attached in `maximize()` and removed in `minimize()`, mirroring how
`bindPresentationKeys` already works.

**`Escape` now has a single owner.** The `Escape` case was removed from
`bindPresentationKeys` (with a comment saying why). Both handlers sit on
`document`, so binding `Escape` in both would fire both on one keypress and
blow through presentation *and* maximize at once — the exact #115 regression to
avoid. `onPresent()` always maximizes first, so presenting implies maximized
and the maximized handler is always bound while a slideshow runs.

**The routing is a pure exported function**, following the `trackWindowResize`
precedent:

```ts
escapeAction({presenting, maximized}) → "exitPresent" | "minimize" | "none"
```

`SlateControls`' DOM paths have no test coverage (the suites use node-canvas,
no jsdom), so this keeps the semantics unit-testable without pulling in a DOM.
Adding jsdom for this felt disproportionate — happy to revisit if you'd rather
have real coverage on the binding itself.

## Verification

- `tsc --noEmit` clean.
- **700 snapshot + 319 unit passing**, 0 errors. Four new unit tests, including
  one that walks the two-press state machine and asserts you are *still
  maximized* after the first press (the #115 guard).
- Docs: `SlateControls.ts` header block, `api.md` (a #139 paragraph under
  maximized-view recenter), `architecture.md` ×2, and the `quickstart.md`
  shortcut table.
- `view/test/escape-exit.html` walks four checks by hand, including the
  click-the-button focus case and confirming a mid-walk drag survives the first
  `Escape`.

Branched off `main` at `9825ab9`. Test counts above predate #140/PR #143, which
adds scenes on its own branch.
