### PR TITLE
Present-centring measures only elements that paint (#138)

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -495,8 +495,30 @@ render path is unchanged. **Consumer note:** scale-to-fit only engages when
 the page lets the canvas shrink, i.e. `canvas { max-width: 100%; height: auto }`.
 
 `visibleBounds()` is the bbox of the *visible* named figure; `figureBounds()`
-(0.11.0+) is the bbox of *all* named elements regardless of visibility — a
-stable centre that doesn't drift as a presentation reveals/hides elements.
+(0.11.0+) is the bbox of *all* named elements regardless of visibility.
+
+**Centring bounds (#138, 0.14.0+).** Neither of those is what the
+maximized / presentation centring should measure. Deck figures carry
+construction helpers that exist only to define a direction or a slider's
+track — a "point at infinity" aim, the two anchors a `lineSlider` runs
+between — authored with zero colours so they draw nothing. They are still
+`visible`, so `visibleBounds()` keeps them, and an off-screen helper then
+inflates the box until the centre transform pushes the real geometry off
+canvas (a blank slideshow; hit on I.35, I.42 and I.43).
+
+`captureCentringBounds()` measures only elements that actually **paint**,
+and stores the result; `centringBounds` reads it back and
+`clearCentringBounds()` drops it. The test is per element type, because a
+colour slot an element never uses tells you nothing — `PointElement`'s
+`drawEdge`/`drawFace` are no-ops, so a point's `edgeColor` (which defaults
+to black when the author omits the field) is not ink. It falls back to the
+all-elements box if nothing paints at all.
+
+The box is captured **once** on entering the maximized view rather than
+recomputed: a resize mid-walk must re-centre on the frame the walk started
+in, not on whatever the current slide reveals, and `cloneAside`'s centre
+phase (#99) reads the same stored box so it eases to exactly where the
+figure already sits.
 
 **Maximized-view recenter (#107, #114, #115).** When the canvas is
 maximized — via the control or by entering presentation — the figure is

--- a/src/Slate.ts
+++ b/src/Slate.ts
@@ -102,6 +102,12 @@ export class Slate {
     // F shrinks the figure to fit a narrow display (#71). Defaults
     // F=1, T=(0,0) are a no-op, so every existing render path — and the
     // headless snapshot path — is bit-for-bit unchanged.
+    // #138 — the bounding box the maximized / presentation centring was
+    // computed from. Captured ONCE on entering the maximized view (#114
+    // centres once, not per slide) and cleared on leaving, so the centre
+    // can't drift as slides reveal and hide elements, and so cloneAside's
+    // centre phase (#99) eases to exactly the same target.
+    private _centringBounds : { minX: number, maxX: number, minY: number, maxY: number } | null = null;
     private _viewOffsetX : number = 0;
     private _viewOffsetY : number = 0;
     private _viewScale : number = 1;
@@ -445,7 +451,54 @@ export class Slate {
         return this._bounds(false);
     }
 
-    private _bounds(visibleOnly: boolean) : { minX: number, maxX: number, minY: number, maxY: number } | null {
+    // #138 — does this element put any ink on the canvas?
+    //
+    // Deck figures carry construction helpers that exist only to define a
+    // direction or a slider's track — a "point at infinity" aim, the two
+    // anchors a lineSlider runs between — authored with zero colours so they
+    // draw nothing. They are still `visible`, so a visibility filter does NOT
+    // exclude them; only asking what actually paints does.
+    //
+    // The test is per type because a colour slot an element never uses tells
+    // us nothing: PointElement.drawEdge / drawFace are no-ops, so a point's
+    // edgeColor (which defaults to black when the author omits the field)
+    // must not count as ink — that default is exactly what made these helpers
+    // look paintable.
+    private _paintsInk(elem: GeomElement) : boolean {
+        if (!elem.visible) return false;
+        if (elem.nameColor != null) return true;
+        if (elem instanceof PointElement) return elem.vertexColor != null;
+        return elem.edgeColor != null || elem.faceColor != null;
+    }
+
+    // Bounding box to centre the figure on in the maximized / presentation
+    // view (#107). Measures only elements that actually paint, so an
+    // off-screen zero-colour helper can't inflate the box and translate the
+    // real geometry off-canvas — the #138 blank-slideshow bug, hit on I.35,
+    // I.42 and I.43.
+    //
+    // Captured once per maximized session rather than recomputed: the result
+    // must not move as slides change visibility, and cloneAside reads the
+    // same captured box so its centre phase lands where the base centring
+    // already is. Falls back to the all-elements bounds if nothing paints at
+    // all (a figure built entirely from helpers), so the caller always gets
+    // the same shape of answer as before.
+    captureCentringBounds() : { minX: number, maxX: number, minY: number, maxY: number } | null {
+        const inked = this._bounds(false, (e) => this._paintsInk(e));
+        this._centringBounds = inked != null ? inked : this._bounds(false);
+        return this._centringBounds;
+    }
+
+    get centringBounds() : { minX: number, maxX: number, minY: number, maxY: number } | null {
+        return this._centringBounds;
+    }
+
+    clearCentringBounds() : void {
+        this._centringBounds = null;
+    }
+
+    private _bounds(visibleOnly: boolean,
+                    accept?: (e: GeomElement) => boolean) : { minX: number, maxX: number, minY: number, maxY: number } | null {
         let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
         const add = (x: number, y: number) => {
             if (x < minX) minX = x; if (x > maxX) maxX = x;
@@ -454,6 +507,7 @@ export class Slate {
         for (let elem of this._elements) {
             if (elem.name == null || elem.name.startsWith("screen")) continue;
             if (visibleOnly && !elem.visible) continue;
+            if (accept != null && !accept(elem)) continue;
             if (elem instanceof PolygonElement) {
                 for (let v of elem.V) add(v.x, v.y);
             } else if (elem instanceof CircleElement) {

--- a/src/SlateControls.ts
+++ b/src/SlateControls.ts
@@ -355,8 +355,19 @@ class SlateControls {
     // the window changes. figureBounds() is in logical coords, so the centre
     // target is computed in display px through the fit-scale F (#71).
     private _applyCentring(): void {
-        if (!this._maximized) { this._slate.clearViewOffset(); return; }
-        const b = this._slate.figureBounds();
+        if (!this._maximized) {
+            this._slate.clearViewOffset();
+            this._slate.clearCentringBounds();
+            return;
+        }
+        // #138 — measure once per maximized session, from elements that
+        // actually paint. Once, because a resize mid-walk must re-centre on
+        // the same box the walk started from rather than on whatever the
+        // current slide happens to reveal; painting elements only, because a
+        // zero-colour off-screen helper would otherwise define the frame and
+        // shove the figure off-canvas (I.35, I.42, I.43 all hit this).
+        const b = this._slate.centringBounds != null
+            ? this._slate.centringBounds : this._slate.captureCentringBounds();
         if (b == null) { this._slate.clearViewOffset(); return; }
         const cx = (b.minX + b.maxX) / 2, cy = (b.minY + b.maxY) / 2;
         const F = this._slate.viewScale;
@@ -393,7 +404,10 @@ class SlateControls {
         if (!this._maximized) this.maximize();
         // #114 — centre ONCE on entering presentation (covers the case
         // where we were already maximized, so maximize() didn't run). Slide
-        // advances no longer re-centre.
+        // advances no longer re-centre. #138 — drop any box captured by an
+        // earlier plain maximize so present-enter measures the figure as it
+        // stands now.
+        this._slate.clearCentringBounds();
         this._applyCentring();
         this.buildPresentationOverlay();
         this.bindPresentationKeys();

--- a/src/elements/group/GroupAnimations.ts
+++ b/src/elements/group/GroupAnimations.ts
@@ -271,10 +271,14 @@ export class GroupCloneAsideAnimation extends Animation {
                 baseOffX = slate.viewOffsetX;
                 baseOffY = slate.viewOffsetY;
 
-                // Centre target from the real (restored) figure. Use the
-                // visibility-independent figure bounds so it matches the
-                // #107 base-centring exactly (no shift when already centred).
-                const fb = slate.figureBounds();
+                // Centre target from the real (restored) figure. Read the
+                // box the #107 base-centring was computed from so this lands
+                // exactly where the figure already sits (no shift when
+                // already centred). #138 — that is now the captured
+                // painting-elements box; fall back to figureBounds() when
+                // nothing captured it (not maximized / no presentation).
+                const fb = slate.centringBounds != null
+                    ? slate.centringBounds : slate.figureBounds();
                 if (fb == null) return;
                 const figW = fb.maxX - fb.minX, figH = fb.maxY - fb.minY;
                 const figCx = (fb.minX + fb.maxX) / 2;

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -1,13 +1,14 @@
 import "mocha";
 import * as assert from "assert";
 import {Slate, isPromoted, promotedDrawOrder} from "../src/Slate";
-import {E, IConstructionInfo, init, slates, revealNoscriptFallback} from "../src/index";
+import {E, IConstructionInfo, init, slates, revealNoscriptFallback, parseParam} from "../src/index";
 import {PlaneSlider} from "../src/elements/point/PlaneSlider";
 import {PointElement} from "../src/elements/point/PointElement";
 import {GeomElement} from "../src/elements/GeomElement";
 import {trackWindowResize} from "../src/SlateControls";
 import {createCanvas} from "canvas";
 import {almostEqual, toElements} from "./shared/testHelpers";
+import {parseColor} from "../src/Colors";
 import {
     buildPivotScene,
     buildScene3d,
@@ -183,6 +184,151 @@ describe("slate", () => {
             assert.ok(slate.highlightOnTop, "#140 promotion is on by default");
             slate.highlightOnTop = false;
             assert.ok(!slate.highlightOnTop);
+        });
+    });
+
+    // #138 — a figure's centring box must ignore construction helpers that
+    // paint nothing. Hit on three decks (I.35, I.42, I.43): an off-screen
+    // zero-colour helper inflated the box, present-centring translated the
+    // real geometry off-canvas, and the slideshow rendered blank.
+    describe("centringBounds (#138)", () => {
+
+        // The I.42 shape: two invisible anchors defining the track two
+        // sliders run along, plus the triangle the reader actually sees.
+        // Zero colours (";0;0") make the anchors paint nothing — but they
+        // are still `visible`, which is the whole point of the bug.
+        function anchoredScene(anchorX: number): Slate {
+            let slate = new Slate(createCanvas(340, 240));
+            slate.inTest = true;
+            const specs = [
+                `B0;point;free;${-anchorX},180;0;0`,
+                `B3;point;free;${anchorX},180;0;0`,
+                "B;point;lineSlider;B0,B3,90,0",
+                "C;point;lineSlider;B0,B3,210,0",
+                "A;point;free;120,30",
+                "AB;line;connect;A,B",
+            ];
+            for (const spec of specs) {
+                const i = parseParam(spec);
+                const el = slate.createElement(i.construction, i.params, i.name);
+                // Mirror what init() does with the colour fields — note
+                // parseParam yields the STRING "0", and parseColor maps that
+                // to null (paints nothing); an omitted field takes the
+                // default, which for edgeColor is black even on a point.
+                el.nameColor = parseColor(i.nameColor, "black", "white");
+                el.vertexColor = parseColor(i.vertexColor, "red", "white");
+                el.edgeColor = parseColor(i.edgeColor, "black", "white");
+            }
+            slate.update();
+            return slate;
+        }
+
+        it("excludes zero-colour helpers that a visibility filter would keep", () => {
+            const slate = anchoredScene(1000);
+
+            // The bug, stated as a test: `visible` is TRUE for these helpers,
+            // so _bounds(true) — the fix originally proposed on the ticket —
+            // would NOT have excluded them.
+            const B0 = slate.lookupElement("B0");
+            assert.ok(B0.visible,
+                "a zero-colour helper is still `visible`; only asking what PAINTS excludes it");
+            assert.deepEqual(slate.visibleBounds(), slate.figureBounds(),
+                "visibleBounds and figureBounds agree here — a visibility filter is no fix");
+
+            const b = slate.captureCentringBounds();
+            assert.ok(b.minX > -1000 && b.maxX < 1000,
+                `centring box should exclude the ±1000 anchors, got ${JSON.stringify(b)}`);
+        });
+
+        it("centres on the real geometry, not the helper span", () => {
+            const slate = anchoredScene(1000);
+            const b = slate.captureCentringBounds();
+            const cx = (b.minX + b.maxX) / 2;
+            // Painted geometry spans x = 90..210 (the two sliders) plus A at
+            // 120, so the centre belongs near 150 — not near 0, which is what
+            // the symmetric ±1000 anchors average to.
+            assert.ok(cx > 90 && cx < 220,
+                `centre should sit inside the drawn figure, got ${cx}`);
+        });
+
+        it("is unmoved by how far off-screen the helpers sit", () => {
+            // I.35 failed with a one-sided helper at x=10000; I.42 with a
+            // symmetric ±1000 pair. Different numbers, same cause — so the
+            // centring box must not depend on them at all.
+            const near = anchoredScene(1000).captureCentringBounds();
+            const far = anchoredScene(100000).captureCentringBounds();
+            // Compared with a tolerance, not exactly: a lineSlider
+            // parameterised across a ±100000 track loses a little precision
+            // (89.99999999998545 rather than 90). That is the slider's
+            // arithmetic, not the centring box — what matters is that the
+            // helpers' distance doesn't move the frame.
+            almostEqual(far.minX, near.minX, 1e-6);
+            almostEqual(far.maxX, near.maxX, 1e-6);
+            almostEqual(far.minY, near.minY, 1e-6);
+            almostEqual(far.maxY, near.maxY, 1e-6);
+        });
+
+        it("still counts an element that paints only a label", () => {
+            let slate = new Slate(createCanvas(200, 200));
+            slate.inTest = true;
+            const i = parseParam("P;point;free;150,150;0;0");
+            const el = slate.createElement(i.construction, i.params, i.name);
+            el.nameColor = "black";     // labelled but no dot — it shows
+            el.vertexColor = null;
+            el.edgeColor = "black";     // irrelevant to a point; must not count
+            const j = parseParam("Q;point;free;10,10");
+            const q = slate.createElement(j.construction, j.params, j.name);
+            q.nameColor = "black"; q.vertexColor = "red";
+            slate.update();
+
+            const b = slate.captureCentringBounds();
+            assert.equal(b.maxX, 150, "a label-only point is visible ink and must count");
+        });
+
+        it("ignores an element hidden by initiallyHidden / a slide", () => {
+            let slate = new Slate(createCanvas(200, 200));
+            slate.inTest = true;
+            for (const spec of ["A;point;free;10,10", "Z;point;free;900,900"]) {
+                const i = parseParam(spec);
+                const el = slate.createElement(i.construction, i.params, i.name);
+                el.nameColor = "black"; el.vertexColor = "red";
+            }
+            slate.lookupElement("Z").visible = false;
+            slate.update();
+
+            const b = slate.captureCentringBounds();
+            assert.ok(b.maxX < 900, "a hidden element paints nothing, so it must not frame the view");
+        });
+
+        it("falls back to the all-elements box when nothing paints", () => {
+            let slate = new Slate(createCanvas(200, 200));
+            slate.inTest = true;
+            const i = parseParam("H;point;free;40,50;0;0");
+            const el = slate.createElement(i.construction, i.params, i.name);
+            el.nameColor = null; el.vertexColor = null;
+            el.edgeColor = "black";     // the point default; still no ink
+            slate.update();
+
+            const b = slate.captureCentringBounds();
+            assert.ok(b != null, "a figure of pure helpers still gets a box rather than null");
+            assert.equal(b.minX, 40);
+        });
+
+        it("caches the box and clears it on demand", () => {
+            const slate = anchoredScene(1000);
+            assert.equal(slate.centringBounds, null, "nothing captured yet");
+            const first = slate.captureCentringBounds();
+            assert.deepEqual(slate.centringBounds, first, "captured box is readable");
+
+            // Moving a point must NOT change the already-captured box: the
+            // centre is fixed on entering the maximized view (#114) so a
+            // resize mid-walk re-centres on the same frame the walk began in.
+            (slate.lookupElement("A") as PointElement).x = 300;
+            slate.update();
+            assert.deepEqual(slate.centringBounds, first, "captured box stays put until cleared");
+
+            slate.clearCentringBounds();
+            assert.equal(slate.centringBounds, null);
         });
     });
 

--- a/view/test/overview.html
+++ b/view/test/overview.html
@@ -69,6 +69,8 @@ individually.</p>
       <td><code>A.Point.slide { to: "E" }</code> — a slider glides to a <b>derived point</b> (an intersection), resolved at runtime so it tracks E when the givens are dragged. I.20 Heron's "land on E".</td><td>#122</td></tr>
   <tr><td><a href="highlight-on-top.html">highlight-on-top.html</a></td>
       <td>Off vs on, two ways: a <b>coincident</b> segment declared over the highlighted one (which buried it entirely), and the subtler <b>crossing</b> case. Promotion also holds through an animation and its fade-out.</td><td>#140</td></tr>
+  <tr><td><a href="present-centring-bounds.html">present-centring-bounds.html</a></td>
+      <td>Present-centring measures only elements that <b>paint</b>. Invisible zero-colour track anchors 1000px off-canvas no longer define the frame — the shape that rendered I.35 / I.42 / I.43 blank on present.</td><td>#138</td></tr>
 </table>
 
 <h2>Responsive / 3D</h2>

--- a/view/test/present-centring-bounds.html
+++ b/view/test/present-centring-bounds.html
@@ -1,0 +1,66 @@
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test View — #138 present-centring ignores unpainted helpers</title>
+</head>
+<body>
+<h3 style="font-family: sans-serif;">Present-centring measures what paints (#138)</h3>
+<p style="font-family: sans-serif; max-width: 720px; color: #444;">
+Both figures carry two <b>invisible anchors</b> at <code>x = &plusmn;1000</code>
+that define the track <b>B</b> and <b>C</b> slide along — the shape that blanked
+the slideshow on I.35, I.42 and I.43. They are authored with zero colours, so
+they paint nothing, but they are still <code>visible</code>: a visibility filter
+does not exclude them, only asking what actually puts ink on the canvas does.
+</p>
+<p style="font-family: sans-serif; max-width: 720px; color: #444;">
+<b>At rest both look fine</b> — no centre transform is applied. Press <b>p</b>
+(or maximize) to see the difference: before this fix the centre landed at
+x&nbsp;=&nbsp;0, translating the triangle off the canvas and leaving the caption
+floating over an empty figure. Now the centre is taken from the drawn geometry.
+</p>
+<p style="font-family: sans-serif; max-width: 720px; color: #666;">
+Drag <b>B</b> or <b>C</b> along the base, then resize the window mid-walk: the
+figure re-centres on the frame the walk <i>started</i> in, not on whatever the
+current slide happens to reveal (#114 centres once).
+</p>
+
+<canvas id="canvasId" style="width:340px; height:240px;" tabindex="0"></canvas>
+
+<script src="../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E, A = geomlib.A;
+    geomlib.init({
+        background: '35,19,100',
+        title: "present-centring",
+        canvasid: "canvasId",
+        elements: [
+            // Invisible track anchors — zero colours, far off-canvas. This is
+            // the I.42 shape (symmetric); I.35's was one-sided at x = 10000.
+            { name: "B0", construction: E.Point.free, params: [-1000, 180],
+              nameColor: 0, vertexColor: 0 },
+            { name: "B3", construction: E.Point.free, params: [1000, 180],
+              nameColor: 0, vertexColor: 0 },
+            { name: "B", construction: E.Point.lineSlider, params: ["B0", "B3", 90, 0] },
+            { name: "C", construction: E.Point.lineSlider, params: ["B0", "B3", 210, 0] },
+            { name: "A", construction: E.Point.free, params: [120, 30] },
+            { name: "AB", construction: E.Line.connect, params: ["A", "B"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black" },
+            { name: "AC", construction: E.Line.connect, params: ["A", "C"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black" },
+            { name: "BC", construction: E.Line.connect, params: ["B", "C"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black" },
+            { name: "ABC", construction: E.Polygon.triangle, params: ["A", "B", "C"],
+              nameColor: 0, vertexColor: 0, edgeColor: 0, faceColor: "rgba(120,180,210,0.35)" },
+        ],
+        slides: [
+            { text: "Triangle {ABC} on the base {BC}. The whole figure should be centred and visible.",
+              visible: ["ABC", "AB", "AC", "BC"] },
+            { text: "Both {B} and {C} slide along a track defined by anchors 1000px off-canvas.",
+              visible: ["ABC", "AB", "AC", "BC"], highlighted: ["BC"] },
+            { text: "Those anchors paint nothing, so they no longer define the frame.",
+              visible: ["ABC", "AB", "AC", "BC"], highlighted: ["ABC"] },
+        ],
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Closes #138.

Entering presentation centres the figure on its bounding box. That box was
measured over **every** element, so an off-screen construction helper inflated
it and the centre transform translated the real geometry off canvas — the
slideshow rendered blank while the resting figure looked perfect (at rest no
centre transform is applied). Hit on **three decks: I.35, I.42 and I.43**.

## The ticket's proposed fix would not have worked

The issue suggested switching `figureBounds()` (`_bounds(false)`) to
`_bounds(true)`, i.e. filtering on `visible`. Checking the actual decks first
showed that would have been a no-op:

```
B0  visible=true  nameColor=null  vertexColor=null  edgeColor=black
B3  visible=true  nameColor=null  vertexColor=null  edgeColor=black
figureBounds : {"minX":-1000,"maxX":1000,...}
visibleBounds: {"minX":-1000,"maxX":1000,...}     <-- identical
```

The helpers are hidden by **zero colours** (`;0;0`), not by `visible = false`.
They paint nothing, but `visible` is `true`, so a visibility filter keeps them
and the two boxes agree exactly. A test in this PR pins that fact so the
distinction doesn't get lost.

## What actually distinguishes them: ink

`Slate._paintsInk()` asks whether an element puts anything on the canvas. The
test is **per element type**, because a colour slot an element never uses tells
you nothing:

```ts
private _paintsInk(elem: GeomElement) : boolean {
    if (!elem.visible) return false;
    if (elem.nameColor != null) return true;
    if (elem instanceof PointElement) return elem.vertexColor != null;
    return elem.edgeColor != null || elem.faceColor != null;
}
```

`PointElement.drawEdge` and `drawFace` are no-ops, so a point's `edgeColor` is
not ink — and that matters here, because `edgeColor` **defaults to black** when
the author omits the field. A naive "any colour slot is set" test would have
kept the helpers for exactly that reason.

`captureCentringBounds()` measures over that predicate, with a fallback to the
all-elements box if nothing paints at all, so callers always get the same shape
of answer as before.

## Captured once, not recomputed

The box is stored on the Slate and cleared on leaving the maximized view.

- **A resize mid-walk** must re-centre on the frame the walk started in, not on
  whatever the current slide happens to reveal. #114 already promised "centre
  once"; recomputing visibility-dependent bounds on every resize would have
  quietly broken that.
- **`cloneAside`'s centre phase (#99)** deliberately used
  `figureBounds()` — its comment says "so it matches the #107 base-centring
  exactly (no shift when already centred)". It now reads the same stored box,
  which keeps that invariant by construction instead of by coincidence.

`onPresent()` clears the box first, so entering a walk re-measures rather than
inheriting one captured by an earlier plain maximize.

## Verification

- `tsc --noEmit` clean; **700 snapshot + 322 unit passing**, 0 errors.
- Seven new unit tests built from the real deck geometry, including: that
  `visible` is true for these helpers and `visibleBounds() == figureBounds()`
  (why the obvious fix fails); that the centre lands inside the drawn figure;
  that helper distance doesn't move the frame (I.35's one-sided x=10000 and
  I.42's symmetric ±1000 are the same bug); that a label-only point still
  counts as ink; that a hidden element does not; the empty-figure fallback; and
  the capture/clear caching contract.
- `view/test/present-centring-bounds.html` reproduces the failing shape — press
  `p` and the figure stays centred.

One incidental finding recorded in a test comment: a `lineSlider`
parameterised across a ±100000 track lands at 89.99999999998545 rather than 90,
so that assertion compares with a tolerance. That's slider arithmetic, not the
centring box.

## For the slideshow session

Once released, the deck-side workarounds in **I.35** and **I.42** (helpers
pulled on-canvas purely to keep the bbox sane) can be reverted, and I.43 no
longer needs to avoid off-canvas helpers.
