### PR TITLE
Caption display override accepts a multi-word phrase (#136)

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -418,6 +418,23 @@ Hover / tap on a span flips `element.emphasisAmount` so the element
 pops with a thicker stroke; tapping pins a single sticky reference at
 a time.
 
+**The DISPLAY half may be a phrase (#136, 0.14.0+.)** The two halves have
+different grammars on purpose: the element name stays strict (it has to
+resolve against the slate), while the display half is anything up to the
+closing brace, because it is prose.
+
+```
+{AB}                             element name doubles as the display
+{ABC|angBint}                    single-word override
+{the side from D to A|sideDA}    a whole phrase lights one element
+```
+
+Before 0.14.0 the display half was restricted to one word, so a
+multi-word token did not match at all and leaked into the caption
+verbatim as `{the side from D to A|sideDA}`. The workaround was to bind a
+single keyword inside the phrase — `the {side|sideDA} from D to A` — which
+lights only that word. `parseCaptionTokens()` is exported for testing.
+
 ### Justification refs
 
 ```typescript

--- a/src/SlateControls.ts
+++ b/src/SlateControls.ts
@@ -82,6 +82,55 @@ export function escapeAction(state: {presenting: boolean; maximized: boolean}): 
     return "none";
 }
 
+// One piece of a rendered caption: literal text, or a reference that binds
+// `display` to the slate element named `target`.
+export type CaptionToken =
+    | { kind: "text"; text: string }
+    | { kind: "ref"; display: string; target: string };
+
+// Caption token grammar.
+//
+//   {AB}                        — display and element name are the same
+//   {ABC|angBint}               — display override (#90): render "ABC" but
+//                                 bind to angBint, for prose names that
+//                                 collide with another element's name
+//   {the side from D to A|sideDA}
+//                               — #136: the DISPLAY half may be a phrase.
+//
+// The two halves have deliberately different grammars. The element name
+// stays strict (identifier-ish), because it has to resolve against the
+// slate. The display half is anything up to the closing brace — it is
+// prose, and restricting it to a single word forced authors to bind one
+// keyword inside a phrase (`the {side|sideDA} from D to A`) when what they
+// meant was to light the whole phrase.
+const CAPTION_NAME = "[A-Za-z][A-Za-z0-9'\\-]*";
+const CAPTION_RE = new RegExp(
+    "\\{([^{}|]+)\\|(" + CAPTION_NAME + ")\\}" +   // {display|element}
+    "|\\{(" + CAPTION_NAME + ")\\}",                 // {element}
+    "g");
+
+export function parseCaptionTokens(text: string): CaptionToken[] {
+    const out: CaptionToken[] = [];
+    const re = new RegExp(CAPTION_RE.source, "g");
+    let lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+        if (m.index > lastIndex) {
+            out.push({ kind: "text", text: text.slice(lastIndex, m.index) });
+        }
+        // Piped form fills groups 1-2; bare form fills group 3.
+        const piped = m[2] != null;
+        const display = piped ? m[1] : m[3];
+        const target = piped ? m[2] : m[3];
+        out.push({ kind: "ref", display: display, target: target });
+        lastIndex = m.index + m[0].length;
+    }
+    if (lastIndex < text.length) {
+        out.push({ kind: "text", text: text.slice(lastIndex) });
+    }
+    return out;
+}
+
 export function createControls(slate: Slate, canvas: HTMLCanvasElement, config: IInitConfig): void {
     // Skip in headless/test environments
     if (!canvas.parentElement) return;
@@ -728,30 +777,23 @@ class SlateControls {
     // Display override (#90): {DISPLAY|element} renders DISPLAY but
     // binds the highlight to `element` — for prose names that collide
     // with another element's name, e.g. "the angle {ABC|angBint}"
-    // where the bare token would resolve to the triangle ABC.
+    // where the bare token would resolve to the triangle ABC. Since #136
+    // the DISPLAY half may be a whole phrase; see parseCaptionTokens.
     private renderCaptionText(host: HTMLElement, text: string): void {
         host.innerHTML = "";
-        const re = /\{([A-Za-z][A-Za-z0-9'\-]*)(?:\|([A-Za-z][A-Za-z0-9'\-]*))?\}/g;
-        let lastIndex = 0;
-        let m: RegExpExecArray | null;
-        while ((m = re.exec(text)) !== null) {
-            if (m.index > lastIndex) {
-                host.appendChild(document.createTextNode(text.slice(lastIndex, m.index)));
+        for (const tok of parseCaptionTokens(text)) {
+            if (tok.kind === "text") {
+                host.appendChild(document.createTextNode(tok.text));
+                continue;
             }
-            const display = m[1];
-            const target = m[2] != null ? m[2] : m[1];
-            const elem = this._slate.lookupElement(target);
+            const elem = this._slate.lookupElement(tok.target);
             if (elem) {
-                host.appendChild(this.buildCaptionRef(display, elem));
+                host.appendChild(this.buildCaptionRef(tok.display, elem));
             } else {
                 // Unknown — render plain so a typo doesn't surface as
                 // raw "{XYZ}" to the reader.
-                host.appendChild(document.createTextNode(display));
+                host.appendChild(document.createTextNode(tok.display));
             }
-            lastIndex = m.index + m[0].length;
-        }
-        if (lastIndex < text.length) {
-            host.appendChild(document.createTextNode(text.slice(lastIndex)));
         }
     }
 

--- a/tests/SlideTest.ts
+++ b/tests/SlideTest.ts
@@ -5,6 +5,7 @@
 
 import "mocha";
 import * as assert from "assert";
+import {parseCaptionTokens} from "../src/SlateControls";
 import {createCanvas} from "canvas";
 import {init, slates, ISlide, IConstructionInfo} from "../src/index";
 import {computeSlideState} from "../src/slideshow";
@@ -213,5 +214,71 @@ describe("computeSlideState (issue #75)", () => {
         assert.ok(s.visible.has("B"));
         assert.ok(!s.visible.has("AB"));
         assert.ok(!s.visible.has("BCD"));
+    });
+});
+
+// #136 — caption token grammar. The DISPLAY half of a {display|element}
+// override may be a whole phrase; the element half stays strict because it
+// has to resolve against the slate.
+describe("parseCaptionTokens (#136)", () => {
+
+    const refs = (text: string) =>
+        parseCaptionTokens(text)
+            .filter(t => t.kind === "ref")
+            .map(t => `${(t as any).display}->${(t as any).target}`);
+
+    it("keeps a bare token binding display and target together", () => {
+        assert.deepEqual(refs("Join {AB} and {CD}."), ["AB->AB", "CD->CD"]);
+    });
+
+    it("keeps the single-word display override (#90)", () => {
+        assert.deepEqual(refs("the angle {ABC|angBint}"), ["ABC->angBint"]);
+    });
+
+    it("accepts a multi-word display — the case that filed the ticket", () => {
+        // From I.31. Before this, the whole token leaked into the caption
+        // verbatim as "{the side from D to A|sideDA}", so decks bound a
+        // single keyword inside the phrase instead.
+        assert.deepEqual(
+            refs("Produce {the side from D to A|sideDA} to meet it."),
+            ["the side from D to A->sideDA"]);
+    });
+
+    it("keeps the surrounding prose intact around a phrase ref", () => {
+        const toks = parseCaptionTokens("Produce {the side from D to A|sideDA} to meet it.");
+        assert.deepEqual(toks.map(t => t.kind), ["text", "ref", "text"]);
+        assert.equal((toks[0] as any).text, "Produce ");
+        assert.equal((toks[2] as any).text, " to meet it.");
+    });
+
+    it("still requires the element half to look like a name", () => {
+        // A strict target is what makes the display half safe to widen: the
+        // second group can never swallow prose.
+        assert.deepEqual(refs("{some words|not a name}"), []);
+        assert.deepEqual(refs("{display|9bad}"), []);
+    });
+
+    it("does not let a display run across the closing brace", () => {
+        assert.deepEqual(refs("{a|X} and {b|Y}"), ["a->X", "b->Y"]);
+    });
+
+    it("handles several refs and adjacent tokens", () => {
+        assert.deepEqual(
+            refs("{AB}{the base|BC} then {angle ABC|angB}."),
+            ["AB->AB", "the base->BC", "angle ABC->angB"]);
+    });
+
+    it("leaves text with no tokens as a single run", () => {
+        const toks = parseCaptionTokens("No refs here at all.");
+        assert.deepEqual(toks, [{ kind: "text", text: "No refs here at all." }]);
+    });
+
+    it("is not stateful across calls", () => {
+        // A module-level regex with /g carries lastIndex between calls; the
+        // tokenizer must build its own each time or every second caption
+        // would tokenize from the wrong offset.
+        const once = refs("{AB} and {CD}");
+        const twice = refs("{AB} and {CD}");
+        assert.deepEqual(once, twice);
     });
 });

--- a/view/test/caption-phrase-ref.html
+++ b/view/test/caption-phrase-ref.html
@@ -1,0 +1,56 @@
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test View — #136 multi-word caption refs</title>
+</head>
+<body>
+<h3 style="font-family: sans-serif;">Multi-word caption display refs (#136)</h3>
+<p style="font-family: sans-serif; max-width: 720px; color: #444;">
+Press <b>p</b> and step through. Each caption hovers a different token form —
+watch which part of the sentence lights up and which element it highlights.
+</p>
+<ul style="font-family: sans-serif; max-width: 720px; color: #444;">
+<li><code>{AB}</code> — the element name is also the display.</li>
+<li><code>{ABC|angA}</code> — single-word override: renders "ABC", binds the
+    angle marker rather than the triangle that owns the name.</li>
+<li><code>{the side from A to C|AC}</code> — <b>the phrase form.</b> Before
+    #136 this did not match and the caption showed the raw
+    <code>{…|…}</code> text; the workaround was to bind one keyword
+    (<code>the {side|AC} from A to C</code>), lighting only that word.</li>
+</ul>
+<canvas id="canvasId" style="width:360px; height:280px;" tabindex="0"></canvas>
+<script src="../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E, A = geomlib.A;
+    geomlib.init({
+        background: '35,19,100',
+        title: "caption-phrase-ref",
+        canvasid: "canvasId",
+        showAngles: true,
+        elements: [
+            { name: "A", construction: E.Point.free, params: [80, 60] },
+            { name: "B", construction: E.Point.free, params: [80, 220] },
+            { name: "C", construction: E.Point.free, params: [280, 220] },
+            { name: "AB", construction: E.Line.connect, params: ["A", "B"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black" },
+            { name: "AC", construction: E.Line.connect, params: ["A", "C"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black" },
+            { name: "BC", construction: E.Line.connect, params: ["B", "C"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black" },
+            { name: "ABC", construction: E.Polygon.triangle, params: ["A", "B", "C"],
+              nameColor: 0, vertexColor: 0, edgeColor: 0, faceColor: "rgba(120,180,210,0.30)" },
+            { name: "angA", construction: E.Sector.angleMarker, params: ["A", "B", "C"] },
+        ],
+        slides: [
+            { text: "Bare token: join {AB}.", visible: ["ABC", "AB", "AC", "BC"] },
+            { text: "Single-word override: the angle {ABC|angA} sits at the vertex.",
+              visible: ["ABC", "AB", "AC", "BC", "angA"] },
+            { text: "Phrase form: {the side from A to C|AC} closes the triangle.",
+              visible: ["ABC", "AB", "AC", "BC"] },
+            { text: "Compare the old workaround: the {side|AC} from A to C — only one word lights.",
+              visible: ["ABC", "AB", "AC", "BC"] },
+        ],
+    });
+</script>
+</body>
+</html>

--- a/view/test/overview.html
+++ b/view/test/overview.html
@@ -73,6 +73,8 @@ individually.</p>
       <td>Present-centring measures only elements that <b>paint</b>. Invisible zero-colour track anchors 1000px off-canvas no longer define the frame — the shape that rendered I.35 / I.42 / I.43 blank on present.</td><td>#138</td></tr>
   <tr><td><a href="escape-exit.html">escape-exit.html</a></td>
       <td><b>Escape</b> peels off one layer of takeover per press: out of the slideshow (staying maximized, #115), then out of the maximized view. Works with focus on the control button, not just the canvas.</td><td>#139</td></tr>
+  <tr><td><a href="caption-phrase-ref.html">caption-phrase-ref.html</a></td>
+      <td>Caption token forms side by side: bare <code>{AB}</code>, single-word override <code>{ABC|angA}</code>, and the new phrase form <code>{the side from A to C|AC}</code> — plus the one-keyword workaround it replaces.</td><td>#136</td></tr>
 </table>
 
 <h2>Responsive / 3D</h2>


### PR DESCRIPTION
Closes #136.

The caption display override `{DISPLAY|element}` accepted only a single word
on the display side:

```js
/\{([A-Za-z][A-Za-z0-9'\-]*)(?:\|([A-Za-z][A-Za-z0-9'\-]*))?\}/g
```

So `{the side from D to A|sideDA}` did not match at all, and the raw
`{…|…}` leaked into the caption verbatim. Decks worked around it by binding a
single keyword inside the phrase — `the {side|sideDA} from D to A` — which
highlights only that one word rather than the phrase the author meant.

Raised from I.31, and listed as a standing ask in the coordination doc.

## The change

The two halves now have deliberately different grammars:

| Form | Meaning |
|---|---|
| `{AB}` | element name doubles as the display |
| `{ABC\|angBint}` | single-word override (#90), unchanged |
| `{the side from D to A\|sideDA}` | a whole phrase lights one element |

The **element** half stays strict — it has to resolve against the slate, and
keeping it strict is what makes widening the display half safe: the second
group can never swallow prose. The **display** half is anything up to the
closing brace, because it is prose. A test pins both directions.

## Extracted a pure tokenizer

`renderCaptionText` is a private DOM method with no coverage (the suites use
node-canvas, no jsdom), so the parsing is now `parseCaptionTokens()` — exported
and DOM-free, following the `trackWindowResize` / `escapeAction` precedent in
this file. `renderCaptionText` consumes its output and is otherwise unchanged,
including the existing behaviour of rendering an unresolved ref as plain text
so a typo never surfaces as raw `{XYZ}`.

One thing that came out of testing it directly: the regex is built per call
rather than shared at module scope. A `/g` regex carries `lastIndex` between
calls, so a shared one would tokenize every second caption from the wrong
offset. There is a test for that specifically.

## Verification

- `tsc --noEmit` clean; **700 snapshot + 324 unit passing**, 0 errors.
- 9 new tests, including the exact I.31 phrase that filed the ticket, that the
  surrounding prose survives around a phrase ref, that a strict element half
  still rejects `{some words|not a name}`, and that a display cannot run across
  a closing brace.
- `view/test/caption-phrase-ref.html` shows all three token forms plus the
  one-keyword workaround, so the difference in what lights up is visible.
- Documented in `api.md` under the caption markup pass.

## For the slideshow session

Existing decks keep working untouched — this only widens what matches. The
one-keyword workaround can be unwound to the natural phrasing wherever it was
used, at whatever pace suits.
