### PR TITLE
Document the Java 8 baseline: archive tag + harness/propI4 branch are kept on purpose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,5 +183,15 @@ Many test fixtures (`view/euclid-html/`, `view/compass_geometry/`,
   targeted at euclids-elements.org. Phase 3 (HTML conversion) was
   completed there.
 - The Java↔TypeScript visual comparison harness (docker, applet
-  viewer, X11) was retired. The snapshot test suite is the
-  ongoing regression mechanism.
+  viewer, X11) was retired from day-to-day use. The snapshot test suite
+  is the ongoing regression mechanism.
+
+  **Kept deliberately as a baseline**, not abandoned: the
+  `archive/java-harness` tag holds the retired harness, and the
+  **`harness/propI4` branch** carries a Proposition I.4 comparison pair
+  (`view/applet-tests/elements/propI4/` + `view/test/elements/propI4.html`)
+  that exists nowhere else — not on `main`, not under the tag. Both are
+  there so that if the port ever shows behaviour we can't explain, the
+  original Java 8 applet can be run as the reference. Expect to reach for
+  this rarely, and less often as the library grows features the applet
+  never had — but do not delete either one during branch cleanup.


### PR DESCRIPTION
`AGENTS.md` (and `CLAUDE.md`, which symlinks to it) said the Java↔TypeScript
comparison harness "was retired", full stop. That reads as *gone*, and during
a branch cleanup it nearly cost us the one branch holding content that exists
nowhere else.

Two things are kept on purpose:

- the **`archive/java-harness` tag** — the retired harness itself;
- the **`harness/propI4` branch** — a Proposition I.4 comparison pair
  (`view/applet-tests/elements/propI4/applet.html`, `original.html`, and
  `view/test/elements/propI4.html`). I checked: this content is **not** on
  `main` and **not** under the archive tag. The branch is its only home.

They exist so that if the port ever shows behaviour we can't explain, the
original Java 8 applet can be run as a reference baseline. That will be needed
rarely, and less often as the library grows features the applet never had —
which is exactly why it needed writing down rather than remembering.

The note now says both are deliberate and must survive branch cleanup.

Docs only; no code, no tests affected.