### PR TITLE
Emit an ASCII-only bundle; declare charset on demo pages (#142)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "build": "tsc --noEmit",
     "bundle": "npx webpack",
     "bundle:prod": "NODE_ENV=production npx webpack",
+    "check:bundle": "node scripts/check-bundle-ascii.js",
     "test": "npm run test:snapshot && npm run test:unit",
     "test:snapshot": "npm run bundle && mocha --reporter min tests/SnapshotTest.ts tests/HighlightSnapshotTest.ts tests/VisibilitySnapshotTest.ts tests/AnimationSnapshotTest.ts",
     "test:unit": "mocha tests/AnimationTest.ts tests/CircleTest.ts tests/ColorsTest.ts tests/HighlightByNameTest.ts tests/HighlightTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateAnimatorTest.ts tests/SlateTest.ts tests/SlideTest.ts tests/SourceHygieneTest.ts tests/SphereTest.ts tests/VisibilityTest.ts",
@@ -33,7 +34,7 @@
     "coverage:unit": "c8 mocha --reporter min tests/AnimationTest.ts tests/CircleTest.ts tests/ColorsTest.ts tests/HighlightByNameTest.ts tests/HighlightTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateAnimatorTest.ts tests/SlateTest.ts tests/SlideTest.ts tests/SphereTest.ts tests/VisibilityTest.ts",
     "coverage:report": "c8 report --reporter=html",
     "snapshots:clean": "rm -rf tests/snapshots && mkdir -p tests/snapshots && touch tests/snapshots/.gitkeep",
-    "prepublishOnly": "npm run test:unit && npm run bundle:prod"
+    "prepublishOnly": "npm run test:unit && npm run bundle:prod && npm run check:bundle"
   },
   "repository": {
     "type": "git",

--- a/src/SlateControls.ts
+++ b/src/SlateControls.ts
@@ -478,6 +478,13 @@ class SlateControls {
         nav.style.alignItems = "center";
         nav.style.justifyContent = "center";
 
+        // #142 — these glyphs must not reach the bundle as raw UTF-8: a
+        // consumer page without <meta charset> decodes our <script src>
+        // using its own encoding and geomlib's controls turn to mojibake.
+        // Escaping them HERE does not help (tsc decodes the escape, the
+        // minifier re-normalises it) — it is enforced at emit by
+        // `ascii_only` in webpack.config.js, and checked by
+        // scripts/check-bundle-ascii.js at publish time.
         const prevBtn = makePresentationButton("‹ Prev");
         const counter = document.createElement("span");
         counter.className = "geomlib-presentation-counter";

--- a/view/test/circle/circle.html
+++ b/view/test/circle/circle.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Circle.radius (Post.3)</title>
 </head>
 <body>

--- a/view/test/circle/circumcircle.html
+++ b/view/test/circle/circumcircle.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Circle.circumcircle (III.10)</title>
 </head>
 <body>

--- a/view/test/circle/intersection.html
+++ b/view/test/circle/intersection.html
@@ -1,5 +1,7 @@
 <html>
-<head><title>Test View - Circle.intersection (sphere intersection)</title></head>
+<head>
+<meta charset="utf-8">
+<title>Test View - Circle.intersection (sphere intersection)</title></head>
 <body>
 <canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
 <script src="../../../dist/bundle.js" type="text/javascript"></script>

--- a/view/test/circle/radius3pt.html
+++ b/view/test/circle/radius3pt.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Circle.radius 3-point (III.26)</title>
 </head>
 <body>

--- a/view/test/circumcenter_lineperp.html
+++ b/view/test/circumcenter_lineperp.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Point.circumcenter + Line.perpendicular (III.25a)</title>
 </head>
 <body>

--- a/view/test/highlight-event.html
+++ b/view/test/highlight-event.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <title>Test View — #108 bidirectional highlight binding</title>
 <style>
     body { font-family: sans-serif; margin: 16px; color: #333; max-width: 720px; }

--- a/view/test/line/angleBisector.html
+++ b/view/test/line/angleBisector.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Line.angleBisector (IV.4)</title>
 </head>
 <body>

--- a/view/test/line/bichord.html
+++ b/view/test/line/bichord.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Line.bichord (I.1)</title>
 </head>
 <body>

--- a/view/test/line/chord.html
+++ b/view/test/line/chord.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Line.chord (I.12)</title>
 </head>
 <body>

--- a/view/test/line/cutoff.html
+++ b/view/test/line/cutoff.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Line.cutoff (standalone)</title>
 </head>
 <body>

--- a/view/test/line/foot.html
+++ b/view/test/line/foot.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Line.foot (I.47 — Pythagoras)</title>
 </head>
 <body>

--- a/view/test/line/parallel.html
+++ b/view/test/line/parallel.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Line.parallel (I.22 excerpt)</title>
 </head>
 <body>

--- a/view/test/line/perpendicular.html
+++ b/view/test/line/perpendicular.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Line.perpendicular (Post.4)</title>
 </head>
 <body>

--- a/view/test/line/planeFoot.html
+++ b/view/test/line/planeFoot.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Line.foot (plane variant, from XI.26)</title>
 </head>
 <body>

--- a/view/test/line/similar.html
+++ b/view/test/line/similar.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Line.similar (I.31)</title>
 </head>
 <body>

--- a/view/test/plane/3points.html
+++ b/view/test/plane/3points.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Plane.3points (XI.29)</title>
 </head>
 <body>

--- a/view/test/plane/parallel.html
+++ b/view/test/plane/parallel.html
@@ -1,5 +1,7 @@
 <html>
-<head><title>Test View - Plane.parallel (XI.11)</title></head>
+<head>
+<meta charset="utf-8">
+<title>Test View - Plane.parallel (XI.11)</title></head>
 <body>
 <canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
 <script src="../../../dist/bundle.js" type="text/javascript"></script>

--- a/view/test/point/foot.html
+++ b/view/test/point/foot.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Point.foot (lemma for X.33)</title>
 </head>
 <body>

--- a/view/test/point/harmonic.html
+++ b/view/test/point/harmonic.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Point.harmonic (Harmonic Conjugates)</title>
 </head>
 <body>

--- a/view/test/point/intersection.html
+++ b/view/test/point/intersection.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Point.intersection (Def I.2)</title>
 </head>
 <body>

--- a/view/test/point/invert.html
+++ b/view/test/point/invert.html
@@ -1,5 +1,7 @@
 <html>
-<head><title>Test View - Point.invert (standalone)</title></head>
+<head>
+<meta charset="utf-8">
+<title>Test View - Point.invert (standalone)</title></head>
 <body>
 <canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
 <script src="../../../dist/bundle.js" type="text/javascript"></script>

--- a/view/test/point/meanProportional.html
+++ b/view/test/point/meanProportional.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Point.meanProportional (standalone)</title>
 </head>
 <body>

--- a/view/test/point/parallelogram.html
+++ b/view/test/point/parallelogram.html
@@ -1,5 +1,7 @@
 <html>
-<head><title>Test View - Point.parallelogram (I.28)</title></head>
+<head>
+<meta charset="utf-8">
+<title>Test View - Point.parallelogram (I.28)</title></head>
 <body>
 <canvas id="canvasId" style="width:360px; height:240px;"></canvas>
 <script src="../../../../dist/bundle.js" type="text/javascript"></script>

--- a/view/test/point/planeFoot.html
+++ b/view/test/point/planeFoot.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Point.foot (plane variant, from XI.26)</title>
 </head>
 <body>

--- a/view/test/point/planeSlider.html
+++ b/view/test/point/planeSlider.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Point.planeSlider (XI.4)</title>
 </head>
 <body>

--- a/view/test/point/propI2-L-drag.html
+++ b/view/test/point/propI2-L-drag.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - propI2 slate1 (drag instability reproducer, issue #41)</title>
 </head>
 <body>

--- a/view/test/point/proportion.html
+++ b/view/test/point/proportion.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Point.proportion (standalone)</title>
 </head>
 <body>

--- a/view/test/point/similar.html
+++ b/view/test/point/similar.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Point.similar (III.Def.11)</title>
 </head>
 <body>

--- a/view/test/point/sphereSlider.html
+++ b/view/test/point/sphereSlider.html
@@ -1,5 +1,7 @@
 <html>
-<head><title>Test View - Point.sphereSlider (standalone)</title></head>
+<head>
+<meta charset="utf-8">
+<title>Test View - Point.sphereSlider (standalone)</title></head>
 <body>
 <canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
 <script src="../../../dist/bundle.js" type="text/javascript"></script>

--- a/view/test/point/vertex.html
+++ b/view/test/point/vertex.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - point;vertex</title>
 </head>
 <body>

--- a/view/test/poly/application.html
+++ b/view/test/poly/application.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Polygon.application (I.44)</title>
 </head>
 <body>

--- a/view/test/poly/equilateralTriangle.html
+++ b/view/test/poly/equilateralTriangle.html
@@ -1,5 +1,7 @@
 <html>
-<head><title>Test View - polygon;equilateralTriangle (propI10)</title></head>
+<head>
+<meta charset="utf-8">
+<title>Test View - polygon;equilateralTriangle (propI10)</title></head>
 <body>
 <canvas id="canvasId" style="width:360px; height:280px;"></canvas>
 <script src="../../../dist/bundle.js" type="text/javascript"></script>

--- a/view/test/poly/octagon.html
+++ b/view/test/poly/octagon.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Polygon.octagon (XII.2 excerpt)</title>
 </head>
 <body>

--- a/view/test/poly/parallelogram.html
+++ b/view/test/poly/parallelogram.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Polygon.parallelogram (I.34)</title>
 </head>
 <body>

--- a/view/test/poly/quadrilateral.html
+++ b/view/test/poly/quadrilateral.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Polygon.quadrilateral (I.43)</title>
 </head>
 <body>

--- a/view/test/poly/regularPolygon.html
+++ b/view/test/poly/regularPolygon.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Polygon.regularPolygon (IV.11)</title>
 </head>
 <body>

--- a/view/test/poly/similar.html
+++ b/view/test/poly/similar.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Polygon.similar (I.23)</title>
 </head>
 <body>

--- a/view/test/poly/square.html
+++ b/view/test/poly/square.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Polygon.square (I.46)</title>
 </head>
 <body>

--- a/view/test/poly/triangle.html
+++ b/view/test/poly/triangle.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Polygon.triangle (Def I.19)</title>
 </head>
 <body>

--- a/view/test/polyhedron/prism.html
+++ b/view/test/polyhedron/prism.html
@@ -1,5 +1,7 @@
 <html>
-<head><title>Test View - Polyhedron.prism (standalone)</title></head>
+<head>
+<meta charset="utf-8">
+<title>Test View - Polyhedron.prism (standalone)</title></head>
 <body>
 <canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
 <script src="../../../../dist/bundle.js" type="text/javascript"></script>

--- a/view/test/polyhedron/pyramid.html
+++ b/view/test/polyhedron/pyramid.html
@@ -1,5 +1,7 @@
 <html>
-<head><title>Test View - Polyhedron.pyramid (standalone)</title></head>
+<head>
+<meta charset="utf-8">
+<title>Test View - Polyhedron.pyramid (standalone)</title></head>
 <body>
 <canvas id="canvasId" style="width:400px; height: 400px;"></canvas>
 <script src="../../../../dist/bundle.js" type="text/javascript"></script>

--- a/view/test/quad_line.html
+++ b/view/test/quad_line.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View</title>
 </head>
 <body>

--- a/view/test/recenter-maximize.html
+++ b/view/test/recenter-maximize.html
@@ -1,5 +1,7 @@
 <html>
-<head><title>Test View — #107 maximized-view recenter</title></head>
+<head>
+<meta charset="utf-8">
+<title>Test View — #107 maximized-view recenter</title></head>
 <body>
 <h3 style="font-family: sans-serif;">maximized-view recenter (#107)</h3>
 <p style="font-family: sans-serif; max-width: 680px; color: #444;">

--- a/view/test/sector/angle-marker.html
+++ b/view/test/sector/angle-marker.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Sector.angleMarker (#91)</title>
 </head>
 <body>

--- a/view/test/sector/arc.html
+++ b/view/test/sector/arc.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Sector.arc (III.2)</title>
 </head>
 <body>

--- a/view/test/sector/sector.html
+++ b/view/test/sector/sector.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - Sector.sector (Def III.10)</title>
 </head>
 <body>

--- a/view/test/slideshow/autoplace-probe.html
+++ b/view/test/slideshow/autoplace-probe.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>autoPlace placement probe (#99)</title>
     <style>
         body { font-family: sans-serif; margin: 16px; color: #333; }

--- a/view/test/slideshow/translate-slide.html
+++ b/view/test/slideshow/translate-slide.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View - A.Group.cloneAside autoPlace + A.Point.slide (#99, #95)</title>
 </head>
 <body>

--- a/view/test/two_canvas.html
+++ b/view/test/two_canvas.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
     <title>Test View</title>
 </head>
 <body>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,29 @@ module.exports = {
   externals: {
       canvas: "commonjs canvas"
   },
+  // #142 — emit non-ASCII in string literals as escape sequences.
+  //
+  // The presentation controls carry glyphs (the nav arrows, the exit mark,
+  // the justification separator). A <script src> with no charset of its own
+  // is decoded using the INCLUDING document's encoding, so on a consumer
+  // page that omits <meta charset> raw UTF-8 in the bundle renders as
+  // mojibake and geomlib's own UI breaks — something we cannot fix from the
+  // consumer side.
+  //
+  // Escaping the characters in the TypeScript source does NOT achieve this:
+  // tsc decodes the escape and emits the literal character, and the
+  // minifier normalises string escapes back to the shortest form. It has to
+  // be done at the emit step, which is what ascii_only does.
+  optimization: {
+    minimizer: [
+      (compiler) => {
+        const TerserPlugin = require('terser-webpack-plugin');
+        new TerserPlugin({
+          terserOptions: { format: { ascii_only: true } },
+        }).apply(compiler);
+      },
+    ],
+  },
   output: {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
Closes #142.

Text rendered as mojibake — an em dash as `a€"`, and the presentation
overlay's own buttons as `a€¹ Prev`, `Next a€º`, `aoe• Exit`. That is UTF-8
being decoded as Windows-1252, which a browser falls back to when a document
declares no encoding.

Two causes, and the second one affects **consumers**, not just our demos.

## 1. The bundle shipped raw UTF-8 (the important half)

`dist/bundle.js` carried the nav glyphs as literal characters. A `<script src>`
with no charset of its own is decoded using the **including document's**
encoding — so any consumer page that omits `<meta charset>` mangles geomlib's
own presentation controls, however clean their own markup is. We cannot fix
that from the consumer side, and the published artifact shouldn't depend on it.

**The obvious fix does not work, and I only caught it by checking the built
file.** Writing the glyphs as escape sequences in the TypeScript source leaves
the bundle unchanged: `tsc` decodes the escape and emits the literal character,
and the minifier normalises string escapes back to the shortest form — which
for a printable character is the character itself. My first attempt did exactly
this and the prod bundle still contained all four glyphs.

It has to be enforced at the emit step, so `webpack.config.js` now sets
terser's `ascii_only`:

```
prod bundle non-ASCII bytes: 0
… var o=h("‹ Prev"), …
```

The source keeps its literal glyphs (they read better), with a comment at the
call site pointing at where the guarantee actually comes from.

**`scripts/check-bundle-ascii.js`** fails the build if a raw non-ASCII byte
reaches the bundle, reporting byte, line and surrounding context. It is wired
into `prepublishOnly` (which already runs `bundle:prod`), so it checks the real
artifact at the moment it would be published. It exists because the failure
mode here is invisible in source review — the source can look correct while the
artifact is wrong.

## 2. Demo pages declared no charset

All 46 broken pages were under `view/test/` — pages we author. The archival
fixtures (`view/euclid-html/`, `compass_geometry/`, `round_geometry/`) are
original applet HTML and are **left untouched**; none of them were affected.

`<meta charset="utf-8">` added to the 49 `view/test/` pages that lacked it (16
already had one), including pages that are currently pure ASCII — new demos get
written by copying an existing one, so leaving some without it invites the bug
back the first time someone types an em dash.

After: **0 pages under `view/` carry non-ASCII without a charset declaration.**

## Verification

- `tsc --noEmit` clean; **700 snapshot + 315 unit passing**, 0 errors.
- `npm run check:bundle` → `OK — 193561 bytes, all ASCII`.
- Both bundles rebuild cleanly.

## Note on scope

The library half is the release-relevant part: without it we publish an
artifact whose own UI breaks on a class of consumer pages. The page half is
housekeeping that happens to share a root cause.
