### PR TITLE
ISlideJust.claim: a justification can state its step, not just cite it (#146)

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -438,6 +438,11 @@ lights only that word. `parseCaptionTokens()` is exported for testing.
 ### Justification refs
 
 ```typescript
+interface ISlideJust {
+    ref: string;
+    claim?: string;      // 0.14.0+ (#146)
+}
+
 type ResolveJustification =
     (ref: string) => string | null | undefined;
 
@@ -445,6 +450,29 @@ class Slate {
     resolveJustification: ResolveJustification | null;
 }
 ```
+
+**`claim` (#146, 0.14.0+)** states what a step asserts, rendered ahead of
+the citation as `claim — ref`:
+
+```js
+justifications: [
+    { claim: "angle EGB = angle AGH",           ref: "I.15" },
+    { claim: "angle AGH + angle BGH = 2rt",     ref: "I.13" },
+    { claim: "subtract angle BGH",              ref: "C.N.3" },
+]
+```
+
+Without it a chip can say *which* proposition licenses a step but never
+*what* the step claims, so a slide carrying several reasoning steps had to
+be split one-per-sub-slide purely to keep each statement beside its own
+citation.
+
+**Layout follows the data.** If any justification on a slide has a claim,
+the entries stack one per line — statements don't read as a dot-separated
+row, and a bare citation shouldn't be stranded mid-row beside them. With no
+claims anywhere, the panel is the same inline `·`-joined row as before, so
+existing decks are untouched. `justsUseStackedLayout()` is exported for
+testing. `claim` is plain text; it does not take `{NAME}` tokens.
 
 Slide entries carry symbolic `justifications: [{ ref: "I.Post.3" }]`.
 URLs are resolved at render time by the consumer-provided callback

--- a/src/SlateControls.ts
+++ b/src/SlateControls.ts
@@ -12,6 +12,7 @@
 
 import {Slate} from "./Slate";
 import {computeSlideState} from "./slideshow";
+import {ISlideJust} from "./index";
 
 interface IInitConfig {
     background: string;
@@ -129,6 +130,20 @@ export function parseCaptionTokens(text: string): CaptionToken[] {
         out.push({ kind: "text", text: text.slice(lastIndex) });
     }
     return out;
+}
+
+// #146 — how a slide's justification panel should lay out.
+//
+// A bare citation ("I.15") is a chip; several of them read fine as one
+// dot-separated row. A claim turns each entry into a statement
+// ("angle EGB = angle AGH — I.15"), and statements do not read as a row —
+// they want a line each. Mixed slides stack too: an entry without a claim
+// still belongs on its own line next to ones that have them.
+//
+// Pure so the layout rule is testable without a DOM.
+export function justsUseStackedLayout(justs: ISlideJust[] | null | undefined): boolean {
+    if (justs == null) return false;
+    return justs.some((j) => j.claim != null && j.claim !== "");
 }
 
 export function createControls(slate: Slate, canvas: HTMLCanvasElement, config: IInitConfig): void {
@@ -739,15 +754,34 @@ class SlateControls {
         if (this._presentationJusts) {
             this._presentationJusts.innerHTML = "";
             const resolve = this._slate.resolveJustification;
-            if (slide.justifications) {
-                for (let i = 0; i < slide.justifications.length; i++) {
-                    if (i > 0) {
+            const justs = slide.justifications;
+            if (justs) {
+                // #146 — a claim makes each entry a statement rather than a
+                // bare citation, and statements don't read as a row joined
+                // by dots. So: any claim on the slide and every entry gets
+                // its own line; no claims and the panel is the same
+                // dot-separated row it has always been.
+                const stacked = justsUseStackedLayout(justs);
+                for (let i = 0; i < justs.length; i++) {
+                    const host = stacked
+                        ? document.createElement("div") : this._presentationJusts;
+                    if (!stacked && i > 0) {
                         const sep = document.createElement("span");
                         sep.textContent = " · ";
                         sep.style.opacity = "0.5";
-                        this._presentationJusts.appendChild(sep);
+                        host.appendChild(sep);
                     }
-                    const ref = slide.justifications[i].ref;
+                    const claim = justs[i].claim;
+                    if (claim != null && claim !== "") {
+                        const c = document.createElement("span");
+                        c.textContent = claim;
+                        host.appendChild(c);
+                        const dash = document.createElement("span");
+                        dash.textContent = " — ";
+                        dash.style.opacity = "0.5";
+                        host.appendChild(dash);
+                    }
+                    const ref = justs[i].ref;
                     const url = resolve ? resolve(ref) : null;
                     if (url) {
                         const a = document.createElement("a");
@@ -756,12 +790,13 @@ class SlateControls {
                         a.target = "_blank";
                         a.rel = "noopener";
                         a.style.color = "#0066cc";
-                        this._presentationJusts.appendChild(a);
+                        host.appendChild(a);
                     } else {
                         const span = document.createElement("span");
                         span.textContent = ref;
-                        this._presentationJusts.appendChild(span);
+                        host.appendChild(span);
                     }
+                    if (stacked) this._presentationJusts.appendChild(host);
                 }
             }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,13 @@ export interface IConstructionInfo {
 // doesn't go stale if a referenced page moves on the consumer site.
 export interface ISlideJust {
     ref: string;
+    // 0.14.0+ — what this step CLAIMS, rendered ahead of the citation as
+    // "claim — ref" (#146). Without it the chip can say which proposition
+    // licenses a step but never what the step asserts, so a slide carrying
+    // several reasoning steps had to be split one-per-sub-slide just to
+    // keep each statement next to its own citation. Plain text; omit it and
+    // the panel renders exactly as before.
+    claim?: string;
 }
 
 // One step in the slideshow / presentation walk-through. The DSL is

--- a/tests/SlideTest.ts
+++ b/tests/SlideTest.ts
@@ -5,9 +5,9 @@
 
 import "mocha";
 import * as assert from "assert";
-import {parseCaptionTokens} from "../src/SlateControls";
+import {parseCaptionTokens, justsUseStackedLayout} from "../src/SlateControls";
 import {createCanvas} from "canvas";
-import {init, slates, ISlide, IConstructionInfo} from "../src/index";
+import {init, slates, ISlide, IConstructionInfo, E} from "../src/index";
 import {computeSlideState} from "../src/slideshow";
 
 // Mock the minimum DOM that init() needs.
@@ -280,5 +280,80 @@ describe("parseCaptionTokens (#136)", () => {
         const once = refs("{AB} and {CD}");
         const twice = refs("{AB} and {CD}");
         assert.deepEqual(once, twice);
+    });
+});
+
+// #146 — ISlideJust.claim lets a justification state the step, not just
+// cite it. The I.28 shape: one paragraph, three reasoning steps, each
+// licensed by a different proposition.
+describe("ISlideJust.claim (#146)", () => {
+
+    it("carries the claim through init() onto the slate", () => {
+        const canvas = createCanvas(200, 200) as any;
+        canvas.id = "just-claim";
+        const doc: any = {
+            getElementById: (id: string) => (id === "just-claim" ? canvas : null),
+        };
+        const savedDoc = (global as any).document;
+        (global as any).document = doc;
+        try {
+            init({
+                background: "0,0,100",
+                title: "claims",
+                canvasid: "just-claim",
+                elements: [
+                    { name: "A", construction: E.Point.free, params: [10, 10] },
+                    { name: "B", construction: E.Point.free, params: [90, 90] },
+                ],
+                slides: [{
+                    text: "Reasoning.",
+                    justifications: [
+                        { claim: "angle EGB = angle AGH", ref: "I.15" },
+                        { claim: "angle AGH + angle BGH = 2rt", ref: "I.13" },
+                        { ref: "C.N.3" },
+                    ],
+                }],
+            });
+            const slate = slates[slates.length - 1];
+            const js = slate.slides[0].justifications;
+            assert.equal(js.length, 3);
+            assert.equal(js[0].claim, "angle EGB = angle AGH");
+            assert.equal(js[0].ref, "I.15");
+            assert.equal(js[2].claim, undefined,
+                "a justification without a claim stays a bare citation");
+        } finally {
+            if (savedDoc === undefined) delete (global as any).document;
+            else (global as any).document = savedDoc;
+        }
+    });
+
+    describe("justsUseStackedLayout", () => {
+        it("keeps the dot-separated row when nothing has a claim", () => {
+            assert.equal(
+                justsUseStackedLayout([{ ref: "I.4" }, { ref: "C.N.1" }]), false,
+                "existing decks must render exactly as before");
+        });
+
+        it("stacks as soon as any entry has a claim", () => {
+            assert.equal(
+                justsUseStackedLayout([{ claim: "AB = CD", ref: "I.4" }]), true);
+        });
+
+        it("stacks a mixed slide, so a bare citation isn't stranded mid-row", () => {
+            assert.equal(
+                justsUseStackedLayout([{ claim: "AB = CD", ref: "I.4" }, { ref: "C.N.1" }]),
+                true);
+        });
+
+        it("treats an empty claim as no claim", () => {
+            assert.equal(justsUseStackedLayout([{ claim: "", ref: "I.4" }]), false,
+                "an empty string shouldn't trigger a layout change");
+        });
+
+        it("handles a slide with no justifications at all", () => {
+            assert.equal(justsUseStackedLayout(undefined), false);
+            assert.equal(justsUseStackedLayout(null), false);
+            assert.equal(justsUseStackedLayout([]), false);
+        });
     });
 });

--- a/view/test/just-claim.html
+++ b/view/test/just-claim.html
@@ -1,0 +1,78 @@
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test View — #146 justification claims</title>
+</head>
+<body>
+<h3 style="font-family: sans-serif;">Justification claims (#146)</h3>
+<p style="font-family: sans-serif; max-width: 720px; color: #444;">
+Press <b>p</b> and step through. The figure is I.28's: transversal <b>EF</b>
+crossing <b>AB</b> at <b>G</b> and <b>CD</b> at <b>H</b> — the deck that filed
+this.
+</p>
+<ul style="font-family: sans-serif; max-width: 720px; color: #444;">
+<li><b>Slide 1</b> — bare citations, no claims. The panel is the same
+    dot-separated row as always.</li>
+<li><b>Slide 2</b> — the same three steps <i>with</i> claims. Each statement
+    sits beside the proposition that licenses it, one per line. This is the
+    content that previously had to be split across three sub-slides so each
+    panel could show a single ref.</li>
+<li><b>Slide 3</b> — a mixed slide: one entry has a claim, one doesn't. It
+    stacks, so the bare citation isn't stranded mid-row.</li>
+</ul>
+<canvas id="canvasId" style="width:360px; height:280px;" tabindex="0"></canvas>
+<script src="../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E;
+    geomlib.init({
+        background: '35,19,100',
+        title: "just-claim",
+        canvasid: "canvasId",
+        resolveJustification: function (ref) {
+            // Stand-in for the site's window.eucrefs map, so the refs render
+            // as links here the way they do on a proposition page.
+            var map = {
+                "I.13": "https://www.euclids-elements.org/elements/books/bookI/propositions/propI13/",
+                "I.15": "https://www.euclids-elements.org/elements/books/bookI/propositions/propI15/",
+                "I.27": "https://www.euclids-elements.org/elements/books/bookI/propositions/propI27/",
+            };
+            return map[ref] || null;
+        },
+        elements: [
+            { name: "A", construction: E.Point.free, params: [40, 100] },
+            { name: "B", construction: E.Point.free, params: [320, 100] },
+            { name: "C", construction: E.Point.free, params: [40, 200] },
+            { name: "D", construction: E.Point.free, params: [320, 200] },
+            { name: "E", construction: E.Point.free, params: [120, 40] },
+            { name: "F", construction: E.Point.free, params: [240, 260] },
+            { name: "AB", construction: E.Line.connect, params: ["A", "B"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black" },
+            { name: "CD", construction: E.Line.connect, params: ["C", "D"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black" },
+            { name: "EF", construction: E.Line.connect, params: ["E", "F"],
+              nameColor: 0, vertexColor: 0, edgeColor: "black" },
+            { name: "G", construction: E.Point.intersection, params: ["AB", "EF"] },
+            { name: "H", construction: E.Point.intersection, params: ["CD", "EF"] },
+        ],
+        slides: [
+            { text: "Bare citations: the panel reads as one row.",
+              visible: ["AB", "CD", "EF", "G", "H"],
+              justifications: [{ ref: "I.15" }, { ref: "I.13" }, { ref: "C.N.3" }] },
+            { text: "The same three steps, each stating what it claims.",
+              visible: ["AB", "CD", "EF", "G", "H"],
+              justifications: [
+                  { claim: "angle EGB = angle AGH", ref: "I.15" },
+                  { claim: "angle AGH + angle BGH = 2rt", ref: "I.13" },
+                  { claim: "subtract angle BGH", ref: "C.N.3" },
+              ] },
+            { text: "A mixed slide stacks too.",
+              visible: ["AB", "CD", "EF", "G", "H"],
+              justifications: [
+                  { claim: "alternate angles are equal, so AB is parallel to CD", ref: "I.27" },
+                  { ref: "Q.E.D." },
+              ] },
+        ],
+    });
+</script>
+</body>
+</html>

--- a/view/test/overview.html
+++ b/view/test/overview.html
@@ -75,6 +75,8 @@ individually.</p>
       <td><b>Escape</b> peels off one layer of takeover per press: out of the slideshow (staying maximized, #115), then out of the maximized view. Works with focus on the control button, not just the canvas.</td><td>#139</td></tr>
   <tr><td><a href="caption-phrase-ref.html">caption-phrase-ref.html</a></td>
       <td>Caption token forms side by side: bare <code>{AB}</code>, single-word override <code>{ABC|angA}</code>, and the new phrase form <code>{the side from A to C|AC}</code> — plus the one-keyword workaround it replaces.</td><td>#136</td></tr>
+  <tr><td><a href="just-claim.html">just-claim.html</a></td>
+      <td><code>ISlideJust.claim</code> — a justification states the step (<i>"angle EGB = angle AGH — I.15"</i>) instead of only citing it. Bare / claimed / mixed slides show the row-vs-stacked layout rule. I.28's figure.</td><td>#146</td></tr>
 </table>
 
 <h2>Responsive / 3D</h2>


### PR DESCRIPTION
Closes #146.

`ISlideJust` carried only a citation ref, so a justification chip could say
**which** proposition licenses a step but never **what** the step claims. The
chip read `I.15` where the useful thing to read is
`angle EGB = angle AGH — I.15`.

Raised while building **I.28**, where one paragraph carries three reasoning
steps under three different propositions. With nowhere to put the statement,
the only way to pair each one with its own citation was to **split the slide
into one sub-slide per statement** — slide count driven by a data-model gap
rather than by the proof's rhythm. The ask had been sitting in the
coordination doc since 2026-06-22 without a ticket.

## The change

```ts
export interface ISlideJust {
    ref: string;
    claim?: string;   // 0.14.0+
}
```

Rendered as `claim — ref`, with `ref` keeping its existing link behaviour
(`resolveJustification` → anchor, otherwise plain text). Omit `claim` and the
panel renders exactly as before.

## Layout follows the data

The ticket flagged this as an open question, and it turns out to answer itself:
a bare citation is a chip and several read fine as one dot-separated row, but a
claim makes each entry a *statement*, and statements don't read as a row.

So: **any** claim on the slide and the entries stack one per line; no claims
anywhere and the panel is the same inline `·`-joined row it has always been.
Mixed slides stack too — a bare citation shouldn't be stranded mid-row beside
statements. `justsUseStackedLayout()` is exported and DOM-free so the rule is
testable, following the `parseCaptionTokens` / `escapeAction` precedent.

## Deliberately not included

The ticket asked whether `claim` should accept `{NAME}` tokens, so
`{EGB} = {AGH}` would light both angle markers on hover. That is a genuinely
bigger feature than the original ask, so this is the plain-text version — the
field can gain tokenization later without changing any deck that adopts it now.

## Verification

- `tsc --noEmit` clean; **700 snapshot + 321 unit passing**, 0 errors.
- 6 new tests: the claim survives `init()` onto the slate, an entry without one
  stays a bare citation, and the layout rule across no-claims / claimed / mixed
  / empty-string / no-justifications.
- `view/test/just-claim.html` builds I.28's actual figure and shows bare,
  claimed and mixed slides so the row-vs-stacked difference is visible.
- Documented in `api.md` under Justification refs.

## For the slideshow session

Nothing changes until a deck opts in. Where I.28 was split into per-statement
sub-slides purely to keep each chip to one citation, those can be recombined —
though a step-per-slide pace is still a fine authoring choice, it just stops
being forced.
