### PR TITLE
Resolve aliases in slide sets; warn on names that match nothing (#151)

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,3 +1,4 @@
 {
-  "require": "ts-node/register"
+  "require": "ts-node/register",
+  "timeout": 10000
 }

--- a/doc/api.md
+++ b/doc/api.md
@@ -363,6 +363,28 @@ synonyms — Joyce's prose refers to the same circle as both *BCD* and
 alias map once. Aliases never appear in `_elements`; the slate stays
 the same size whether or not you register them.
 
+**Aliases work in slide sets too (#151, 0.14.0+).** `visible`,
+`highlighted` and an animation's `elem:` all accept either the declared
+name or any alias of it. Before 0.14.0 the slide sets were passed through
+verbatim while the renderers compared against the element's own `name`, so
+an alias there matched nothing and was **silently ignored** — the element
+simply never lit. (An audit of the Elements decks found 33 such inert names
+across 17 canvases.)
+
+**A name matching no element is now reported.** `computeSlideState` warns
+once per slate, naming the slide number and the field:
+
+```
+[geomlib] slide 4 lists 'FC' in highlighted, but no element or alias
+resolves to it — the name is ignored. Check for a typo, or for a target
+left behind by a figure change.
+```
+
+An animation whose `elem:` resolves to nothing warns similarly instead of
+skipping in silence. That second case catches **stale targets**: entries
+left in a deck after the figure they pointed at was refactored away, which
+otherwise never play and never complain.
+
 ### Slideshow data on `init()`
 
 ```typescript

--- a/src/SlateAnimator.ts
+++ b/src/SlateAnimator.ts
@@ -107,7 +107,20 @@ export class SlateAnimator {
         const reduced = config.reducedMotion === true || speedMul === 0;
         for (const entry of slideAnimations || []) {
             const target = this.slate.lookupElement(entry.elem);
-            if (target == null) continue;
+            if (target == null) {
+                // #151 — say so. A silent skip here is how a stale target
+                // survives a figure refactor: the animation entry stays in
+                // the deck, resolves to nothing, and simply never plays.
+                if (typeof console !== "undefined" && console.warn) {
+                    console.warn(
+                        "[geomlib] animation targets '" + entry.elem +
+                        "', but no element or alias resolves to it — " +
+                        "the step is skipped. Check for a typo, or for a " +
+                        "target left behind by a figure change."
+                    );
+                }
+                continue;
+            }
             const animation: Animation | null = findAnimation(entry.name);
             if (animation == null) continue;
             // Type guard: console.warn-and-skip when the animation's

--- a/src/slideshow.ts
+++ b/src/slideshow.ts
@@ -5,6 +5,62 @@
 import {Slate} from "./Slate";
 import {ISlide} from "./index";
 
+
+// #151 — resolve slide-set names through the alias table, and report the
+// ones that resolve to nothing.
+//
+// Aliases worked for prose `{NAME}` refs and `lookupElement`, but a slide's
+// `visible` / `highlighted` arrays were passed through verbatim and both
+// consumers compare against the element's own `name`. An alias placed in a
+// slide set therefore matched nothing and was **silently** ignored: no
+// error, no warning, the element just never lit. An audit of the lektor
+// decks found 33 such inert names across 17 canvases, spanning propositions
+// I.8 to I.47.
+//
+// The asymmetry was the trap: an author who wrote `aliases: { FC: "CF" }`
+// and watched `{FC}` light from the prose had every reason to expect "FC" to
+// work in a slide set too.
+
+// Names already reported per slate, so a warning fires once rather than on
+// every redraw of every slide. Keyed weakly so a discarded slate doesn't
+// pin its strings.
+const warnedNames: WeakMap<Slate, {[key: string]: boolean}> = new WeakMap();
+
+function warnOnce(slate: Slate, key: string, message: string): void {
+    let seen = warnedNames.get(slate);
+    if (seen == null) { seen = {}; warnedNames.set(slate, seen); }
+    if (seen[key]) return;
+    seen[key] = true;
+    if (typeof console !== "undefined" && console.warn) console.warn(message);
+}
+
+/**
+ * Map slide-set names onto the element names the renderers actually compare
+ * against, following one alias hop via `lookupElement`.
+ *
+ * Returns the canonical set plus every name that resolved to no element.
+ * An unmatched name is kept in the set as authored — dropping it would
+ * change nothing on screen (nothing matches it either way) and keeping it
+ * makes the returned set a faithful record of what the slide asked for.
+ */
+export function canonicaliseSlideNames(
+    slate: Slate,
+    names: string[],
+): { canonical: Set<string>, unmatched: string[] } {
+    const canonical = new Set<string>();
+    const unmatched: string[] = [];
+    for (const name of names || []) {
+        const elem = slate.lookupElement(name);
+        if (elem != null && elem.name != null) {
+            canonical.add(elem.name);
+        } else {
+            canonical.add(name);
+            unmatched.push(name);
+        }
+    }
+    return { canonical, unmatched };
+}
+
 // Compute the visible + highlighted name sets for slide `index` given:
 //   - visible inherits from the previous slide if omitted;
 //     "hide all at start" applies when no earlier slide ever declared
@@ -17,6 +73,10 @@ import {ISlide} from "./index";
 //     element.
 //   - Every highlighted name is auto-unioned into visible — you can't
 //     highlight what isn't drawn.
+//   - Names are resolved through the alias table (#151), so a slide set may
+//     spell an element any way the prose does. A name matching no element
+//     is reported once per slate via console.warn — that also surfaces
+//     stale targets left behind when a figure is refactored.
 export function computeSlideState(
     slate: Slate,
     slides: ISlide[],
@@ -24,16 +84,23 @@ export function computeSlideState(
 ): { visible: Set<string>, highlighted: Set<string> } {
     // Walk back to find the most recent explicit `visible` array.
     let baseVisible: string[] = [];
+    let baseIndex = index;
     for (let i = index; i >= 0; i--) {
         if (slides[i].visible != null) {
             baseVisible = slides[i].visible;
+            baseIndex = i;
             break;
         }
     }
-    const visible = new Set<string>(baseVisible);
+    // #151 — resolve aliases before the renderers compare against e.name.
+    const v = canonicaliseSlideNames(slate, baseVisible);
+    const visible = v.canonical;
+    reportUnmatched(slate, v.unmatched, baseIndex, "visible");
 
     const slide = slides[index];
-    const highlighted = new Set<string>(slide.highlighted || []);
+    const h = canonicaliseSlideNames(slate, slide.highlighted || []);
+    const highlighted = h.canonical;
+    reportUnmatched(slate, h.unmatched, index, "highlighted");
 
     for (const e of slate.elements) {
         if (e.draggable && e.name != null
@@ -44,4 +111,21 @@ export function computeSlideState(
     highlighted.forEach(name => visible.add(name));
 
     return { visible, highlighted };
+}
+
+// Shared wording for an unmatched slide-set name, so `visible`,
+// `highlighted` and an animation's `elem:` all read the same in the console.
+function reportUnmatched(
+    slate: Slate,
+    unmatched: string[],
+    slideIndex: number,
+    field: string,
+): void {
+    for (const name of unmatched) {
+        warnOnce(slate, field + ":" + name,
+            "[geomlib] slide " + (slideIndex + 1) + " lists '" + name +
+            "' in " + field + ", but no element or alias resolves to it — " +
+            "the name is ignored. Check for a typo, or for a target left " +
+            "behind by a figure change.");
+    }
 }

--- a/tests/SlideTest.ts
+++ b/tests/SlideTest.ts
@@ -7,8 +7,9 @@ import "mocha";
 import * as assert from "assert";
 import {parseCaptionTokens, justsUseStackedLayout} from "../src/SlateControls";
 import {createCanvas} from "canvas";
-import {init, slates, ISlide, IConstructionInfo, E} from "../src/index";
-import {computeSlideState} from "../src/slideshow";
+import {init, slates, ISlide, IConstructionInfo, E, parseParam} from "../src/index";
+import {computeSlideState, canonicaliseSlideNames} from "../src/slideshow";
+import {Slate} from "../src/Slate";
 
 // Mock the minimum DOM that init() needs.
 function withFakeDOM<T>(fn: (canvasId: string) => T): T {
@@ -354,6 +355,109 @@ describe("ISlideJust.claim (#146)", () => {
             assert.equal(justsUseStackedLayout(undefined), false);
             assert.equal(justsUseStackedLayout(null), false);
             assert.equal(justsUseStackedLayout([]), false);
+        });
+    });
+});
+
+// #151 — aliases in slide sets, and a warning for names that match nothing.
+describe("slide-set alias resolution (#151)", () => {
+
+    // A line declared as CF, which the prose also calls FC.
+    function scene(): Slate {
+        const slate = new Slate(createCanvas(200, 200) as any);
+        slate.inTest = true;
+        for (const spec of ["C;point;free;10,10", "F;point;free;90,90"]) {
+            const i = parseParam(spec);
+            slate.createElement(i.construction, i.params, i.name);
+        }
+        const l = parseParam("CF;line;connect;C,F");
+        slate.createElement(l.construction, l.params, l.name);
+        slate.addAliases({ "FC": "CF" });
+        slate.update();
+        return slate;
+    }
+
+    function captureWarnings<T>(fn: () => T): {result: T, warnings: string[]} {
+        const warnings: string[] = [];
+        const saved = console.warn;
+        console.warn = (...args: any[]) => { warnings.push(args.join(" ")); };
+        try { return {result: fn(), warnings}; }
+        finally { console.warn = saved; }
+    }
+
+    it("canonicalises an alias used in highlighted", () => {
+        const slate = scene();
+        const st = computeSlideState(slate, [
+            { text: "", visible: ["CF"], highlighted: ["FC"] },
+        ], 0);
+        assert.ok(st.highlighted.has("CF"),
+            "the renderers compare against e.name, so the set must hold the " +
+            "declared name — an alias here used to be silently ignored");
+    });
+
+    it("canonicalises an alias used in visible", () => {
+        const slate = scene();
+        const st = computeSlideState(slate, [
+            { text: "", visible: ["FC"] },
+        ], 0);
+        assert.ok(st.visible.has("CF"));
+    });
+
+    it("leaves an already-canonical name alone", () => {
+        const slate = scene();
+        const st = computeSlideState(slate, [
+            { text: "", visible: ["CF"], highlighted: ["CF"] },
+        ], 0);
+        assert.ok(st.visible.has("CF") && st.highlighted.has("CF"));
+    });
+
+    it("warns once for a name that resolves to nothing", () => {
+        const slate = scene();
+        const slides = [{ text: "", visible: ["CF"], highlighted: ["ZZ"] }];
+        const {warnings} = captureWarnings(() => {
+            computeSlideState(slate, slides, 0);
+            computeSlideState(slate, slides, 0);   // redraw — must not re-warn
+            computeSlideState(slate, slides, 0);
+        });
+        assert.equal(warnings.length, 1, "one warning per name per slate, not per redraw");
+        assert.ok(warnings[0].indexOf("ZZ") >= 0, warnings[0]);
+        assert.ok(warnings[0].indexOf("highlighted") >= 0, warnings[0]);
+    });
+
+    it("names the slide number in the warning", () => {
+        const slate = scene();
+        const {warnings} = captureWarnings(() =>
+            computeSlideState(slate, [
+                { text: "", visible: ["CF"] },
+                { text: "", highlighted: ["nope"] },
+            ], 1));
+        assert.equal(warnings.length, 1);
+        assert.ok(warnings[0].indexOf("slide 2") >= 0,
+            "1-based, matching the slide counter the viewer sees: " + warnings[0]);
+    });
+
+    it("does not warn for a valid alias", () => {
+        const slate = scene();
+        const {warnings} = captureWarnings(() =>
+            computeSlideState(slate, [{ text: "", highlighted: ["FC"] }], 0));
+        assert.deepEqual(warnings, []);
+    });
+
+    describe("canonicaliseSlideNames", () => {
+        it("reports which names matched nothing", () => {
+            const slate = scene();
+            const r = canonicaliseSlideNames(slate, ["FC", "CF", "ghost"]);
+            assert.deepEqual(r.unmatched, ["ghost"]);
+            assert.ok(r.canonical.has("CF"));
+            assert.ok(r.canonical.has("ghost"),
+                "an unmatched name is kept as authored — dropping it would " +
+                "change nothing on screen and lose what the slide asked for");
+        });
+
+        it("handles an empty / missing list", () => {
+            const slate = scene();
+            assert.deepEqual(canonicaliseSlideNames(slate, []).unmatched, []);
+            assert.deepEqual(canonicaliseSlideNames(slate, null as any).unmatched, []);
         });
     });
 });


### PR DESCRIPTION
Closes #151.

Aliases resolved for prose `{NAME}` refs and `lookupElement`, but **not**
inside a slide's `visible` / `highlighted` arrays. `computeSlideState` built
those sets verbatim from the slide, while both consumers compare against the
element's own `name` — so an alias in a slide set matched nothing and was
**silently ignored**. No error, no warning; the element just never lit.

An audit of the Elements decks found **33 inert names across 17 canvases**,
in propositions spanning I.8 to I.47. All were fixed deck-side, but the trap
remained for every future deck.

The asymmetry is what made it costly: an author who wrote
`aliases: { FC: "CF" }` and watched `{FC}` light from the prose had every
reason to expect `"FC"` to work in a slide set too.

## Both halves of the fix

**1. Canonicalise.** `canonicaliseSlideNames()` maps each slide-set name
through `lookupElement` (one alias hop, same as prose refs) before the
renderers see it. `visible`, `highlighted` and an animation's `elem:` now all
accept either spelling.

**2. Warn on a name that matches nothing** — which the issue argued is the
more valuable half, and I agree. `computeSlideState` reports once per slate:

```
[geomlib] slide 4 lists 'FC' in highlighted, but no element or alias
resolves to it — the name is ignored. Check for a typo, or for a target
left behind by a figure change.
```

Once per slate, not per redraw — `computeSlideState` runs on every slide
advance, so an un-deduped warning would bury the console. Tracked in a
`WeakMap` so a discarded slate doesn't pin its strings.

The slide number is **1-based**, matching the counter the viewer sees in the
presentation overlay rather than the array index.

## The stale-target case

`SlateAnimator` already resolved `elem:` through `lookupElement`, so aliases
worked there — but an unresolvable target hit a bare `continue`. That silence
is exactly how a stale target survives a figure refactor: the entry stays in
the deck, resolves to nothing, and never plays or complains. It now warns in
the same wording.

The issue names a live instance: **I.23 still animates 8 `t1*`/`t2*` elements
deleted in the #127 `compassTransfer` swap**. Nothing anywhere reported it.
After this, loading that deck says so.

## Unmatched names are kept, not dropped

`canonicaliseSlideNames` leaves an unresolvable name in the returned set as
authored. Dropping it would change nothing on screen — nothing matches it
either way — and keeping it makes the set a faithful record of what the slide
asked for. There's a test pinning that.

## Also: the CI flake

`.mocharc.json` gains `"timeout": 10000`. Mocha's 2 s default is measured
against the **first test in a file**, which on a cold CI runner includes
ts-node compiling that file. #145 failed CI on
`SectorTest.ts › assigns translucent palette colors in construction order`
purely for that reason — 22 tests, 31 ms locally. A re-run passed unchanged.
This stops a red check that means nothing from blocking a release.

## Verification

- `tsc --noEmit` clean; **705 snapshot + 358 unit passing**, 0 errors.
- 8 new tests: alias resolution in both fields, canonical names untouched,
  warn-once-per-name across repeated redraws, the 1-based slide number in the
  message, silence for a valid alias, and `canonicaliseSlideNames` reporting
  unmatched names / handling an empty or missing list.
- No existing test emits a warning, so the suite confirms the current fixtures
  have no unmatched names.
- Documented in `api.md` under Name aliases.

## For the slideshow session

Nothing to change — the 33 names are already canonicalised deck-side, and this
only widens what resolves. On the pin bump, loading a deck will start
reporting anything stale; I.23's 8 dead animation targets are the known first
hit.
