### PR TITLE
On-canvas diagnostic badge + per-slate diagnostics API (#154)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,12 +101,54 @@ npm run test:snapshot    # 700 snapshot tests; auto-creates goldens on first run
 npm test                 # both
 npm run bundle           # dev-mode bundle to dist/bundle.js
 npm run bundle:prod      # production (minified) bundle, ~125 kB
+npm run archive:index    # regenerate view/test/archive-index.json (see below)
 npm publish --dry-run    # preview tarball without publishing
 ```
 
 Goldens under `tests/snapshots/**/*.png` are gitignored — each
 contributor regenerates locally. `npm run snapshots:clean` wipes
 them; the next `npm test` re-creates from scratch.
+
+## Tracing a diagnostic back to its page
+
+geomlib reports what it cannot resolve (#154) — a slide naming a missing
+element, an animation target deleted by a refactor, a param that won't
+parse. During a test or coverage run those arrive as a wall of
+`[geomlib] …` lines, each prefixed with the fixture that produced it:
+
+```
+[geomlib] view/euclid-html/booki/propI4.html: element 'b' failed to construct: Element with name a not found.
+```
+
+To look at the page itself, serve the repo root and open the **archive
+viewer**:
+
+```sh
+python3 -m http.server 8000
+# then: http://localhost:8000/view/test/archive-viewer.html
+```
+
+**Paste the diagnostic output straight into it.** It pulls the paths out,
+groups the messages per page, and gives you a link that loads each one.
+Absolute paths, repo-relative paths and bare filenames all resolve; a path
+it doesn't recognise is listed as skipped rather than dropped. There is
+also a filterable index of every fixture the snapshot suite discovers, and
+`?p=` deep-links a page directly.
+
+Why a viewer is needed at all: the pages under `view/euclid-html/`,
+`view/compass_geometry/` and `view/round_geometry/` are Dr. Joyce's 1996
+originals, kept verbatim as snapshot input. **They cannot load in a
+browser on their own** — each figure is a Java `<applet>`,
+`navigator.javaEnabled()` has been removed from browsers (so the page's own
+`.gif` fallback never swaps in either), and `../elements.js` was never
+mirrored into this repo. The snapshot suite doesn't care: it never executes
+the page, it scrapes the `<param>` tags as text
+(`tests/HtmlParamParser.ts`) and renders through node-canvas. The viewer
+does the same translation in the browser, reading each page **without
+modifying it**.
+
+The index is a generated manifest — a browser can't list a directory — so
+run `npm run archive:index` after adding or removing fixtures.
 
 ## CRITICAL contracts (when touching element code)
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -668,8 +668,8 @@ class Slate {
 ```
 
 **The badge.** A canvas that has reported anything shows a small mark in
-its **upper-left** corner — an amber `!` triangle for warnings, a red ✕
-when anything reached error severity (error supersedes warning). Tooltip:
+its **upper-left** corner — an amber `!` triangle for warnings, a red stop-sign
+octagon when anything reached error severity (error supersedes warning). Tooltip:
 `geomlib generated warnings - check console`. A clean diagram shows
 nothing and does not even create the element.
 
@@ -685,6 +685,13 @@ so it cannot scroll past unnoticed. It clears on the **reset** control
 *not* `Slate.reset()`: minimize and presentation-exit both call that
 internally, and construction-time diagnostics never fire again, so
 clearing there would discard exactly the warnings worth keeping.
+
+**Decks are checked at load.** Every name in a slide's `visible` /
+`highlighted` set and every animation `elem:` is resolved once when the
+figure is built, so a stale reference reports immediately. Without that
+the diagnostic would only fire if a viewer actually advanced to the
+offending slide — the case that goes unnoticed, and one that would leave
+a build-time checker seeing a clean page.
 
 **Per canvas.** Diagnostics belong to the slate that produced them, so on
 a page of many figures each badge reflects only its own canvas. (Before

--- a/doc/api.md
+++ b/doc/api.md
@@ -637,6 +637,96 @@ render is bit-for-bit identical to earlier versions, which is why no existing
 snapshot golden moved. Opt out per slate with `init({ highlightOnTop: false })`
 or `slate.highlightOnTop = false`.
 
+### Diagnostics and the on-canvas badge (#154, 0.14.0+)
+
+geomlib skips what it cannot resolve and keeps rendering: an animation
+whose target does not exist is passed over, a slide name matching nothing
+is ignored. That keeps a partly-broken deck usable, but the only evidence
+used to be a `console.warn` — and a deck author has no reason to have
+devtools open. (An audit of the *Elements* decks found 33 inert names
+across 17 canvases that had gone unnoticed for months.)
+
+Every diagnostic is now recorded on the slate that produced it:
+
+```typescript
+interface IDiagnostic {
+    severity: "warning" | "error";
+    code: string;        // "unknown-animation", "unknown-slide-name", ...
+    message: string;     // without the "[geomlib] " console prefix
+    detail?: object;     // structured payload, e.g. { elem: "GHOST" }
+    at: number;          // first occurrence
+    count: number;       // occurrences of this dedupe key
+}
+
+class Slate {
+    reportDiagnostic(input): void;
+    get diagnostics(): IDiagnostic[];
+    get diagnosticSeverity(): "warning" | "error" | null;   // null = clean
+    clearDiagnostics(): void;
+    onDiagnosticsChanged(fn: (s: Slate) => void): () => void;
+}
+```
+
+**The badge.** A canvas that has reported anything shows a small mark in
+its **upper-left** corner — an amber `!` triangle for warnings, a red ✕
+when anything reached error severity (error supersedes warning). Tooltip:
+`geomlib generated warnings - check console`. A clean diagram shows
+nothing and does not even create the element.
+
+Unlike the reset / maximize / present controls, which stay hidden until
+the canvas is hovered or focused (#69), **the badge is always visible** —
+a diagnostic you only see once you go looking for it is no use. It rides
+along into maximized and presentation views, and does not overlap the
+presentation caption or nav (those are pinned to the bottom).
+
+**It latches.** A warning raised on slide 4 is still showing on slide 5,
+so it cannot scroll past unnoticed. It clears on the **reset** control
+(`r` / space) — the deliberate "I have seen it" gesture. Note this is
+*not* `Slate.reset()`: minimize and presentation-exit both call that
+internally, and construction-time diagnostics never fire again, so
+clearing there would discard exactly the warnings worth keeping.
+
+**Per canvas.** Diagnostics belong to the slate that produced them, so on
+a page of many figures each badge reflects only its own canvas. (Before
+0.14.0 two dedupe flags were module-global, so the first figure to hit a
+bad name silenced every other figure on the page.)
+
+#### Reading diagnostics programmatically
+
+```typescript
+geomlib.diagnostics(opts?: { canvasids?: string[] }): {
+    severity: "warning" | "error" | null;   // worst on the page
+    count: number;
+    slates: { canvasid: string | null; index: number;
+              severity: "warning" | "error" | null;
+              entries: IDiagnostic[] }[];   // only slates that reported
+    init: IDiagnostic[];                    // init() failures (no slate exists)
+}
+```
+
+One call gives a page's whole diagnostic state — for a console check, or
+for a static-site generator gating a build. `opts.canvasids` scopes the
+query, mirroring [`highlightByName`](#geomlibhighlightbyname--cross-canvas-highlight-130-0130).
+
+`init()` failures cannot belong to a slate (a wrong `canvasid` makes the
+Slate constructor throw), so they collect in `geomlib.initDiagnostics`
+and appear under `init`. On failure geomlib also places an error mark
+next to where the diagram would have been, then reveals the `<noscript>`
+fallback as before.
+
+#### `geomlib:diagnostic` event
+
+Mirrors `geomlib:highlight`: a bubbling `CustomEvent` on the slate's
+canvas, so a page can collect diagnostics as they happen.
+
+```js
+document.addEventListener("geomlib:diagnostic", (ev) => {
+    // ev.detail.diagnostic — the new IDiagnostic, or null when cleared
+    // ev.detail.severity   — worst on that slate, null when cleared
+    // ev.detail.count      — distinct diagnostics on that slate
+});
+```
+
 ### `geomlib:highlight` event (#108, 0.11.0+)
 
 When the set of highlighted elements (`shouldHighlight || emphasized`)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "coverage:unit": "c8 mocha --reporter min tests/AnimationTest.ts tests/CircleTest.ts tests/DiagnosticsTest.ts tests/ColorsTest.ts tests/HighlightByNameTest.ts tests/HighlightTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateAnimatorTest.ts tests/SlateTest.ts tests/SlideTest.ts tests/SourceHygieneTest.ts tests/SphereTest.ts tests/VisibilityTest.ts",
     "coverage:report": "c8 report --reporter=html",
     "snapshots:clean": "rm -rf tests/snapshots && mkdir -p tests/snapshots && touch tests/snapshots/.gitkeep",
-    "prepublishOnly": "npm run test:unit && npm run bundle:prod && npm run check:bundle"
+    "prepublishOnly": "npm run test:unit && npm run bundle:prod && npm run check:bundle",
+    "archive:index": "node scripts/build-archive-index.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@brownnrl/geomlib",
   "version": "0.13.0",
-  "description": "Interactive Euclidean geometry constructions in the browser — a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
+  "description": "Interactive Euclidean geometry constructions in the browser \u2014 a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
   "keywords": [
     "euclid",
     "elements",
@@ -29,9 +29,9 @@
     "check:bundle": "node scripts/check-bundle-ascii.js",
     "test": "npm run test:snapshot && npm run test:unit",
     "test:snapshot": "npm run bundle && mocha --reporter min tests/SnapshotTest.ts tests/HighlightSnapshotTest.ts tests/VisibilitySnapshotTest.ts tests/AnimationSnapshotTest.ts",
-    "test:unit": "mocha tests/AnimationTest.ts tests/CircleTest.ts tests/ColorsTest.ts tests/HighlightByNameTest.ts tests/HighlightTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateAnimatorTest.ts tests/SlateTest.ts tests/SlideTest.ts tests/SourceHygieneTest.ts tests/SphereTest.ts tests/VisibilityTest.ts",
-    "coverage": "c8 mocha --reporter min tests/SnapshotTest.ts tests/AnimationTest.ts tests/CircleTest.ts tests/ColorsTest.ts tests/HighlightByNameTest.ts tests/HighlightTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateAnimatorTest.ts tests/SlateTest.ts tests/SlideTest.ts tests/SphereTest.ts tests/VisibilityTest.ts",
-    "coverage:unit": "c8 mocha --reporter min tests/AnimationTest.ts tests/CircleTest.ts tests/ColorsTest.ts tests/HighlightByNameTest.ts tests/HighlightTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateAnimatorTest.ts tests/SlateTest.ts tests/SlideTest.ts tests/SphereTest.ts tests/VisibilityTest.ts",
+    "test:unit": "mocha tests/AnimationTest.ts tests/CircleTest.ts tests/DiagnosticsTest.ts tests/ColorsTest.ts tests/HighlightByNameTest.ts tests/HighlightTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateAnimatorTest.ts tests/SlateTest.ts tests/SlideTest.ts tests/SourceHygieneTest.ts tests/SphereTest.ts tests/VisibilityTest.ts",
+    "coverage": "c8 mocha --reporter min tests/SnapshotTest.ts tests/AnimationTest.ts tests/CircleTest.ts tests/DiagnosticsTest.ts tests/ColorsTest.ts tests/HighlightByNameTest.ts tests/HighlightTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateAnimatorTest.ts tests/SlateTest.ts tests/SlideTest.ts tests/SourceHygieneTest.ts tests/SphereTest.ts tests/VisibilityTest.ts",
+    "coverage:unit": "c8 mocha --reporter min tests/AnimationTest.ts tests/CircleTest.ts tests/DiagnosticsTest.ts tests/ColorsTest.ts tests/HighlightByNameTest.ts tests/HighlightTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateAnimatorTest.ts tests/SlateTest.ts tests/SlideTest.ts tests/SourceHygieneTest.ts tests/SphereTest.ts tests/VisibilityTest.ts",
     "coverage:report": "c8 report --reporter=html",
     "snapshots:clean": "rm -rf tests/snapshots && mkdir -p tests/snapshots && touch tests/snapshots/.gitkeep",
     "prepublishOnly": "npm run test:unit && npm run bundle:prod && npm run check:bundle"

--- a/src/Diagnostics.ts
+++ b/src/Diagnostics.ts
@@ -1,0 +1,140 @@
+/*----------------------------------------------------------------------+
+|    Title:  Diagnostics.ts                                             |
+|    Per-slate diagnostic records (#154).                               |
+|                                                                        |
+|    geomlib fails quietly by design: an animation whose target does    |
+|    not resolve is skipped, a slide name that matches nothing is       |
+|    ignored. That keeps a bad deck rendering, but it also means the    |
+|    only evidence is a console line nobody has open. This module is    |
+|    the record of what went wrong, so a slate can show a badge and a   |
+|    consumer can read the list.                                        |
+|                                                                        |
+|    Deliberately free of any DOM or Slate import: every decision the   |
+|    badge makes (which severity wins, whether to show anything at      |
+|    all) is made here, where it can be unit-tested without a browser.  |
++----------------------------------------------------------------------*/
+
+export type DiagnosticSeverity = "warning" | "error";
+
+// Ordering for "error supersedes warning". One place, so the badge and
+// the page-wide aggregator can't disagree about which is worse.
+export const SEVERITY_RANK: { [k: string]: number } = { warning: 1, error: 2 };
+
+export interface IDiagnostic {
+    severity: DiagnosticSeverity;
+    // Stable machine-readable class ("unknown-animation", "init-failed").
+    // The badge must not parse English, and a consumer filtering by kind
+    // shouldn't have to regex prose.
+    code: string;
+    // Human text, WITHOUT the "[geomlib] " prefix — the console mirror
+    // adds that, so the stored message stays clean for a UI to render.
+    message: string;
+    detail?: { [k: string]: any };
+    // Time of FIRST occurrence. Useful for ordering; note it makes the
+    // record nondeterministic, so drop it before serialising in a test.
+    at: number;
+    // How many times this dedupe key fired, including the first.
+    count: number;
+}
+
+export interface IDiagnosticInput {
+    code: string;
+    message: string;
+    severity?: DiagnosticSeverity;      // default "warning"
+    detail?: { [k: string]: any };
+    // Dedupe discriminator. Defaults to the message, but naming the
+    // varying part explicitly ("the element name") keeps the key stable
+    // when the wording of the message changes.
+    key?: string;
+}
+
+export function dedupeKeyOf(input: IDiagnosticInput): string {
+    const sev = input.severity != null ? input.severity : "warning";
+    const k = input.key != null ? input.key : input.message;
+    return sev + "|" + input.code + "|" + k;
+}
+
+/** The worse of two severities; null means "clean". */
+export function worstSeverity(
+    a: DiagnosticSeverity | null,
+    b: DiagnosticSeverity | null,
+): DiagnosticSeverity | null {
+    if (a == null) return b;
+    if (b == null) return a;
+    return SEVERITY_RANK[a] >= SEVERITY_RANK[b] ? a : b;
+}
+
+/**
+ * An append-only log of what a slate has complained about.
+ *
+ * Never evicts: a diagnostic reported on slide 4 is still there on slide
+ * 5, so a warning cannot scroll past unnoticed. Cleared only explicitly.
+ */
+export class DiagnosticLog {
+
+    private _entries: IDiagnostic[] = [];
+    private _byKey: { [key: string]: IDiagnostic } = {};
+    private _worst: DiagnosticSeverity | null = null;
+
+    /**
+     * Record a diagnostic. Returns the new record, or null when this key
+     * has already been seen — so a caller can mirror to the console only
+     * on first occurrence, which is what the old per-module dedupe flags
+     * were doing, except now scoped to one slate instead of the page.
+     */
+    report(input: IDiagnosticInput, now: number): IDiagnostic | null {
+        const key = dedupeKeyOf(input);
+        const existing = this._byKey[key];
+        if (existing != null) {
+            existing.count++;
+            return null;
+        }
+        const rec: IDiagnostic = {
+            severity: input.severity != null ? input.severity : "warning",
+            code: input.code,
+            message: input.message,
+            at: now,
+            count: 1,
+        };
+        if (input.detail != null) rec.detail = input.detail;
+        this._byKey[key] = rec;
+        this._entries.push(rec);
+        this._worst = worstSeverity(this._worst, rec.severity);
+        return rec;
+    }
+
+    get entries(): IDiagnostic[] {
+        return this._entries.slice();
+    }
+
+    /** Worst severity recorded, or null when the slate is clean. */
+    get severity(): DiagnosticSeverity | null {
+        return this._worst;
+    }
+
+    /** Distinct diagnostics (not total occurrences). */
+    get count(): number {
+        return this._entries.length;
+    }
+
+    clear(): void {
+        this._entries = [];
+        this._byKey = {};
+        this._worst = null;
+    }
+}
+
+/**
+ * Payload for the `geomlib:diagnostic` CustomEvent. Extracted so the
+ * event's shape is testable without a DOM — the dispatch site is then
+ * just a capability guard plus a wrap.
+ *
+ * `diagnostic` is null when the log was cleared, so a listener can
+ * un-render without special-casing.
+ */
+export function diagnosticEventDetail(
+    log: DiagnosticLog,
+    d: IDiagnostic | null,
+): { diagnostic: IDiagnostic | null; severity: DiagnosticSeverity | null; count: number } {
+    return { diagnostic: d, severity: log.severity, count: log.count };
+}

--- a/src/Slate.ts
+++ b/src/Slate.ts
@@ -9,6 +9,8 @@ import {PolygonElement} from "./elements/polygon/PolygonElement";
 import {CircleElement} from "./elements/circle/CircleElement";
 import {ISlide, ISlideAnimation, IAnimationConfig} from "./index";
 import {SlateAnimator} from "./SlateAnimator";
+import {DiagnosticLog, IDiagnostic, IDiagnosticInput, DiagnosticSeverity,
+        diagnosticEventDetail} from "./Diagnostics";
 
 export type SlateCanvas = HTMLCanvasElement | Canvas;
 
@@ -121,6 +123,12 @@ export class Slate {
     // (#108) fires only when the SET of highlighted elements changes — not
     // on every redraw frame / emphasisAmount fade.
     private _lastHighlightedKey : string = "\u0000";
+    // #154 — what this slate has complained about, so a badge can show it
+    // and a consumer can read it. Per-slate on purpose: the dedupe flags
+    // this replaced were module-global, so one figure's warning silenced
+    // every other figure on the page.
+    private _diagnostics : DiagnosticLog = new DiagnosticLog();
+    private _diagnosticListeners : Array<(s: Slate) => void> = [];
     protected _screen : PlaneElement;
     protected _pick : PointElement;
     protected _canvas : SlateCanvas;
@@ -766,6 +774,87 @@ export class Slate {
         canvas.dispatchEvent(new CustomEvent("geomlib:highlight", {
             bubbles: true,
             detail: { highlighted },
+        }));
+    }
+
+    // ---- Diagnostics (#154) ------------------------------------------
+    //
+    // geomlib skips what it cannot resolve and keeps rendering, which is
+    // the right behaviour — a deck with one bad name should still draw.
+    // The cost is that the only evidence was a console line nobody has
+    // open. Reporting through here records it too, so SlateControls can
+    // badge the canvas and a consumer can read the list.
+
+    /**
+     * Record a diagnostic and mirror it to the console.
+     *
+     * Deduped per key, per slate: repeat reports bump a counter without
+     * a second console line. That replaces two module-global dedupe
+     * flags which silenced a warning for every OTHER figure on the page
+     * once any one figure tripped them.
+     */
+    reportDiagnostic(input: IDiagnosticInput) : void {
+        const rec = this._diagnostics.report(input, Date.now());
+        if (rec == null) return;   // already reported on this slate
+
+        if (typeof console !== "undefined") {
+            const fn = rec.severity === "error" ? console.error : console.warn;
+            if (fn) fn("[geomlib] " + rec.message);
+        }
+        this._dispatchDiagnostic(rec);
+        this._notifyDiagnosticListeners();
+    }
+
+    /** Everything this slate has reported, oldest first. */
+    get diagnostics() : IDiagnostic[] {
+        return this._diagnostics.entries;
+    }
+
+    /** Worst severity reported, or null when the slate is clean. */
+    get diagnosticSeverity() : DiagnosticSeverity | null {
+        return this._diagnostics.severity;
+    }
+
+    /**
+     * Forget everything reported so far.
+     *
+     * NOT called from reset(): minimize() and presentation-exit both run
+     * reset() internally, and construction-time diagnostics never fire
+     * again, so clearing there would silently discard exactly the
+     * warnings worth keeping. SlateControls calls this from the explicit
+     * reset control / `r` key instead — a deliberate viewer gesture.
+     */
+    clearDiagnostics() : void {
+        this._diagnostics.clear();
+        this._dispatchDiagnostic(null);
+        this._notifyDiagnosticListeners();
+    }
+
+    /** Subscribe to diagnostic changes. Returns an unsubscribe fn. */
+    onDiagnosticsChanged(listener: (s: Slate) => void) : () => void {
+        this._diagnosticListeners.push(listener);
+        return () => {
+            const i = this._diagnosticListeners.indexOf(listener);
+            if (i >= 0) this._diagnosticListeners.splice(i, 1);
+        };
+    }
+
+    private _notifyDiagnosticListeners() : void {
+        for (const l of this._diagnosticListeners.slice()) {
+            try { l(this); } catch (_) { /* a listener must not break reporting */ }
+        }
+    }
+
+    // Same capability guard as the geomlib:highlight dispatch above — a
+    // node-canvas Canvas has no dispatchEvent, so the headless path
+    // short-circuits here exactly as it does for highlights.
+    private _dispatchDiagnostic(d: IDiagnostic | null) : void {
+        const canvas: any = this._canvas;
+        if (!canvas || typeof canvas.dispatchEvent !== "function"
+            || typeof CustomEvent !== "function") return;
+        canvas.dispatchEvent(new CustomEvent("geomlib:diagnostic", {
+            bubbles: true,
+            detail: diagnosticEventDetail(this._diagnostics, d),
         }));
     }
 

--- a/src/SlateAnimator.ts
+++ b/src/SlateAnimator.ts
@@ -111,30 +111,43 @@ export class SlateAnimator {
                 // #151 — say so. A silent skip here is how a stale target
                 // survives a figure refactor: the animation entry stays in
                 // the deck, resolves to nothing, and simply never plays.
-                if (typeof console !== "undefined" && console.warn) {
-                    console.warn(
-                        "[geomlib] animation targets '" + entry.elem +
-                        "', but no element or alias resolves to it — " +
+                this.slate.reportDiagnostic({
+                    code: "unknown-element",
+                    key: String(entry.elem),
+                    message: "animation targets '" + entry.elem +
+                        "', but no element or alias resolves to it \u2014 " +
                         "the step is skipped. Check for a typo, or for a " +
-                        "target left behind by a figure change."
-                    );
-                }
+                        "target left behind by a figure change.",
+                    detail: { elem: entry.elem },
+                });
                 continue;
             }
             const animation: Animation | null = findAnimation(entry.name);
-            if (animation == null) continue;
+            if (animation == null) {
+                // #154 — reported here rather than inside findAnimation,
+                // which has no slate to attribute it to.
+                this.slate.reportDiagnostic({
+                    code: "unknown-animation",
+                    key: String(entry.name),
+                    message: "unknown animation '" + String(entry.name) +
+                        "' \u2014 falling back to instant",
+                    detail: { name: String(entry.name), elem: entry.elem },
+                });
+                continue;
+            }
             // Type guard: console.warn-and-skip when the animation's
             // elementType doesn't match the actual target class.
             if (!(target instanceof (animation.elementType as any))) {
-                if (typeof console !== "undefined" && console.warn) {
-                    console.warn(
-                        "[geomlib] animation '" + animation.name +
+                this.slate.reportDiagnostic({
+                    code: "animation-type-mismatch",
+                    key: String(animation.name) + "|" + String(entry.elem),
+                    message: "animation '" + animation.name +
                         "' targets " + (animation.elementType as any).name +
                         " but element '" + entry.elem + "' is " +
                         (target.constructor as any).name +
-                        " — falling back to instant"
-                    );
-                }
+                        " \u2014 falling back to instant",
+                    detail: { animation: String(animation.name), elem: entry.elem },
+                });
                 target.drawProgress = 1;
                 target.visible = true;
                 continue;

--- a/src/SlateControls.ts
+++ b/src/SlateControls.ts
@@ -13,6 +13,7 @@
 import {Slate} from "./Slate";
 import {computeSlideState} from "./slideshow";
 import {ISlideJust} from "./index";
+import {DiagnosticSeverity} from "./Diagnostics";
 
 interface IInitConfig {
     background: string;
@@ -174,6 +175,10 @@ class SlateControls {
         canvasAttrHeight: number;
     } = null;
     private _stopTrackingResize: (() => void) | null = null;
+    // #154 — lazy: a clean diagram adds no DOM at all.
+    private _badge: HTMLDivElement | null = null;
+    private _badgeSeverity: DiagnosticSeverity | null = null;
+    private _stopDiagnostics: (() => void) | null = null;
     private _maximizedOnKey: ((e: KeyboardEvent) => void) | null = null;
 
     // Presentation-mode (slideshow) state. Caption + nav float over
@@ -207,6 +212,43 @@ class SlateControls {
         // flip / column resize, not only while maximized. resizeAndRedraw
         // re-syncs the bitmap, recomputes the fit-scale, and redraws.
         this._stopTrackingResize = trackWindowResize(window, () => this.resizeAndRedraw());
+        // #154 — subscribe, then paint once. The second call matters:
+        // createControls is the LAST statement of initInner, so anything
+        // reported while the figure was being built is already in the log
+        // by the time this badge exists.
+        this._stopDiagnostics = this._slate.onDiagnosticsChanged(() => this.updateBadge());
+        this.updateBadge();
+    }
+
+    // Reconcile the badge with the slate's worst severity. Creates the
+    // node on first need, hides it when the slate is clean, and repaints
+    // in place when a warning escalates to an error.
+    private updateBadge(): void {
+        const severity = this._slate.diagnosticSeverity;
+        if (severity == null) {
+            if (this._badge) this._badge.style.display = "none";
+            this._badgeSeverity = null;
+            return;
+        }
+        if (!this._badge) {
+            this._badge = createDiagnosticBadge(severity);
+            this._badge.style.position = "absolute";
+            // Top-LEFT: the control buttons use style.right, and the
+            // presentation overlay is fixed to the bottom of the viewport,
+            // so nothing else claims this corner. Absolute on the wrapper
+            // means maximize/presentation carry it along for free.
+            this._badge.style.top = BTN_MARGIN + "px";
+            this._badge.style.left = BTN_MARGIN + "px";
+            this._badge.style.zIndex = "1";
+            this._wrapper.appendChild(this._badge);
+            this._badgeSeverity = severity;
+            return;
+        }
+        this._badge.style.display = "";
+        if (severity !== this._badgeSeverity) {
+            paintDiagnosticBadge(this._badge, severity);
+            this._badgeSeverity = severity;
+        }
     }
 
     private createWrapper(): HTMLDivElement {
@@ -324,6 +366,12 @@ class SlateControls {
 
     private onReset(): void {
         this._slate.reset();
+        // #154 — the badge latches until the viewer explicitly resets.
+        // Cleared HERE rather than inside Slate.reset() on purpose:
+        // minimize() and presentation-exit both call reset() internally,
+        // and construction-time diagnostics never fire again, so clearing
+        // there would quietly discard the warnings most worth keeping.
+        this._slate.clearDiagnostics();
     }
 
     private onMaximize(): void {
@@ -1024,6 +1072,103 @@ function drawMinimizeIcon(ctx: CanvasRenderingContext2D, size: number): void {
     ctx.lineTo(bx, by + 5);
     ctx.closePath();
     ctx.fill();
+}
+
+// #154 — the diagnostic badge.
+//
+// A <div>, deliberately NOT a <button>: ensureControlsStyle() hides
+// `.geomlib-wrapper>button` until hover (#69), and a diagnostic that only
+// appears when you already went looking for it is useless. It is also
+// non-interactive — no click handler, no tab stop — so it adds nothing to
+// the keyboard order and never fights the buttons' :focus-within reveal.
+export const BADGE_TOOLTIP = "geomlib generated warnings - check console";
+
+export function createDiagnosticBadge(
+    severity: DiagnosticSeverity,
+    size?: number,
+): HTMLDivElement {
+    const px = size != null ? size : BTN_SIZE;
+    const badge = document.createElement("div");
+    badge.className = "geomlib-badge";
+    badge.setAttribute("role", "img");
+    // Native title attribute, same mechanism as the buttons (btn.title):
+    // no positioning code, and it survives maximize with no z-index fight.
+    badge.title = BADGE_TOOLTIP;
+    badge.setAttribute("aria-label", BADGE_TOOLTIP);
+    badge.style.width = px + "px";
+    badge.style.height = px + "px";
+    badge.style.lineHeight = "0";
+    badge.style.cursor = "default";
+    paintDiagnosticBadge(badge, severity, px);
+    return badge;
+}
+
+// Redraw an existing badge in place, so a warning that escalates to an
+// error swaps its icon without churning the DOM node.
+export function paintDiagnosticBadge(
+    badge: HTMLElement,
+    severity: DiagnosticSeverity,
+    size?: number,
+): void {
+    const px = size != null ? size : BTN_SIZE;
+    let icon = badge.firstChild as HTMLCanvasElement;
+    if (!icon || (icon as any).tagName !== "CANVAS") {
+        badge.innerHTML = "";
+        icon = document.createElement("canvas");
+        badge.appendChild(icon);
+    }
+    icon.width = px;
+    icon.height = px;
+    const ctx = icon.getContext("2d");
+    if (!ctx) return;
+    ctx.clearRect(0, 0, px, px);
+    if (severity === "error") drawErrorIcon(ctx, px);
+    else drawWarningIcon(ctx, px);
+}
+
+// Icons are DRAWN, not text glyphs. A "\u26A0" in a string literal is the
+// mojibake class #142 exists to prevent, and a glyph would drag in a font
+// metric dependency the rest of the icon set doesn't have.
+//
+// Unlike the control icons (a neutral rgba(0,0,0,0.7)), these are
+// coloured: the badge has to read as a diagnostic, not as another
+// control the viewer can press.
+export function drawWarningIcon(ctx: CanvasRenderingContext2D, size: number): void {
+    const pad = size * 0.06;
+    const left = pad, right = size - pad;
+    const top = pad, bottom = size - pad * 1.2;
+    // Amber triangle, apex up.
+    ctx.fillStyle = "#e6a700";
+    ctx.beginPath();
+    ctx.moveTo(size / 2, top);
+    ctx.lineTo(right, bottom);
+    ctx.lineTo(left, bottom);
+    ctx.closePath();
+    ctx.fill();
+    // "!" as a bar plus a dot — no fillText, so no font dependency.
+    const barW = Math.max(1.5, size * 0.11);
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(size / 2 - barW / 2, size * 0.34, barW, size * 0.3);
+    ctx.fillRect(size / 2 - barW / 2, size * 0.71, barW, barW);
+}
+
+export function drawErrorIcon(ctx: CanvasRenderingContext2D, size: number): void {
+    // A light plate first so the mark reads on any canvas background,
+    // mirroring the buttons' rgba(0,0,0,0.12) chip.
+    ctx.fillStyle = "rgba(255,255,255,0.85)";
+    ctx.beginPath();
+    ctx.arc(size / 2, size / 2, size * 0.46, 0, Math.PI * 2);
+    ctx.fill();
+    const pad = size * 0.3;
+    ctx.strokeStyle = "#d13438";
+    ctx.lineWidth = Math.max(2, size * 0.13);
+    ctx.lineCap = "round";
+    ctx.beginPath();
+    ctx.moveTo(pad, pad);
+    ctx.lineTo(size - pad, size - pad);
+    ctx.moveTo(size - pad, pad);
+    ctx.lineTo(pad, size - pad);
+    ctx.stroke();
 }
 
 function drawPresentIcon(ctx: CanvasRenderingContext2D, size: number): void {

--- a/src/SlateControls.ts
+++ b/src/SlateControls.ts
@@ -1153,15 +1153,27 @@ export function drawWarningIcon(ctx: CanvasRenderingContext2D, size: number): vo
 }
 
 export function drawErrorIcon(ctx: CanvasRenderingContext2D, size: number): void {
-    // A light plate first so the mark reads on any canvas background,
-    // mirroring the buttons' rgba(0,0,0,0.12) chip.
-    ctx.fillStyle = "rgba(255,255,255,0.85)";
+    // A stop-sign octagon with a white X. Reads as "stop" at 20px in a way
+    // a bare X does not, and its silhouette is distinct from the warning
+    // triangle even before colour registers.
+    const cx = size / 2, cy = size / 2;
+    const r = size * 0.47;
+    ctx.fillStyle = "#d13438";
     ctx.beginPath();
-    ctx.arc(size / 2, size / 2, size * 0.46, 0, Math.PI * 2);
+    for (let k = 0; k < 8; k++) {
+        // Start at 22.5 degrees so the octagon sits flat-topped, the way a
+        // road sign does, rather than resting on a vertex.
+        const a = Math.PI / 8 + k * Math.PI / 4;
+        const x = cx + r * Math.cos(a);
+        const y = cy + r * Math.sin(a);
+        if (k === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
     ctx.fill();
-    const pad = size * 0.3;
-    ctx.strokeStyle = "#d13438";
-    ctx.lineWidth = Math.max(2, size * 0.13);
+
+    const pad = size * 0.34;
+    ctx.strokeStyle = "#ffffff";
+    ctx.lineWidth = Math.max(1.5, size * 0.11);
     ctx.lineCap = "round";
     ctx.beginPath();
     ctx.moveTo(pad, pad);

--- a/src/elements/Animations.ts
+++ b/src/elements/Animations.ts
@@ -148,7 +148,6 @@ export class InstantAnimation extends Animation {
 // looks anything up.
 const animationsByEnum: Map<AllAnimations, Animation> = new Map();
 const animationsByName: Map<string, Animation> = new Map();
-const warnedUnknown: Set<string> = new Set();
 
 export function registerAnimation(a: Animation): void {
     animationsByEnum.set(a.animationMethod, a);
@@ -156,26 +155,19 @@ export function registerAnimation(a: Animation): void {
 }
 
 // Accepts either the enum value or the string name; returns the
-// registered Animation or null when the name doesn't resolve. An
-// unknown name emits a console.warn once per name across the slate's
-// lifetime so consumers see typos surfaced without log spam.
+// registered Animation or null when the name doesn't resolve.
+//
+// Pure lookup: it does NOT report an unknown name. #154 moved that to
+// the caller (SlateAnimator.run), which holds the slate the diagnostic
+// belongs to. That also retired a module-global "already warned" Set
+// which suppressed the warning for every OTHER slate on the page once
+// any one slate hit the same bad name.
 export function findAnimation(ref: AllAnimations | string): Animation | null {
     let a: Animation | undefined;
     if (typeof ref === "string") {
         a = animationsByName.get(ref);
     } else {
         a = animationsByEnum.get(ref);
-    }
-    if (a == null) {
-        const key = String(ref);
-        if (!warnedUnknown.has(key)) {
-            warnedUnknown.add(key);
-            // eslint-disable-next-line no-console
-            if (typeof console !== "undefined" && console.warn) {
-                console.warn("[geomlib] unknown animation '" + key + "' — falling back to instant");
-            }
-        }
-        return null;
     }
     return a ?? null;
 }

--- a/src/elements/circle/CircleAnimations.ts
+++ b/src/elements/circle/CircleAnimations.ts
@@ -127,10 +127,13 @@ export class CircleCompassTransferAnimation extends Animation {
         // Need a radius defined by two distinct source points (the length to
         // copy), distinct from the centre — i.e. circle;radius;P,C,D.
         if (s0 == null || s1 == null || s0 === P || s1 === P || s0.distance(s1) < 1e-6) {
-            if (typeof console !== "undefined" && console.warn) {
-                console.warn("[geomlib] Circle.compassTransfer: needs a radius defined by two "
-                    + "points distinct from the centre (circle;radius;centre,p1,p2) — skipping");
-            }
+            slate.reportDiagnostic({
+                code: "bad-animation-args",
+                key: "Circle.compassTransfer|" + String(circ.name),
+                message: "Circle.compassTransfer: needs a radius defined by two "
+                    + "points distinct from the centre (circle;radius;centre,p1,p2) — skipping",
+                detail: { animation: "Circle.compassTransfer", elem: String(circ.name) },
+            });
             return instant();
         }
         const plane = (P as any).AP || circ.AP;

--- a/src/elements/group/GroupAnimations.ts
+++ b/src/elements/group/GroupAnimations.ts
@@ -98,18 +98,24 @@ function resolveSources(slate: Slate, include: any): GeomElement[] {
 }
 
 // Snapshot the figure's current geometry into bare render-copies.
-let warnedUnsupported = false;
-function snapshotSources(sources: GeomElement[]): { ghosts: GeomElement[], pts: ClonePoint[] } {
+//
+// Takes the slate purely so an unsupported element can be reported
+// against it (#154). It used to latch a module-global boolean, which hid
+// the 2nd..Nth distinct unsupported element even within one figure, and
+// silenced the warning entirely for every later figure on the page.
+function snapshotSources(sources: GeomElement[], slate: Slate): { ghosts: GeomElement[], pts: ClonePoint[] } {
     const ghosts: GeomElement[] = [];
     const pts: ClonePoint[] = [];
     for (const el of sources) {
         const snap = snapshotElement(el);
         if (snap == null) {
-            if (!warnedUnsupported && typeof console !== "undefined" && console.warn) {
-                console.warn("[geomlib] Group.cloneAside: skipping unsupported "
-                    + "element type (" + el.name + ")");
-                warnedUnsupported = true;
-            }
+            slate.reportDiagnostic({
+                code: "unsupported-element",
+                key: String(el.name),
+                message: "Group.cloneAside: skipping unsupported "
+                    + "element type (" + el.name + ")",
+                detail: { animation: "Group.cloneAside", elem: String(el.name) },
+            });
             continue;
         }
         ghosts.push(snap.ghost);
@@ -255,7 +261,7 @@ export class GroupCloneAsideAnimation extends Animation {
                 const snaps: { ghosts: GeomElement[], pts: ClonePoint[], bbox: Bounds, prefer?: Side }[] = [];
                 for (const variant of variants) {
                     const restore = applyVary(slate, variant && variant.vary);
-                    const snap = snapshotSources(sources);
+                    const snap = snapshotSources(sources, slate);
                     if (restore) restore();
                     if (snap.pts.length === 0) continue;
                     snaps.push({
@@ -365,7 +371,7 @@ export class GroupCloneAsideAnimation extends Animation {
                 target.drawProgress = 1;
                 target.visible = true;
                 const restore = applyVary(slate, vary);
-                const snap = snapshotSources(sources);
+                const snap = snapshotSources(sources, slate);
                 if (restore) restore();
                 const temp = snap.ghosts;
                 const pts = snap.pts;

--- a/src/elements/point/PointAnimations.ts
+++ b/src/elements/point/PointAnimations.ts
@@ -97,7 +97,14 @@ export class PointSlideAnimation extends Animation {
                     // Resolve the target element and project it onto the line.
                     const tgt = slate.lookupElement(toName) as PointElement;
                     if (tgt == null || !(tgt instanceof PointElement)) {
-                        console.warn(`[geomlib] Point.slide: target "${toName}" is not a resolvable point — staying put`);
+                        // #154 — was the one site with no typeof-console
+                        // guard; reportDiagnostic owns that check now.
+                        slate.reportDiagnostic({
+                            code: "unresolvable-target",
+                            key: "Point.slide|" + String(toName),
+                            message: `Point.slide: target "${toName}" is not a resolvable point — staying put`,
+                            detail: { animation: "Point.slide", to: String(toName) },
+                        });
                         tx = sx; ty = sy; tz = sz;
                         return;
                     }

--- a/src/elements/polygon/PolygonAnimations.ts
+++ b/src/elements/polygon/PolygonAnimations.ts
@@ -143,11 +143,14 @@ export class PolygonSuperposeAnimation extends Animation {
         const ontoName = args && args.onto;
         const onto = ontoName != null ? slate.lookupElement(String(ontoName)) : null;
         if (!(onto instanceof PolygonElement) || onto.V.length !== poly.V.length) {
-            if (typeof console !== "undefined" && console.warn) {
-                console.warn("[geomlib] Polygon.superpose: args.onto ('"
+            slate.reportDiagnostic({
+                code: "bad-animation-args",
+                key: "Polygon.superpose|" + String(poly.name) + "|" + String(ontoName),
+                message: "Polygon.superpose: args.onto ('"
                     + ontoName + "') is not a polygon with "
-                    + poly.V.length + " vertices — skipping");
-            }
+                    + poly.V.length + " vertices — skipping",
+                detail: { animation: "Polygon.superpose", elem: String(poly.name), onto: String(ontoName) },
+            });
             return [{
                 durationMs: 0,
                 tick: () => {},

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,8 @@ import {Slate} from "./Slate";
 import {PlaneSlider} from "./elements/point/PlaneSlider";
 import {AngleMarkerElement} from "./elements/sector/AngleMarkerElement";
 import {colors, randomColor, lighten, darken, parseColor, anglePalette} from "./Colors";
-import {createControls} from "./SlateControls";
+import {createControls, createDiagnosticBadge} from "./SlateControls";
+import {IDiagnostic, DiagnosticSeverity, worstSeverity} from "./Diagnostics";
 
 export type IndexAllConstructions = AllConstructions;
 export {align  as Align};
@@ -56,6 +57,50 @@ export function highlightByName(name: string, on: boolean = true,
         hits++;
     }
     return hits;
+}
+
+export interface ISlateDiagnostics {
+    canvasid: string | null;
+    index: number;
+    severity: DiagnosticSeverity | null;
+    entries: IDiagnostic[];
+}
+
+/**
+ * Every diagnostic on the page, in one call (#154).
+ *
+ * Exists so a consumer — a static-site generator checking decks at build
+ * time, or a human in a console — can ask "did anything on this page go
+ * wrong?" without reimplementing geomlib's own name-resolution rules.
+ * Only slates that actually reported something are listed.
+ *
+ * `opts.canvasids` scopes the query, mirroring highlightByName's idiom.
+ */
+export function diagnostics(opts?: { canvasids?: string[] }): {
+    severity: DiagnosticSeverity | null;
+    count: number;
+    slates: ISlateDiagnostics[];
+    init: IDiagnostic[];
+} {
+    const ids = opts && opts.canvasids;
+    let worst: DiagnosticSeverity | null = null;
+    let count = 0;
+    const out: ISlateDiagnostics[] = [];
+    for (let i = 0; i < slates.length; i++) {
+        const slate = slates[i];
+        const id = ((slate.canvas as any) && (slate.canvas as any).id) || null;
+        if (ids != null && (id == null || ids.indexOf(id) === -1)) continue;
+        const entries = slate.diagnostics;
+        if (entries.length === 0) continue;
+        worst = worstSeverity(worst, slate.diagnosticSeverity);
+        count += entries.length;
+        out.push({ canvasid: id, index: i, severity: slate.diagnosticSeverity, entries });
+    }
+    for (const d of initDiagnostics) {
+        worst = worstSeverity(worst, d.severity);
+        count++;
+    }
+    return { severity: worst, count, slates: out, init: initDiagnostics.slice() };
 }
 
 export interface IConstructionInfo {
@@ -320,6 +365,45 @@ export function revealNoscriptFallback(canvas: HTMLCanvasElement | null): void {
     }
 }
 
+// #154 — a slate-less record of init() failures. init() throws before any
+// Slate exists in the common case (a wrong canvasid makes `new Slate(null)`
+// throw), so these can't live on a slate and are collected here instead.
+export let initDiagnostics : IDiagnostic[] = [];
+
+/**
+ * Mark a failed init on the page, next to where the diagram would have been.
+ *
+ * Deliberately modest. On the most common failure — a canvasid that matches
+ * nothing — there is no canvas to badge, and a marker floating at some
+ * arbitrary spot is worse than none; the console error plus the revealed
+ * <noscript> image is the indication. So: badge when there is an anchor,
+ * stay silent when there isn't.
+ *
+ * The whole body swallows its own exceptions, matching
+ * revealNoscriptFallback. init()'s catch re-throws the original error, and
+ * a throw from in here would replace it.
+ */
+export function markInitFailure(canvas: HTMLCanvasElement | null, canvasid: string): void {
+    try {
+        if (typeof document === "undefined") return;
+        const anchor = canvas ||
+            (document.getElementById(canvasid) as HTMLCanvasElement | null);
+        if (!anchor) return;
+        const host = anchor.parentElement;
+        if (!host) return;
+        const badge = createDiagnosticBadge("error");
+        // Static, not absolute: createControls is the last statement of
+        // initInner, so on failure the positioned .geomlib-wrapper almost
+        // never exists and there is no containing block to anchor to. An
+        // inline-block sibling just before the canvas lands where the
+        // diagram's top-left would have been.
+        badge.style.position = "static";
+        badge.style.display = "inline-block";
+        badge.style.verticalAlign = "top";
+        host.insertBefore(badge, anchor);
+    } catch (_) { /* never let the badge replace the real error */ }
+}
+
 export function init(i : IInitialization) {
     let canvasid : string = i.canvasid != null ? i.canvasid : "canvasid";
     let canvas = document.getElementById(canvasid) as HTMLCanvasElement;
@@ -331,6 +415,15 @@ export function init(i : IInitialization) {
         // static-image fallback so they at least see the diagram, then
         // re-throw so callers / test harnesses can detect the failure.
         console.error("[geomlib] init failed:", err);
+        initDiagnostics.push({
+            severity: "error", code: "init-failed",
+            message: "init failed: " + String(err),
+            detail: { canvasid: canvasid }, at: Date.now(), count: 1,
+        });
+        // Badge BEFORE revealing the fallback: revealNoscriptFallback sets
+        // canvas.style.display = "none", so inserting first puts the mark
+        // above the static image rather than beside a hidden canvas.
+        markInitFailure(canvas, canvasid);
         revealNoscriptFallback(canvas);
         throw err;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,53 @@ export function highlightByName(name: string, on: boolean = true,
     return hits;
 }
 
+// #154 — check a deck's names at load, not only when a slide runs.
+//
+// Every name in a slide set and every animation target is resolved once
+// here, so a stale reference reports the moment the figure is built.
+// Without this the diagnostic only fires if a viewer actually advances
+// to the offending slide — which is precisely the case that goes
+// unnoticed, and would leave a build-time checker seeing a clean page.
+//
+// Reporting is deduped per slate, so a name the walk later hits again
+// does not report twice.
+function validateSlides(slate: Slate, slides: ISlide[]): void {
+    for (let n = 0; n < slides.length; n++) {
+        const slide = slides[n];
+        for (const field of ["visible", "highlighted"]) {
+            const names = (slide as any)[field] as string[] | undefined;
+            if (names == null) continue;
+            for (const name of names) {
+                if (slate.lookupElement(name) != null) continue;
+                slate.reportDiagnostic({
+                    code: "unknown-slide-name",
+                    key: field + ":" + name,
+                    message: "slide " + (n + 1) + " lists '" + name +
+                        "' in " + field + ", but no element or alias resolves to it \u2014 " +
+                        "the name is ignored. Check for a typo, or for a target left " +
+                        "behind by a figure change.",
+                    detail: { slide: n + 1, field: field, name: name },
+                });
+            }
+        }
+        const anims = slide.transition && slide.transition.animations;
+        if (anims == null) continue;
+        for (const entry of anims) {
+            if (entry.elem == null) continue;
+            if (slate.lookupElement(entry.elem) != null) continue;
+            slate.reportDiagnostic({
+                code: "unknown-element",
+                key: String(entry.elem),
+                message: "slide " + (n + 1) + " animates '" + entry.elem +
+                    "', but no element or alias resolves to it \u2014 the step " +
+                    "is skipped. Check for a typo, or for a target left behind " +
+                    "by a figure change.",
+                detail: { slide: n + 1, elem: entry.elem },
+            });
+        }
+    }
+}
+
 export interface ISlateDiagnostics {
     canvasid: string | null;
     index: number;
@@ -565,6 +612,7 @@ function initInner(i: IInitialization, canvas: HTMLCanvasElement) {
 
     if (i.slides != null && i.slides.length > 0) {
         slate.slides = i.slides;
+        validateSlides(slate, i.slides);
     }
 
     if (i.resolveJustification != null) {

--- a/src/slideshow.ts
+++ b/src/slideshow.ts
@@ -21,19 +21,6 @@ import {ISlide} from "./index";
 // and watched `{FC}` light from the prose had every reason to expect "FC" to
 // work in a slide set too.
 
-// Names already reported per slate, so a warning fires once rather than on
-// every redraw of every slide. Keyed weakly so a discarded slate doesn't
-// pin its strings.
-const warnedNames: WeakMap<Slate, {[key: string]: boolean}> = new WeakMap();
-
-function warnOnce(slate: Slate, key: string, message: string): void {
-    let seen = warnedNames.get(slate);
-    if (seen == null) { seen = {}; warnedNames.set(slate, seen); }
-    if (seen[key]) return;
-    seen[key] = true;
-    if (typeof console !== "undefined" && console.warn) console.warn(message);
-}
-
 /**
  * Map slide-set names onto the element names the renderers actually compare
  * against, following one alias hop via `lookupElement`.
@@ -122,10 +109,16 @@ function reportUnmatched(
     field: string,
 ): void {
     for (const name of unmatched) {
-        warnOnce(slate, field + ":" + name,
-            "[geomlib] slide " + (slideIndex + 1) + " lists '" + name +
-            "' in " + field + ", but no element or alias resolves to it — " +
-            "the name is ignored. Check for a typo, or for a target left " +
-            "behind by a figure change.");
+        // #154 — reported through the slate so the canvas can badge it;
+        // reportDiagnostic owns the dedupe that warnOnce used to do.
+        slate.reportDiagnostic({
+            code: "unknown-slide-name",
+            key: field + ":" + name,
+            message: "slide " + (slideIndex + 1) + " lists '" + name +
+                "' in " + field + ", but no element or alias resolves to it — " +
+                "the name is ignored. Check for a typo, or for a target left " +
+                "behind by a figure change.",
+            detail: { slide: slideIndex + 1, field: field, name: name },
+        });
     }
 }

--- a/tests/AnimationSnapshotTest.ts
+++ b/tests/AnimationSnapshotTest.ts
@@ -5,6 +5,7 @@ import "mocha";
 import * as path from "path";
 import {assertSnapshot, buildScene, ReportEntry} from "./SnapshotHelper";
 import {SlateConfig} from "./HtmlParamParser";
+import {Slate} from "../src/Slate";
 import {reportEntries, ensureReportFlushed} from "./sharedSnapshotReport";
 
 const SNAPSHOT_DIR = path.join(__dirname, "snapshots");
@@ -78,8 +79,9 @@ function runScenario(
                 dragResults: [],
             };
 
+            let slate: Slate | null = null;
             try {
-                const slate = buildScene(config);
+                slate = buildScene(config);
                 const elem = slate.lookupElement(elemName);
                 if (elem == null) {
                     throw new Error("element " + elemName + " not found");
@@ -103,6 +105,9 @@ function runScenario(
                 entry.error = (e as Error).message;
                 throw e;
             } finally {
+                // #154 — attribute whatever the slate complained about to
+                // this scene, so report.html can show it per row.
+                if (slate) entry.warnings = slate.diagnostics.map((d) => d.message);
                 reportEntries.push(entry);
             }
         });

--- a/tests/DiagnosticsTest.ts
+++ b/tests/DiagnosticsTest.ts
@@ -1,0 +1,274 @@
+// Diagnostics (#154) — the per-slate record behind the on-canvas badge.
+//
+// The DOM half (badge element, icon drawing) is not covered here: the repo
+// has no jsdom. That is deliberate rather than a gap — every DECISION the
+// badge makes (which severity wins, whether to show anything at all) lives
+// in this pure layer, and the DOM half only reads it.
+
+import "mocha";
+import * as assert from "assert";
+import {createCanvas} from "canvas";
+import {Slate} from "../src/Slate";
+import {E} from "../src/index";
+import {
+    DiagnosticLog, worstSeverity, dedupeKeyOf, diagnosticEventDetail,
+} from "../src/Diagnostics";
+
+describe("diagnostics (#154)", () => {
+
+    function slate(): Slate {
+        const s = new Slate(createCanvas(200, 200) as any);
+        s.inTest = true;
+        return s;
+    }
+
+    // console is mirrored by reportDiagnostic; capture it so the suite
+    // stays quiet and so we can assert on what reaches it.
+    function capture<T>(fn: () => T): { result: T; warns: string[]; errors: string[] } {
+        const warns: string[] = [], errors: string[] = [];
+        const w = console.warn, e = console.error;
+        console.warn = (...a: any[]) => { warns.push(a.join(" ")); };
+        console.error = (...a: any[]) => { errors.push(a.join(" ")); };
+        try { return { result: fn(), warns, errors }; }
+        finally { console.warn = w; console.error = e; }
+    }
+
+    describe("DiagnosticLog", () => {
+        it("records a diagnostic and reports it as new", () => {
+            const log = new DiagnosticLog();
+            const rec = log.report({ code: "x", message: "bad thing" }, 1000);
+            assert.ok(rec != null);
+            assert.equal(rec!.severity, "warning", "warning is the default severity");
+            assert.equal(rec!.count, 1);
+            assert.equal(log.count, 1);
+        });
+
+        it("dedupes by key and returns null on a repeat", () => {
+            const log = new DiagnosticLog();
+            assert.ok(log.report({ code: "x", message: "same" }, 1) != null);
+            assert.equal(log.report({ code: "x", message: "same" }, 2), null,
+                "a repeat returns null so the caller knows not to log again");
+            assert.equal(log.count, 1, "still one distinct diagnostic");
+            assert.equal(log.entries[0].count, 2, "but the occurrence counter advanced");
+        });
+
+        it("separates entries that differ only by key", () => {
+            const log = new DiagnosticLog();
+            log.report({ code: "x", message: "m", key: "a" }, 1);
+            log.report({ code: "x", message: "m", key: "b" }, 2);
+            assert.equal(log.count, 2,
+                "an explicit key is what lets one message class track several elements");
+        });
+
+        it("tracks the worst severity, and error outranks warning", () => {
+            const log = new DiagnosticLog();
+            assert.equal(log.severity, null, "clean log has no severity");
+            log.report({ code: "w", message: "warn" }, 1);
+            assert.equal(log.severity, "warning");
+            log.report({ code: "e", message: "err", severity: "error" }, 2);
+            assert.equal(log.severity, "error");
+            log.report({ code: "w2", message: "another warn" }, 3);
+            assert.equal(log.severity, "error", "a later warning must not demote it");
+        });
+
+        it("clear() empties it completely", () => {
+            const log = new DiagnosticLog();
+            log.report({ code: "x", message: "m" }, 1);
+            log.clear();
+            assert.equal(log.count, 0);
+            assert.equal(log.severity, null);
+            assert.ok(log.report({ code: "x", message: "m" }, 2) != null,
+                "and the dedupe memory is cleared too, so it can report again");
+        });
+
+        it("entries are a copy, so a caller can't mutate the log", () => {
+            const log = new DiagnosticLog();
+            log.report({ code: "x", message: "m" }, 1);
+            log.entries.length = 0;
+            assert.equal(log.count, 1);
+        });
+    });
+
+    describe("worstSeverity / dedupeKeyOf", () => {
+        it("treats null as clean", () => {
+            assert.equal(worstSeverity(null, null), null);
+            assert.equal(worstSeverity(null, "warning"), "warning");
+            assert.equal(worstSeverity("warning", null), "warning");
+        });
+        it("ranks error above warning either way round", () => {
+            assert.equal(worstSeverity("warning", "error"), "error");
+            assert.equal(worstSeverity("error", "warning"), "error");
+        });
+        it("falls back to the message when no key is given", () => {
+            assert.equal(dedupeKeyOf({ code: "c", message: "m" }),
+                         dedupeKeyOf({ code: "c", message: "m" }));
+            assert.notEqual(dedupeKeyOf({ code: "c", message: "m" }),
+                            dedupeKeyOf({ code: "c", message: "other" }));
+        });
+        it("keeps severities in separate buckets", () => {
+            assert.notEqual(
+                dedupeKeyOf({ code: "c", message: "m" }),
+                dedupeKeyOf({ code: "c", message: "m", severity: "error" }),
+                "the same text as a warning and as an error are different facts");
+        });
+    });
+
+    describe("Slate reporting", () => {
+        it("records and mirrors to the console", () => {
+            const s = slate();
+            const { warns } = capture(() =>
+                s.reportDiagnostic({ code: "x", message: "something is off" }));
+            assert.equal(s.diagnostics.length, 1);
+            assert.equal(warns.length, 1);
+            assert.ok(warns[0].indexOf("[geomlib] ") === 0,
+                "the console keeps the prefix; the stored record does not");
+            assert.equal(s.diagnostics[0].message, "something is off");
+        });
+
+        it("sends errors to console.error, not console.warn", () => {
+            const s = slate();
+            const { warns, errors } = capture(() =>
+                s.reportDiagnostic({ code: "x", message: "fatal", severity: "error" }));
+            assert.equal(errors.length, 1);
+            assert.equal(warns.length, 0);
+            assert.equal(s.diagnosticSeverity, "error");
+        });
+
+        it("mirrors to the console only on first occurrence", () => {
+            const s = slate();
+            const { warns } = capture(() => {
+                s.reportDiagnostic({ code: "x", message: "same" });
+                s.reportDiagnostic({ code: "x", message: "same" });
+                s.reportDiagnostic({ code: "x", message: "same" });
+            });
+            assert.equal(warns.length, 1, "no console spam on repeats");
+            assert.equal(s.diagnostics[0].count, 3, "but every occurrence is counted");
+        });
+
+        it("latches: a diagnostic survives reset()", () => {
+            const s = slate();
+            capture(() => s.reportDiagnostic({ code: "x", message: "m" }));
+            s.reset();
+            assert.equal(s.diagnostics.length, 1,
+                "reset() is called internally by minimize() and presentation exit; " +
+                "clearing there would discard construction-time diagnostics that " +
+                "never fire again");
+        });
+
+        it("clears only on the explicit clearDiagnostics()", () => {
+            const s = slate();
+            capture(() => s.reportDiagnostic({ code: "x", message: "m" }));
+            s.clearDiagnostics();
+            assert.equal(s.diagnostics.length, 0);
+            assert.equal(s.diagnosticSeverity, null);
+        });
+
+        it("notifies listeners, and unsubscribe stops them", () => {
+            const s = slate();
+            let calls = 0;
+            const off = s.onDiagnosticsChanged(() => { calls++; });
+            capture(() => s.reportDiagnostic({ code: "x", message: "m" }));
+            assert.equal(calls, 1);
+            capture(() => s.reportDiagnostic({ code: "x", message: "m" }));
+            assert.equal(calls, 1, "a deduped repeat is not a change");
+            s.clearDiagnostics();
+            assert.equal(calls, 2, "clearing is a change, so the badge can un-render");
+            off();
+            capture(() => s.reportDiagnostic({ code: "y", message: "n" }));
+            assert.equal(calls, 2);
+        });
+
+        it("a throwing listener cannot break reporting", () => {
+            const s = slate();
+            s.onDiagnosticsChanged(() => { throw new Error("listener blew up"); });
+            capture(() => s.reportDiagnostic({ code: "x", message: "m" }));
+            assert.equal(s.diagnostics.length, 1);
+        });
+    });
+
+    // The question this feature has to get right: on a page of several
+    // figures, each canvas must own its own diagnostics.
+    describe("per-canvas attribution", () => {
+        it("keeps two slates' diagnostics entirely separate", () => {
+            const a = slate(), b = slate();
+            capture(() => a.reportDiagnostic({ code: "x", message: "only on A" }));
+            assert.equal(a.diagnostics.length, 1);
+            assert.equal(b.diagnostics.length, 0, "B is a different figure");
+            assert.equal(a.diagnosticSeverity, "warning");
+            assert.equal(b.diagnosticSeverity, null,
+                "so B's canvas shows no badge at all");
+        });
+
+        it("does NOT suppress the same message on a second slate", () => {
+            // Regression guard for the bug this replaced: dedupe used to be
+            // module-global (Animations.ts warnedUnknown, GroupAnimations.ts
+            // warnedUnsupported), so the FIRST figure to hit a bad name
+            // silenced every other figure on the page — the warning arrived
+            // attributed to the wrong canvas, or not at all.
+            const a = slate(), b = slate();
+            const { warns } = capture(() => {
+                a.reportDiagnostic({ code: "unknown-animation", key: "Foo", message: "unknown animation 'Foo'" });
+                b.reportDiagnostic({ code: "unknown-animation", key: "Foo", message: "unknown animation 'Foo'" });
+            });
+            assert.equal(warns.length, 2, "each figure reports its own copy");
+            assert.equal(a.diagnostics.length, 1);
+            assert.equal(b.diagnostics.length, 1);
+        });
+
+        it("clearing one slate leaves the other's intact", () => {
+            const a = slate(), b = slate();
+            capture(() => {
+                a.reportDiagnostic({ code: "x", message: "m" });
+                b.reportDiagnostic({ code: "x", message: "m" });
+            });
+            a.clearDiagnostics();
+            assert.equal(a.diagnostics.length, 0);
+            assert.equal(b.diagnostics.length, 1);
+        });
+
+        it("attributes a real animation diagnostic to the slate that owns it", () => {
+            // End-to-end through the actual animation path rather than a
+            // direct reportDiagnostic call.
+            const a = slate(), b = slate();
+            for (const s of [a, b]) {
+                s.createElement(E.Point.free, [10, 10], "A");
+                s.createElement(E.Point.free, [90, 90], "B");
+                s.createElement(E.Line.connect, ["A", "B"], "AB");
+                s.update();
+            }
+            capture(() => {
+                a.animateTo(
+                    new Set(["A", "B", "AB"]),
+                    new Set(),
+                    [{ elem: "GHOST", name: "Line.straightEdgeConnect" }],
+                    "cascade",
+                );
+            });
+            assert.equal(a.diagnostics.length, 1, "A owns the bad target");
+            assert.equal(a.diagnostics[0].code, "unknown-element");
+            assert.equal(b.diagnostics.length, 0, "B never mentioned it");
+        });
+    });
+
+    describe("event payload", () => {
+        it("carries the record, the worst severity and the count", () => {
+            const log = new DiagnosticLog();
+            const rec = log.report({ code: "x", message: "m" }, 1)!;
+            const d = diagnosticEventDetail(log, rec);
+            assert.equal(d.diagnostic, rec);
+            assert.equal(d.severity, "warning");
+            assert.equal(d.count, 1);
+        });
+
+        it("uses a null diagnostic to mean 'cleared'", () => {
+            const log = new DiagnosticLog();
+            log.report({ code: "x", message: "m" }, 1);
+            log.clear();
+            const d = diagnosticEventDetail(log, null);
+            assert.equal(d.diagnostic, null);
+            assert.equal(d.severity, null,
+                "so a listener can un-render without special-casing");
+            assert.equal(d.count, 0);
+        });
+    });
+});

--- a/tests/DiagnosticsTest.ts
+++ b/tests/DiagnosticsTest.ts
@@ -9,7 +9,7 @@ import "mocha";
 import * as assert from "assert";
 import {createCanvas} from "canvas";
 import {Slate} from "../src/Slate";
-import {E} from "../src/index";
+import {E, init, slates} from "../src/index";
 import {
     DiagnosticLog, worstSeverity, dedupeKeyOf, diagnosticEventDetail,
 } from "../src/Diagnostics";
@@ -247,6 +247,107 @@ describe("diagnostics (#154)", () => {
             assert.equal(a.diagnostics.length, 1, "A owns the bad target");
             assert.equal(a.diagnostics[0].code, "unknown-element");
             assert.equal(b.diagnostics.length, 0, "B never mentioned it");
+        });
+    });
+
+
+    // The gap the demo page exposed: a dead animation target used to stay
+    // invisible until a viewer advanced to the offending slide, which is
+    // exactly the case nobody notices. Decks are now checked at load.
+    describe("init-time deck validation", () => {
+
+        function initWith(canvasid: string, slides: any[]): Slate {
+            const canvas: any = createCanvas(200, 200);
+            canvas.id = canvasid;
+            const savedDoc = (global as any).document;
+            (global as any).document = {
+                getElementById: (id: string) => (id === canvasid ? canvas : null),
+            };
+            try {
+                init({
+                    background: "0,0,100", title: canvasid, canvasid: canvasid,
+                    elements: [
+                        { name: "A", construction: E.Point.free, params: [10, 10] },
+                        { name: "B", construction: E.Point.free, params: [90, 90] },
+                        { name: "AB", construction: E.Line.connect, params: ["A", "B"] },
+                    ],
+                    slides: slides,
+                });
+                return slates[slates.length - 1];
+            } finally {
+                if (savedDoc === undefined) delete (global as any).document;
+                else (global as any).document = savedDoc;
+            }
+        }
+
+        it("reports a dead animation target at load, before any slide runs", () => {
+            let s!: Slate;
+            capture(() => {
+                s = initWith("d1", [
+                    { text: "one", visible: ["AB"] },
+                    { text: "two", visible: ["AB"], transition: { animations: [
+                        { elem: "GHOST", name: "Line.straightEdgeConnect" },
+                    ] } },
+                ]);
+            });
+            assert.equal(s.diagnostics.length, 1,
+                "the badge must appear on load, not only once someone presses p");
+            assert.equal(s.diagnostics[0].code, "unknown-element");
+            assert.ok(s.diagnostics[0].message.indexOf("slide 2") >= 0,
+                "and it should say which slide: " + s.diagnostics[0].message);
+        });
+
+        it("reports an unresolvable name in a slide set at load", () => {
+            let s!: Slate;
+            capture(() => {
+                s = initWith("d2", [{ text: "one", visible: ["AB"], highlighted: ["NOPE"] }]);
+            });
+            assert.equal(s.diagnostics.length, 1);
+            assert.equal(s.diagnostics[0].code, "unknown-slide-name");
+        });
+
+        it("stays silent for a deck whose names all resolve", () => {
+            let s!: Slate;
+            capture(() => {
+                s = initWith("d3", [
+                    { text: "one", visible: ["A", "B", "AB"], highlighted: ["AB"] },
+                    { text: "two", visible: ["A", "B", "AB"], transition: { animations: [
+                        { elem: "AB", name: "Line.straightEdgeConnect" },
+                    ] } },
+                ]);
+            });
+            assert.equal(s.diagnostics.length, 0, "a clean deck must stay clean");
+            assert.equal(s.diagnosticSeverity, null, "so no badge is created at all");
+        });
+
+        it("resolves aliases, so a valid alias is not flagged", () => {
+            let s!: Slate;
+            capture(() => {
+                const canvas: any = createCanvas(200, 200);
+                canvas.id = "d4";
+                const savedDoc = (global as any).document;
+                (global as any).document = {
+                    getElementById: (id: string) => (id === "d4" ? canvas : null),
+                };
+                try {
+                    init({
+                        background: "0,0,100", title: "d4", canvasid: "d4",
+                        elements: [
+                            { name: "A", construction: E.Point.free, params: [10, 10] },
+                            { name: "B", construction: E.Point.free, params: [90, 90] },
+                            { name: "AB", construction: E.Line.connect, params: ["A", "B"] },
+                        ],
+                        aliases: { "BA": "AB" },
+                        slides: [{ text: "one", visible: ["BA"], highlighted: ["BA"] }],
+                    });
+                    s = slates[slates.length - 1];
+                } finally {
+                    if (savedDoc === undefined) delete (global as any).document;
+                    else (global as any).document = savedDoc;
+                }
+            });
+            assert.equal(s.diagnostics.length, 0,
+                "aliases resolve in slide sets since #151; the checker must agree");
         });
     });
 

--- a/tests/HighlightSnapshotTest.ts
+++ b/tests/HighlightSnapshotTest.ts
@@ -18,6 +18,7 @@ import "mocha";
 import * as path from "path";
 import {assertSnapshot, buildScene, ReportEntry} from "./SnapshotHelper";
 import {SlateConfig} from "./HtmlParamParser";
+import {Slate} from "../src/Slate";
 import {reportEntries, ensureReportFlushed} from "./sharedSnapshotReport";
 
 const SNAPSHOT_DIR = path.join(__dirname, "snapshots");
@@ -137,8 +138,9 @@ describe("highlight snapshot (issue #72)", function() {
                 dragResults: [],
             };
 
+            let slate: Slate | null = null;
             try {
-                const slate = buildScene(config);
+                slate = buildScene(config);
                 if (scenario.highlightOnTop != null) {
                     slate.highlightOnTop = scenario.highlightOnTop;
                 }
@@ -162,6 +164,9 @@ describe("highlight snapshot (issue #72)", function() {
                 entry.error = (e as Error).message;
                 throw e;
             } finally {
+                // #154 — attribute whatever the slate complained about to
+                // this scene, so report.html can show it per row.
+                if (slate) entry.warnings = slate.diagnostics.map((d) => d.message);
                 reportEntries.push(entry);
             }
         });

--- a/tests/SnapshotHelper.ts
+++ b/tests/SnapshotHelper.ts
@@ -26,9 +26,13 @@ const FAIL_PERCENT = 0.5;
 // -----------------------------------------------------------------
 // Build a Slate from a SlateConfig (parsed from HTML)
 // -----------------------------------------------------------------
-export function buildScene(config: SlateConfig): Slate {
+export function buildScene(config: SlateConfig, label?: string): Slate {
     let canvas = createCanvas(config.width, config.height);
     let slate = new Slate(canvas as unknown as HTMLCanvasElement);
+    // #154 — the fixture this scene came from. Diagnostics are mirrored to
+    // the console during a test run, where "element 'b' failed to construct"
+    // is unactionable without knowing which of ~650 fixtures produced it.
+    const scene = label != null ? label + ": " : "";
 
     // Parse background
     let bgcolor = parseColor(config.background, "#ffffff", "#ffffff");
@@ -49,7 +53,7 @@ export function buildScene(config: SlateConfig): Slate {
             slate.reportDiagnostic({
                 code: "unparseable-element",
                 key: String(paramStr),
-                message: "could not parse element param: " + String(paramStr),
+                message: scene + "could not parse element param: " + String(paramStr),
                 detail: { param: String(paramStr) },
             });
             continue;
@@ -64,7 +68,7 @@ export function buildScene(config: SlateConfig): Slate {
             slate.reportDiagnostic({
                 code: "construction-failed",
                 key: String(param.name),
-                message: "element '" + String(param.name) + "' failed to construct: "
+                message: scene + "element '" + String(param.name) + "' failed to construct: "
                     + String((e as Error).message),
                 detail: { elem: String(param.name) },
             });

--- a/tests/SnapshotHelper.ts
+++ b/tests/SnapshotHelper.ts
@@ -42,7 +42,16 @@ export function buildScene(config: SlateConfig): Slate {
         try {
             param = parseParam(paramStr);
         } catch (e) {
-            // Skip unparseable elements (e.g., unknown constructions)
+            // #154 — was a silent skip. A fixture with an unparseable
+            // element still renders, just missing a piece, so nothing ever
+            // said so. Report it against the slate and the Warn column in
+            // report.html picks it up.
+            slate.reportDiagnostic({
+                code: "unparseable-element",
+                key: String(paramStr),
+                message: "could not parse element param: " + String(paramStr),
+                detail: { param: String(paramStr) },
+            });
             continue;
         }
 
@@ -50,7 +59,15 @@ export function buildScene(config: SlateConfig): Slate {
         try {
             element = slate.createElement(param.construction, param.params, param.name);
         } catch (e) {
-            // Skip elements that fail to construct
+            // #154 — likewise: a construction that throws leaves a hole in
+            // the figure and used to do so silently.
+            slate.reportDiagnostic({
+                code: "construction-failed",
+                key: String(param.name),
+                message: "element '" + String(param.name) + "' failed to construct: "
+                    + String((e as Error).message),
+                detail: { elem: String(param.name) },
+            });
             continue;
         }
 
@@ -324,6 +341,10 @@ export interface ReportEntry {
         result: SnapshotResult;
     }[];
     error?: string;
+    // #154 — diagnostics the slate reported while this scene was built
+    // and rendered. Report-only: nothing here fails a test, because CI
+    // runs test:unit and never reaches the snapshot suite.
+    warnings?: string[];
 }
 
 export function generateReport(entries: ReportEntry[]): void {
@@ -361,6 +382,7 @@ img { max-width: 150px; max-height: 120px; border: 1px solid #ddd; }
 .fail { background: #f8d7da; }
 .new { background: #fff3cd; }
 .error { background: #f8d7da; color: #721c24; }
+.warn { background: #fff3cd; color: #7a5c00; font-weight: 600; }
 .section { margin-bottom: 30px; }
 details { margin: 5px 0; }
 
@@ -445,7 +467,8 @@ details { margin: 5px 0; }
    Passed: ${entries.filter(e => !e.error && e.beforeResult.passed).length} |
    New baselines: ${entries.filter(e => e.beforeResult.isNew).length} |
    Failed: ${entries.filter(e => !e.error && !e.beforeResult.passed).length} |
-   Errors: ${entries.filter(e => e.error).length}</p>
+   Errors: ${entries.filter(e => e.error).length} |
+   Warnings: ${entries.filter(e => e.warnings && e.warnings.length).length}</p>
 <p style="color:#555;font-size:13px">Click any image to open a live slate + image sequence. Click a strip image again to enlarge.</p>
 `;
 
@@ -461,10 +484,10 @@ details { margin: 5px 0; }
         for (let i = 1; i <= MAX_DRAG_PAIRS; i++) {
             html += `<th>Drag ${i} Move</th><th>Drag ${i} Verify</th>`;
         }
-        html += `<th>Status</th></tr>\n`;
+        html += `<th>Warn</th><th>Status</th></tr>\n`;
 
         let dragColCount = MAX_DRAG_PAIRS * 2;
-        let errorColspan = dragColCount + 2;  // +before +status
+        let errorColspan = dragColCount + 3;  // +before +warn +status
 
         for (let entry of catEntries) {
             let statusClass = entry.error ? "error" :
@@ -495,6 +518,10 @@ details { margin: 5px 0; }
                         html += `<td>—</td><td>—</td>`;
                     }
                 }
+                const warns = entry.warnings || [];
+                html += warns.length
+                    ? `<td class="warn" title="${warns.join(" | ").replace(/"/g, "&quot;")}">${warns.length}</td>`
+                    : `<td>-</td>`;
                 html += `<td>${statusText}</td>`;
             }
             html += `</tr>\n`;

--- a/tests/SnapshotTest.ts
+++ b/tests/SnapshotTest.ts
@@ -61,7 +61,7 @@ describe("snapshot verification", function() {
                 let slate: Slate | null = null;
                 try {
                     // Build and render the scene
-                    slate = buildScene(config);
+                    slate = buildScene(config, fileResult.filePath);
                     let canvas = renderScene(slate);
 
                     // Snapshot the initial state

--- a/tests/SnapshotTest.ts
+++ b/tests/SnapshotTest.ts
@@ -15,6 +15,7 @@ import {
     drawVerificationImage, assertSnapshot, saveVerificationImage,
     ReportEntry, countDiffPixels, capturePixels
 } from "./SnapshotHelper";
+import {Slate} from "../src/Slate";
 import {reportEntries, ensureReportFlushed} from "./sharedSnapshotReport";
 
 const REPO_ROOT = path.resolve(__dirname, "..");
@@ -57,9 +58,10 @@ describe("snapshot verification", function() {
                     dragResults: [],
                 };
 
+                let slate: Slate | null = null;
                 try {
                     // Build and render the scene
-                    let slate = buildScene(config);
+                    slate = buildScene(config);
                     let canvas = renderScene(slate);
 
                     // Snapshot the initial state
@@ -160,6 +162,9 @@ describe("snapshot verification", function() {
                     }
                     throw e;
                 } finally {
+                    // #154 — attribute whatever the slate complained about to
+                    // this scene, so report.html can show it per row.
+                    if (slate) entry.warnings = slate.diagnostics.map((d) => d.message);
                     reportEntries.push(entry);
                 }
             });

--- a/tests/VisibilitySnapshotTest.ts
+++ b/tests/VisibilitySnapshotTest.ts
@@ -9,6 +9,7 @@ import "mocha";
 import * as path from "path";
 import {assertSnapshot, buildScene, ReportEntry} from "./SnapshotHelper";
 import {SlateConfig} from "./HtmlParamParser";
+import {Slate} from "../src/Slate";
 import {reportEntries, ensureReportFlushed} from "./sharedSnapshotReport";
 
 const SNAPSHOT_DIR = path.join(__dirname, "snapshots");
@@ -58,8 +59,9 @@ describe("visibility snapshot (issue #75)", function() {
                 dragResults: [],
             };
 
+            let slate: Slate | null = null;
             try {
-                const slate = buildScene(TRIANGLE_CONFIG);
+                slate = buildScene(TRIANGLE_CONFIG);
                 if (scenario.visible !== null) {
                     slate.setVisibleNames(scenario.visible);
                 }
@@ -77,6 +79,9 @@ describe("visibility snapshot (issue #75)", function() {
                 entry.error = (e as Error).message;
                 throw e;
             } finally {
+                // #154 — attribute whatever the slate complained about to
+                // this scene, so report.html can show it per row.
+                if (slate) entry.warnings = slate.diagnostics.map((d) => d.message);
                 reportEntries.push(entry);
             }
         });

--- a/view/test/archive-index.json
+++ b/view/test/archive-index.json
@@ -1,0 +1,4933 @@
+{
+ "generated": 616,
+ "pages": [
+  {
+   "path": "../compass_geometry/compass1.html",
+   "repoPath": "view/compass_geometry/compass1.html",
+   "name": "compass1",
+   "category": "compass",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../compass_geometry/compass2.html",
+   "repoPath": "view/compass_geometry/compass2.html",
+   "name": "compass2",
+   "category": "compass",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../compass_geometry/compass3.html",
+   "repoPath": "view/compass_geometry/compass3.html",
+   "name": "compass3",
+   "category": "compass",
+   "applets": 7,
+   "inits": 0
+  },
+  {
+   "path": "../compass_geometry/compass4.html",
+   "repoPath": "view/compass_geometry/compass4.html",
+   "name": "compass4",
+   "category": "compass",
+   "applets": 5,
+   "inits": 0
+  },
+  {
+   "path": "../compass_geometry/compass5.html",
+   "repoPath": "view/compass_geometry/compass5.html",
+   "name": "compass5",
+   "category": "compass",
+   "applets": 4,
+   "inits": 0
+  },
+  {
+   "path": "../compass_geometry/compass6.html",
+   "repoPath": "view/compass_geometry/compass6.html",
+   "name": "compass6",
+   "category": "compass",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../compass_geometry/compass7.html",
+   "repoPath": "view/compass_geometry/compass7.html",
+   "name": "compass7",
+   "category": "compass",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/defI10.html",
+   "repoPath": "view/euclid-html/booki/defI10.html",
+   "name": "defI10",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/defI11.html",
+   "repoPath": "view/euclid-html/booki/defI11.html",
+   "name": "defI11",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/defI15.html",
+   "repoPath": "view/euclid-html/booki/defI15.html",
+   "name": "defI15",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/defI19.html",
+   "repoPath": "view/euclid-html/booki/defI19.html",
+   "name": "defI19",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/defI2.html",
+   "repoPath": "view/euclid-html/booki/defI2.html",
+   "name": "defI2",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/defI20.html",
+   "repoPath": "view/euclid-html/booki/defI20.html",
+   "name": "defI20",
+   "category": "euclid/bookI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/defI22.html",
+   "repoPath": "view/euclid-html/booki/defI22.html",
+   "name": "defI22",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/defI23.html",
+   "repoPath": "view/euclid-html/booki/defI23.html",
+   "name": "defI23",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/defI8.html",
+   "repoPath": "view/euclid-html/booki/defI8.html",
+   "name": "defI8",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/defI9.html",
+   "repoPath": "view/euclid-html/booki/defI9.html",
+   "name": "defI9",
+   "category": "euclid/bookI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/post1.html",
+   "repoPath": "view/euclid-html/booki/post1.html",
+   "name": "post1",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/post2.html",
+   "repoPath": "view/euclid-html/booki/post2.html",
+   "name": "post2",
+   "category": "euclid/bookI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/post3.html",
+   "repoPath": "view/euclid-html/booki/post3.html",
+   "name": "post3",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/post4.html",
+   "repoPath": "view/euclid-html/booki/post4.html",
+   "name": "post4",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/post5.html",
+   "repoPath": "view/euclid-html/booki/post5.html",
+   "name": "post5",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI1.html",
+   "repoPath": "view/euclid-html/booki/propI1.html",
+   "name": "propI1",
+   "category": "euclid/bookI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI10.html",
+   "repoPath": "view/euclid-html/booki/propI10.html",
+   "name": "propI10",
+   "category": "euclid/bookI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI11.html",
+   "repoPath": "view/euclid-html/booki/propI11.html",
+   "name": "propI11",
+   "category": "euclid/bookI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI12.html",
+   "repoPath": "view/euclid-html/booki/propI12.html",
+   "name": "propI12",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI13.html",
+   "repoPath": "view/euclid-html/booki/propI13.html",
+   "name": "propI13",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI14.html",
+   "repoPath": "view/euclid-html/booki/propI14.html",
+   "name": "propI14",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI15.html",
+   "repoPath": "view/euclid-html/booki/propI15.html",
+   "name": "propI15",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI16.html",
+   "repoPath": "view/euclid-html/booki/propI16.html",
+   "name": "propI16",
+   "category": "euclid/bookI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI17.html",
+   "repoPath": "view/euclid-html/booki/propI17.html",
+   "name": "propI17",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI18.html",
+   "repoPath": "view/euclid-html/booki/propI18.html",
+   "name": "propI18",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI19.html",
+   "repoPath": "view/euclid-html/booki/propI19.html",
+   "name": "propI19",
+   "category": "euclid/bookI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI2.html",
+   "repoPath": "view/euclid-html/booki/propI2.html",
+   "name": "propI2",
+   "category": "euclid/bookI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI20.html",
+   "repoPath": "view/euclid-html/booki/propI20.html",
+   "name": "propI20",
+   "category": "euclid/bookI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI21.html",
+   "repoPath": "view/euclid-html/booki/propI21.html",
+   "name": "propI21",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI22.html",
+   "repoPath": "view/euclid-html/booki/propI22.html",
+   "name": "propI22",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI23.html",
+   "repoPath": "view/euclid-html/booki/propI23.html",
+   "name": "propI23",
+   "category": "euclid/bookI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI24.html",
+   "repoPath": "view/euclid-html/booki/propI24.html",
+   "name": "propI24",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI25.html",
+   "repoPath": "view/euclid-html/booki/propI25.html",
+   "name": "propI25",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI26.html",
+   "repoPath": "view/euclid-html/booki/propI26.html",
+   "name": "propI26",
+   "category": "euclid/bookI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI27.html",
+   "repoPath": "view/euclid-html/booki/propI27.html",
+   "name": "propI27",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI28.html",
+   "repoPath": "view/euclid-html/booki/propI28.html",
+   "name": "propI28",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI29.html",
+   "repoPath": "view/euclid-html/booki/propI29.html",
+   "name": "propI29",
+   "category": "euclid/bookI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI3.html",
+   "repoPath": "view/euclid-html/booki/propI3.html",
+   "name": "propI3",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI30.html",
+   "repoPath": "view/euclid-html/booki/propI30.html",
+   "name": "propI30",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI31.html",
+   "repoPath": "view/euclid-html/booki/propI31.html",
+   "name": "propI31",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI32.html",
+   "repoPath": "view/euclid-html/booki/propI32.html",
+   "name": "propI32",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI33.html",
+   "repoPath": "view/euclid-html/booki/propI33.html",
+   "name": "propI33",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI34.html",
+   "repoPath": "view/euclid-html/booki/propI34.html",
+   "name": "propI34",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI35.html",
+   "repoPath": "view/euclid-html/booki/propI35.html",
+   "name": "propI35",
+   "category": "euclid/bookI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI36.html",
+   "repoPath": "view/euclid-html/booki/propI36.html",
+   "name": "propI36",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI37.html",
+   "repoPath": "view/euclid-html/booki/propI37.html",
+   "name": "propI37",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI38.html",
+   "repoPath": "view/euclid-html/booki/propI38.html",
+   "name": "propI38",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI39.html",
+   "repoPath": "view/euclid-html/booki/propI39.html",
+   "name": "propI39",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI4.html",
+   "repoPath": "view/euclid-html/booki/propI4.html",
+   "name": "propI4",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI40.html",
+   "repoPath": "view/euclid-html/booki/propI40.html",
+   "name": "propI40",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI41.html",
+   "repoPath": "view/euclid-html/booki/propI41.html",
+   "name": "propI41",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI42.html",
+   "repoPath": "view/euclid-html/booki/propI42.html",
+   "name": "propI42",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI43.html",
+   "repoPath": "view/euclid-html/booki/propI43.html",
+   "name": "propI43",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI44.html",
+   "repoPath": "view/euclid-html/booki/propI44.html",
+   "name": "propI44",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI45.html",
+   "repoPath": "view/euclid-html/booki/propI45.html",
+   "name": "propI45",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI46.html",
+   "repoPath": "view/euclid-html/booki/propI46.html",
+   "name": "propI46",
+   "category": "euclid/bookI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI47.html",
+   "repoPath": "view/euclid-html/booki/propI47.html",
+   "name": "propI47",
+   "category": "euclid/bookI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI48.html",
+   "repoPath": "view/euclid-html/booki/propI48.html",
+   "name": "propI48",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI5.html",
+   "repoPath": "view/euclid-html/booki/propI5.html",
+   "name": "propI5",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI6.html",
+   "repoPath": "view/euclid-html/booki/propI6.html",
+   "name": "propI6",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI7.html",
+   "repoPath": "view/euclid-html/booki/propI7.html",
+   "name": "propI7",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI8.html",
+   "repoPath": "view/euclid-html/booki/propI8.html",
+   "name": "propI8",
+   "category": "euclid/bookI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/booki/propI9.html",
+   "repoPath": "view/euclid-html/booki/propI9.html",
+   "name": "propI9",
+   "category": "euclid/bookI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookii/defII.html",
+   "repoPath": "view/euclid-html/bookii/defII.html",
+   "name": "defII",
+   "category": "euclid/bookII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookii/propII1.html",
+   "repoPath": "view/euclid-html/bookii/propII1.html",
+   "name": "propII1",
+   "category": "euclid/bookII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookii/propII10.html",
+   "repoPath": "view/euclid-html/bookii/propII10.html",
+   "name": "propII10",
+   "category": "euclid/bookII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookii/propII11.html",
+   "repoPath": "view/euclid-html/bookii/propII11.html",
+   "name": "propII11",
+   "category": "euclid/bookII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookii/propII12.html",
+   "repoPath": "view/euclid-html/bookii/propII12.html",
+   "name": "propII12",
+   "category": "euclid/bookII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookii/propII13.html",
+   "repoPath": "view/euclid-html/bookii/propII13.html",
+   "name": "propII13",
+   "category": "euclid/bookII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookii/propII14.html",
+   "repoPath": "view/euclid-html/bookii/propII14.html",
+   "name": "propII14",
+   "category": "euclid/bookII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookii/propII2.html",
+   "repoPath": "view/euclid-html/bookii/propII2.html",
+   "name": "propII2",
+   "category": "euclid/bookII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookii/propII3.html",
+   "repoPath": "view/euclid-html/bookii/propII3.html",
+   "name": "propII3",
+   "category": "euclid/bookII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookii/propII4.html",
+   "repoPath": "view/euclid-html/bookii/propII4.html",
+   "name": "propII4",
+   "category": "euclid/bookII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookii/propII5.html",
+   "repoPath": "view/euclid-html/bookii/propII5.html",
+   "name": "propII5",
+   "category": "euclid/bookII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookii/propII6.html",
+   "repoPath": "view/euclid-html/bookii/propII6.html",
+   "name": "propII6",
+   "category": "euclid/bookII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookii/propII7.html",
+   "repoPath": "view/euclid-html/bookii/propII7.html",
+   "name": "propII7",
+   "category": "euclid/bookII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookii/propII8.html",
+   "repoPath": "view/euclid-html/bookii/propII8.html",
+   "name": "propII8",
+   "category": "euclid/bookII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookii/propII9.html",
+   "repoPath": "view/euclid-html/bookii/propII9.html",
+   "name": "propII9",
+   "category": "euclid/bookII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookii/propII9a.html",
+   "repoPath": "view/euclid-html/bookii/propII9a.html",
+   "name": "propII9a",
+   "category": "euclid/bookII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/defIII1.html",
+   "repoPath": "view/euclid-html/bookiii/defIII1.html",
+   "name": "defIII1",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/defIII10.html",
+   "repoPath": "view/euclid-html/bookiii/defIII10.html",
+   "name": "defIII10",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/defIII11.html",
+   "repoPath": "view/euclid-html/bookiii/defIII11.html",
+   "name": "defIII11",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/defIII2.html",
+   "repoPath": "view/euclid-html/bookiii/defIII2.html",
+   "name": "defIII2",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/defIII4.html",
+   "repoPath": "view/euclid-html/bookiii/defIII4.html",
+   "name": "defIII4",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/defIII6.html",
+   "repoPath": "view/euclid-html/bookiii/defIII6.html",
+   "name": "defIII6",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII1.html",
+   "repoPath": "view/euclid-html/bookiii/propIII1.html",
+   "name": "propIII1",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII10.html",
+   "repoPath": "view/euclid-html/bookiii/propIII10.html",
+   "name": "propIII10",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII11.html",
+   "repoPath": "view/euclid-html/bookiii/propIII11.html",
+   "name": "propIII11",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII12.html",
+   "repoPath": "view/euclid-html/bookiii/propIII12.html",
+   "name": "propIII12",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII13.html",
+   "repoPath": "view/euclid-html/bookiii/propIII13.html",
+   "name": "propIII13",
+   "category": "euclid/bookIII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII14.html",
+   "repoPath": "view/euclid-html/bookiii/propIII14.html",
+   "name": "propIII14",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII15.html",
+   "repoPath": "view/euclid-html/bookiii/propIII15.html",
+   "name": "propIII15",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII16.html",
+   "repoPath": "view/euclid-html/bookiii/propIII16.html",
+   "name": "propIII16",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII17.html",
+   "repoPath": "view/euclid-html/bookiii/propIII17.html",
+   "name": "propIII17",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII18.html",
+   "repoPath": "view/euclid-html/bookiii/propIII18.html",
+   "name": "propIII18",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII19.html",
+   "repoPath": "view/euclid-html/bookiii/propIII19.html",
+   "name": "propIII19",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII2.html",
+   "repoPath": "view/euclid-html/bookiii/propIII2.html",
+   "name": "propIII2",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII20.html",
+   "repoPath": "view/euclid-html/bookiii/propIII20.html",
+   "name": "propIII20",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII21.html",
+   "repoPath": "view/euclid-html/bookiii/propIII21.html",
+   "name": "propIII21",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII22.html",
+   "repoPath": "view/euclid-html/bookiii/propIII22.html",
+   "name": "propIII22",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII23.html",
+   "repoPath": "view/euclid-html/bookiii/propIII23.html",
+   "name": "propIII23",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII24.html",
+   "repoPath": "view/euclid-html/bookiii/propIII24.html",
+   "name": "propIII24",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII25.html",
+   "repoPath": "view/euclid-html/bookiii/propIII25.html",
+   "name": "propIII25",
+   "category": "euclid/bookIII",
+   "applets": 3,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII26.html",
+   "repoPath": "view/euclid-html/bookiii/propIII26.html",
+   "name": "propIII26",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII27.html",
+   "repoPath": "view/euclid-html/bookiii/propIII27.html",
+   "name": "propIII27",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII28.html",
+   "repoPath": "view/euclid-html/bookiii/propIII28.html",
+   "name": "propIII28",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII29.html",
+   "repoPath": "view/euclid-html/bookiii/propIII29.html",
+   "name": "propIII29",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII3.html",
+   "repoPath": "view/euclid-html/bookiii/propIII3.html",
+   "name": "propIII3",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII30.html",
+   "repoPath": "view/euclid-html/bookiii/propIII30.html",
+   "name": "propIII30",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII31.html",
+   "repoPath": "view/euclid-html/bookiii/propIII31.html",
+   "name": "propIII31",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII32.html",
+   "repoPath": "view/euclid-html/bookiii/propIII32.html",
+   "name": "propIII32",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII33.html",
+   "repoPath": "view/euclid-html/bookiii/propIII33.html",
+   "name": "propIII33",
+   "category": "euclid/bookIII",
+   "applets": 3,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII34.html",
+   "repoPath": "view/euclid-html/bookiii/propIII34.html",
+   "name": "propIII34",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII35.html",
+   "repoPath": "view/euclid-html/bookiii/propIII35.html",
+   "name": "propIII35",
+   "category": "euclid/bookIII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII36.html",
+   "repoPath": "view/euclid-html/bookiii/propIII36.html",
+   "name": "propIII36",
+   "category": "euclid/bookIII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII37.html",
+   "repoPath": "view/euclid-html/bookiii/propIII37.html",
+   "name": "propIII37",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII4.html",
+   "repoPath": "view/euclid-html/bookiii/propIII4.html",
+   "name": "propIII4",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII5.html",
+   "repoPath": "view/euclid-html/bookiii/propIII5.html",
+   "name": "propIII5",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII6.html",
+   "repoPath": "view/euclid-html/bookiii/propIII6.html",
+   "name": "propIII6",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII7.html",
+   "repoPath": "view/euclid-html/bookiii/propIII7.html",
+   "name": "propIII7",
+   "category": "euclid/bookIII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII8.html",
+   "repoPath": "view/euclid-html/bookiii/propIII8.html",
+   "name": "propIII8",
+   "category": "euclid/bookIII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiii/propIII9.html",
+   "repoPath": "view/euclid-html/bookiii/propIII9.html",
+   "name": "propIII9",
+   "category": "euclid/bookIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiv/defIV.html",
+   "repoPath": "view/euclid-html/bookiv/defIV.html",
+   "name": "defIV",
+   "category": "euclid/bookIV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiv/propIV1.html",
+   "repoPath": "view/euclid-html/bookiv/propIV1.html",
+   "name": "propIV1",
+   "category": "euclid/bookIV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiv/propIV10.html",
+   "repoPath": "view/euclid-html/bookiv/propIV10.html",
+   "name": "propIV10",
+   "category": "euclid/bookIV",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiv/propIV11.html",
+   "repoPath": "view/euclid-html/bookiv/propIV11.html",
+   "name": "propIV11",
+   "category": "euclid/bookIV",
+   "applets": 3,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiv/propIV12.html",
+   "repoPath": "view/euclid-html/bookiv/propIV12.html",
+   "name": "propIV12",
+   "category": "euclid/bookIV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiv/propIV13.html",
+   "repoPath": "view/euclid-html/bookiv/propIV13.html",
+   "name": "propIV13",
+   "category": "euclid/bookIV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiv/propIV14.html",
+   "repoPath": "view/euclid-html/bookiv/propIV14.html",
+   "name": "propIV14",
+   "category": "euclid/bookIV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiv/propIV15.html",
+   "repoPath": "view/euclid-html/bookiv/propIV15.html",
+   "name": "propIV15",
+   "category": "euclid/bookIV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiv/propIV16.html",
+   "repoPath": "view/euclid-html/bookiv/propIV16.html",
+   "name": "propIV16",
+   "category": "euclid/bookIV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiv/propIV2.html",
+   "repoPath": "view/euclid-html/bookiv/propIV2.html",
+   "name": "propIV2",
+   "category": "euclid/bookIV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiv/propIV3.html",
+   "repoPath": "view/euclid-html/bookiv/propIV3.html",
+   "name": "propIV3",
+   "category": "euclid/bookIV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiv/propIV4.html",
+   "repoPath": "view/euclid-html/bookiv/propIV4.html",
+   "name": "propIV4",
+   "category": "euclid/bookIV",
+   "applets": 4,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiv/propIV5.html",
+   "repoPath": "view/euclid-html/bookiv/propIV5.html",
+   "name": "propIV5",
+   "category": "euclid/bookIV",
+   "applets": 4,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiv/propIV6.html",
+   "repoPath": "view/euclid-html/bookiv/propIV6.html",
+   "name": "propIV6",
+   "category": "euclid/bookIV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiv/propIV7.html",
+   "repoPath": "view/euclid-html/bookiv/propIV7.html",
+   "name": "propIV7",
+   "category": "euclid/bookIV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiv/propIV8.html",
+   "repoPath": "view/euclid-html/bookiv/propIV8.html",
+   "name": "propIV8",
+   "category": "euclid/bookIV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookiv/propIV9.html",
+   "repoPath": "view/euclid-html/bookiv/propIV9.html",
+   "name": "propIV9",
+   "category": "euclid/bookIV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX1.html",
+   "repoPath": "view/euclid-html/bookix/propIX1.html",
+   "name": "propIX1",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX10.html",
+   "repoPath": "view/euclid-html/bookix/propIX10.html",
+   "name": "propIX10",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX11.html",
+   "repoPath": "view/euclid-html/bookix/propIX11.html",
+   "name": "propIX11",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX12.html",
+   "repoPath": "view/euclid-html/bookix/propIX12.html",
+   "name": "propIX12",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX13.html",
+   "repoPath": "view/euclid-html/bookix/propIX13.html",
+   "name": "propIX13",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX14.html",
+   "repoPath": "view/euclid-html/bookix/propIX14.html",
+   "name": "propIX14",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX15.html",
+   "repoPath": "view/euclid-html/bookix/propIX15.html",
+   "name": "propIX15",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX16.html",
+   "repoPath": "view/euclid-html/bookix/propIX16.html",
+   "name": "propIX16",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX17.html",
+   "repoPath": "view/euclid-html/bookix/propIX17.html",
+   "name": "propIX17",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX18.html",
+   "repoPath": "view/euclid-html/bookix/propIX18.html",
+   "name": "propIX18",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX19.html",
+   "repoPath": "view/euclid-html/bookix/propIX19.html",
+   "name": "propIX19",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX2.html",
+   "repoPath": "view/euclid-html/bookix/propIX2.html",
+   "name": "propIX2",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX20.html",
+   "repoPath": "view/euclid-html/bookix/propIX20.html",
+   "name": "propIX20",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX21.html",
+   "repoPath": "view/euclid-html/bookix/propIX21.html",
+   "name": "propIX21",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX22.html",
+   "repoPath": "view/euclid-html/bookix/propIX22.html",
+   "name": "propIX22",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX23.html",
+   "repoPath": "view/euclid-html/bookix/propIX23.html",
+   "name": "propIX23",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX24.html",
+   "repoPath": "view/euclid-html/bookix/propIX24.html",
+   "name": "propIX24",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX25.html",
+   "repoPath": "view/euclid-html/bookix/propIX25.html",
+   "name": "propIX25",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX26.html",
+   "repoPath": "view/euclid-html/bookix/propIX26.html",
+   "name": "propIX26",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX27.html",
+   "repoPath": "view/euclid-html/bookix/propIX27.html",
+   "name": "propIX27",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX28.html",
+   "repoPath": "view/euclid-html/bookix/propIX28.html",
+   "name": "propIX28",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX29.html",
+   "repoPath": "view/euclid-html/bookix/propIX29.html",
+   "name": "propIX29",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX3.html",
+   "repoPath": "view/euclid-html/bookix/propIX3.html",
+   "name": "propIX3",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX30.html",
+   "repoPath": "view/euclid-html/bookix/propIX30.html",
+   "name": "propIX30",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX31.html",
+   "repoPath": "view/euclid-html/bookix/propIX31.html",
+   "name": "propIX31",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX32.html",
+   "repoPath": "view/euclid-html/bookix/propIX32.html",
+   "name": "propIX32",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX33.html",
+   "repoPath": "view/euclid-html/bookix/propIX33.html",
+   "name": "propIX33",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX34.html",
+   "repoPath": "view/euclid-html/bookix/propIX34.html",
+   "name": "propIX34",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX35.html",
+   "repoPath": "view/euclid-html/bookix/propIX35.html",
+   "name": "propIX35",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX36.html",
+   "repoPath": "view/euclid-html/bookix/propIX36.html",
+   "name": "propIX36",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX4.html",
+   "repoPath": "view/euclid-html/bookix/propIX4.html",
+   "name": "propIX4",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX5.html",
+   "repoPath": "view/euclid-html/bookix/propIX5.html",
+   "name": "propIX5",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX6.html",
+   "repoPath": "view/euclid-html/bookix/propIX6.html",
+   "name": "propIX6",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX7.html",
+   "repoPath": "view/euclid-html/bookix/propIX7.html",
+   "name": "propIX7",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX8.html",
+   "repoPath": "view/euclid-html/bookix/propIX8.html",
+   "name": "propIX8",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookix/propIX9.html",
+   "repoPath": "view/euclid-html/bookix/propIX9.html",
+   "name": "propIX9",
+   "category": "euclid/bookIX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/defV1.html",
+   "repoPath": "view/euclid-html/bookv/defV1.html",
+   "name": "defV1",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/defV11.html",
+   "repoPath": "view/euclid-html/bookv/defV11.html",
+   "name": "defV11",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/defV14.html",
+   "repoPath": "view/euclid-html/bookv/defV14.html",
+   "name": "defV14",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/defV17.html",
+   "repoPath": "view/euclid-html/bookv/defV17.html",
+   "name": "defV17",
+   "category": "euclid/bookV",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/defV3.html",
+   "repoPath": "view/euclid-html/bookv/defV3.html",
+   "name": "defV3",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/defV5.html",
+   "repoPath": "view/euclid-html/bookv/defV5.html",
+   "name": "defV5",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/defV8.html",
+   "repoPath": "view/euclid-html/bookv/defV8.html",
+   "name": "defV8",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV1.html",
+   "repoPath": "view/euclid-html/bookv/propV1.html",
+   "name": "propV1",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV10.html",
+   "repoPath": "view/euclid-html/bookv/propV10.html",
+   "name": "propV10",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV11.html",
+   "repoPath": "view/euclid-html/bookv/propV11.html",
+   "name": "propV11",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV12.html",
+   "repoPath": "view/euclid-html/bookv/propV12.html",
+   "name": "propV12",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV13.html",
+   "repoPath": "view/euclid-html/bookv/propV13.html",
+   "name": "propV13",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV14.html",
+   "repoPath": "view/euclid-html/bookv/propV14.html",
+   "name": "propV14",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV15.html",
+   "repoPath": "view/euclid-html/bookv/propV15.html",
+   "name": "propV15",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV16.html",
+   "repoPath": "view/euclid-html/bookv/propV16.html",
+   "name": "propV16",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV17.html",
+   "repoPath": "view/euclid-html/bookv/propV17.html",
+   "name": "propV17",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV18.html",
+   "repoPath": "view/euclid-html/bookv/propV18.html",
+   "name": "propV18",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV19.html",
+   "repoPath": "view/euclid-html/bookv/propV19.html",
+   "name": "propV19",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV2.html",
+   "repoPath": "view/euclid-html/bookv/propV2.html",
+   "name": "propV2",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV20.html",
+   "repoPath": "view/euclid-html/bookv/propV20.html",
+   "name": "propV20",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV21.html",
+   "repoPath": "view/euclid-html/bookv/propV21.html",
+   "name": "propV21",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV22.html",
+   "repoPath": "view/euclid-html/bookv/propV22.html",
+   "name": "propV22",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV23.html",
+   "repoPath": "view/euclid-html/bookv/propV23.html",
+   "name": "propV23",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV24.html",
+   "repoPath": "view/euclid-html/bookv/propV24.html",
+   "name": "propV24",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV25.html",
+   "repoPath": "view/euclid-html/bookv/propV25.html",
+   "name": "propV25",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV3.html",
+   "repoPath": "view/euclid-html/bookv/propV3.html",
+   "name": "propV3",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV4.html",
+   "repoPath": "view/euclid-html/bookv/propV4.html",
+   "name": "propV4",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV5.html",
+   "repoPath": "view/euclid-html/bookv/propV5.html",
+   "name": "propV5",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV6.html",
+   "repoPath": "view/euclid-html/bookv/propV6.html",
+   "name": "propV6",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV7.html",
+   "repoPath": "view/euclid-html/bookv/propV7.html",
+   "name": "propV7",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV8.html",
+   "repoPath": "view/euclid-html/bookv/propV8.html",
+   "name": "propV8",
+   "category": "euclid/bookV",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookv/propV9.html",
+   "repoPath": "view/euclid-html/bookv/propV9.html",
+   "name": "propV9",
+   "category": "euclid/bookV",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/defVI1.html",
+   "repoPath": "view/euclid-html/bookvi/defVI1.html",
+   "name": "defVI1",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/defVI2.html",
+   "repoPath": "view/euclid-html/bookvi/defVI2.html",
+   "name": "defVI2",
+   "category": "euclid/bookVI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/defVI3.html",
+   "repoPath": "view/euclid-html/bookvi/defVI3.html",
+   "name": "defVI3",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/defVI4.html",
+   "repoPath": "view/euclid-html/bookvi/defVI4.html",
+   "name": "defVI4",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI1.html",
+   "repoPath": "view/euclid-html/bookvi/propVI1.html",
+   "name": "propVI1",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI10.html",
+   "repoPath": "view/euclid-html/bookvi/propVI10.html",
+   "name": "propVI10",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI11.html",
+   "repoPath": "view/euclid-html/bookvi/propVI11.html",
+   "name": "propVI11",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI12.html",
+   "repoPath": "view/euclid-html/bookvi/propVI12.html",
+   "name": "propVI12",
+   "category": "euclid/bookVI",
+   "applets": 3,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI13.html",
+   "repoPath": "view/euclid-html/bookvi/propVI13.html",
+   "name": "propVI13",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI14.html",
+   "repoPath": "view/euclid-html/bookvi/propVI14.html",
+   "name": "propVI14",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI15.html",
+   "repoPath": "view/euclid-html/bookvi/propVI15.html",
+   "name": "propVI15",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI16.html",
+   "repoPath": "view/euclid-html/bookvi/propVI16.html",
+   "name": "propVI16",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI17.html",
+   "repoPath": "view/euclid-html/bookvi/propVI17.html",
+   "name": "propVI17",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI18.html",
+   "repoPath": "view/euclid-html/bookvi/propVI18.html",
+   "name": "propVI18",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI19.html",
+   "repoPath": "view/euclid-html/bookvi/propVI19.html",
+   "name": "propVI19",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI2.html",
+   "repoPath": "view/euclid-html/bookvi/propVI2.html",
+   "name": "propVI2",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI20.html",
+   "repoPath": "view/euclid-html/bookvi/propVI20.html",
+   "name": "propVI20",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI21.html",
+   "repoPath": "view/euclid-html/bookvi/propVI21.html",
+   "name": "propVI21",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI22.html",
+   "repoPath": "view/euclid-html/bookvi/propVI22.html",
+   "name": "propVI22",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI23.html",
+   "repoPath": "view/euclid-html/bookvi/propVI23.html",
+   "name": "propVI23",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI24.html",
+   "repoPath": "view/euclid-html/bookvi/propVI24.html",
+   "name": "propVI24",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI25.html",
+   "repoPath": "view/euclid-html/bookvi/propVI25.html",
+   "name": "propVI25",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI26.html",
+   "repoPath": "view/euclid-html/bookvi/propVI26.html",
+   "name": "propVI26",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI27.html",
+   "repoPath": "view/euclid-html/bookvi/propVI27.html",
+   "name": "propVI27",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI28.html",
+   "repoPath": "view/euclid-html/bookvi/propVI28.html",
+   "name": "propVI28",
+   "category": "euclid/bookVI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI29.html",
+   "repoPath": "view/euclid-html/bookvi/propVI29.html",
+   "name": "propVI29",
+   "category": "euclid/bookVI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI3.html",
+   "repoPath": "view/euclid-html/bookvi/propVI3.html",
+   "name": "propVI3",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI30.html",
+   "repoPath": "view/euclid-html/bookvi/propVI30.html",
+   "name": "propVI30",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI31.html",
+   "repoPath": "view/euclid-html/bookvi/propVI31.html",
+   "name": "propVI31",
+   "category": "euclid/bookVI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI32.html",
+   "repoPath": "view/euclid-html/bookvi/propVI32.html",
+   "name": "propVI32",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI33.html",
+   "repoPath": "view/euclid-html/bookvi/propVI33.html",
+   "name": "propVI33",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI4.html",
+   "repoPath": "view/euclid-html/bookvi/propVI4.html",
+   "name": "propVI4",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI5.html",
+   "repoPath": "view/euclid-html/bookvi/propVI5.html",
+   "name": "propVI5",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI6.html",
+   "repoPath": "view/euclid-html/bookvi/propVI6.html",
+   "name": "propVI6",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI7.html",
+   "repoPath": "view/euclid-html/bookvi/propVI7.html",
+   "name": "propVI7",
+   "category": "euclid/bookVI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI8.html",
+   "repoPath": "view/euclid-html/bookvi/propVI8.html",
+   "name": "propVI8",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/propVI9.html",
+   "repoPath": "view/euclid-html/bookvi/propVI9.html",
+   "name": "propVI9",
+   "category": "euclid/bookVI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvi/temp.html",
+   "repoPath": "view/euclid-html/bookvi/temp.html",
+   "name": "temp",
+   "category": "euclid/bookVI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/defVII1.html",
+   "repoPath": "view/euclid-html/bookvii/defVII1.html",
+   "name": "defVII1",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/defVII15.html",
+   "repoPath": "view/euclid-html/bookvii/defVII15.html",
+   "name": "defVII15",
+   "category": "euclid/bookVII",
+   "applets": 3,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/defVII21.html",
+   "repoPath": "view/euclid-html/bookvii/defVII21.html",
+   "name": "defVII21",
+   "category": "euclid/bookVII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/defVII3.html",
+   "repoPath": "view/euclid-html/bookvii/defVII3.html",
+   "name": "defVII3",
+   "category": "euclid/bookVII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII1.html",
+   "repoPath": "view/euclid-html/bookvii/propVII1.html",
+   "name": "propVII1",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII10.html",
+   "repoPath": "view/euclid-html/bookvii/propVII10.html",
+   "name": "propVII10",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII11.html",
+   "repoPath": "view/euclid-html/bookvii/propVII11.html",
+   "name": "propVII11",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII12.html",
+   "repoPath": "view/euclid-html/bookvii/propVII12.html",
+   "name": "propVII12",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII13.html",
+   "repoPath": "view/euclid-html/bookvii/propVII13.html",
+   "name": "propVII13",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII14.html",
+   "repoPath": "view/euclid-html/bookvii/propVII14.html",
+   "name": "propVII14",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII15.html",
+   "repoPath": "view/euclid-html/bookvii/propVII15.html",
+   "name": "propVII15",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII16.html",
+   "repoPath": "view/euclid-html/bookvii/propVII16.html",
+   "name": "propVII16",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII17.html",
+   "repoPath": "view/euclid-html/bookvii/propVII17.html",
+   "name": "propVII17",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII18.html",
+   "repoPath": "view/euclid-html/bookvii/propVII18.html",
+   "name": "propVII18",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII19.html",
+   "repoPath": "view/euclid-html/bookvii/propVII19.html",
+   "name": "propVII19",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII2.html",
+   "repoPath": "view/euclid-html/bookvii/propVII2.html",
+   "name": "propVII2",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII20.html",
+   "repoPath": "view/euclid-html/bookvii/propVII20.html",
+   "name": "propVII20",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII21.html",
+   "repoPath": "view/euclid-html/bookvii/propVII21.html",
+   "name": "propVII21",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII22.html",
+   "repoPath": "view/euclid-html/bookvii/propVII22.html",
+   "name": "propVII22",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII23.html",
+   "repoPath": "view/euclid-html/bookvii/propVII23.html",
+   "name": "propVII23",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII24.html",
+   "repoPath": "view/euclid-html/bookvii/propVII24.html",
+   "name": "propVII24",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII25.html",
+   "repoPath": "view/euclid-html/bookvii/propVII25.html",
+   "name": "propVII25",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII26.html",
+   "repoPath": "view/euclid-html/bookvii/propVII26.html",
+   "name": "propVII26",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII27.html",
+   "repoPath": "view/euclid-html/bookvii/propVII27.html",
+   "name": "propVII27",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII28.html",
+   "repoPath": "view/euclid-html/bookvii/propVII28.html",
+   "name": "propVII28",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII29.html",
+   "repoPath": "view/euclid-html/bookvii/propVII29.html",
+   "name": "propVII29",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII3.html",
+   "repoPath": "view/euclid-html/bookvii/propVII3.html",
+   "name": "propVII3",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII30.html",
+   "repoPath": "view/euclid-html/bookvii/propVII30.html",
+   "name": "propVII30",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII31.html",
+   "repoPath": "view/euclid-html/bookvii/propVII31.html",
+   "name": "propVII31",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII32.html",
+   "repoPath": "view/euclid-html/bookvii/propVII32.html",
+   "name": "propVII32",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII33.html",
+   "repoPath": "view/euclid-html/bookvii/propVII33.html",
+   "name": "propVII33",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII34.html",
+   "repoPath": "view/euclid-html/bookvii/propVII34.html",
+   "name": "propVII34",
+   "category": "euclid/bookVII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII35.html",
+   "repoPath": "view/euclid-html/bookvii/propVII35.html",
+   "name": "propVII35",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII36.html",
+   "repoPath": "view/euclid-html/bookvii/propVII36.html",
+   "name": "propVII36",
+   "category": "euclid/bookVII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII37.html",
+   "repoPath": "view/euclid-html/bookvii/propVII37.html",
+   "name": "propVII37",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII38.html",
+   "repoPath": "view/euclid-html/bookvii/propVII38.html",
+   "name": "propVII38",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII39.html",
+   "repoPath": "view/euclid-html/bookvii/propVII39.html",
+   "name": "propVII39",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII4.html",
+   "repoPath": "view/euclid-html/bookvii/propVII4.html",
+   "name": "propVII4",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII5.html",
+   "repoPath": "view/euclid-html/bookvii/propVII5.html",
+   "name": "propVII5",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII6.html",
+   "repoPath": "view/euclid-html/bookvii/propVII6.html",
+   "name": "propVII6",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII7.html",
+   "repoPath": "view/euclid-html/bookvii/propVII7.html",
+   "name": "propVII7",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII8.html",
+   "repoPath": "view/euclid-html/bookvii/propVII8.html",
+   "name": "propVII8",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookvii/propVII9.html",
+   "repoPath": "view/euclid-html/bookvii/propVII9.html",
+   "name": "propVII9",
+   "category": "euclid/bookVII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII1.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII1.html",
+   "name": "propVIII1",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII10.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII10.html",
+   "name": "propVIII10",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII11.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII11.html",
+   "name": "propVIII11",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII12.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII12.html",
+   "name": "propVIII12",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII13.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII13.html",
+   "name": "propVIII13",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII14.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII14.html",
+   "name": "propVIII14",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII15.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII15.html",
+   "name": "propVIII15",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII16.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII16.html",
+   "name": "propVIII16",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII17.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII17.html",
+   "name": "propVIII17",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII18.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII18.html",
+   "name": "propVIII18",
+   "category": "euclid/bookVIII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII19.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII19.html",
+   "name": "propVIII19",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII2.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII2.html",
+   "name": "propVIII2",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII20.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII20.html",
+   "name": "propVIII20",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII21.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII21.html",
+   "name": "propVIII21",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII22.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII22.html",
+   "name": "propVIII22",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII23.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII23.html",
+   "name": "propVIII23",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII24.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII24.html",
+   "name": "propVIII24",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII25.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII25.html",
+   "name": "propVIII25",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII26.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII26.html",
+   "name": "propVIII26",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII27.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII27.html",
+   "name": "propVIII27",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII3.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII3.html",
+   "name": "propVIII3",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII4.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII4.html",
+   "name": "propVIII4",
+   "category": "euclid/bookVIII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII5.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII5.html",
+   "name": "propVIII5",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII6.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII6.html",
+   "name": "propVIII6",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII7.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII7.html",
+   "name": "propVIII7",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII8.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII8.html",
+   "name": "propVIII8",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookviii/propVIII9.html",
+   "repoPath": "view/euclid-html/bookviii/propVIII9.html",
+   "name": "propVIII9",
+   "category": "euclid/bookVIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX1.html",
+   "repoPath": "view/euclid-html/bookx/propX1.html",
+   "name": "propX1",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX10.html",
+   "repoPath": "view/euclid-html/bookx/propX10.html",
+   "name": "propX10",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX100.html",
+   "repoPath": "view/euclid-html/bookx/propX100.html",
+   "name": "propX100",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX101.html",
+   "repoPath": "view/euclid-html/bookx/propX101.html",
+   "name": "propX101",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX102.html",
+   "repoPath": "view/euclid-html/bookx/propX102.html",
+   "name": "propX102",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX103.html",
+   "repoPath": "view/euclid-html/bookx/propX103.html",
+   "name": "propX103",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX104.html",
+   "repoPath": "view/euclid-html/bookx/propX104.html",
+   "name": "propX104",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX105.html",
+   "repoPath": "view/euclid-html/bookx/propX105.html",
+   "name": "propX105",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX106.html",
+   "repoPath": "view/euclid-html/bookx/propX106.html",
+   "name": "propX106",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX107.html",
+   "repoPath": "view/euclid-html/bookx/propX107.html",
+   "name": "propX107",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX108.html",
+   "repoPath": "view/euclid-html/bookx/propX108.html",
+   "name": "propX108",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX109.html",
+   "repoPath": "view/euclid-html/bookx/propX109.html",
+   "name": "propX109",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX11.html",
+   "repoPath": "view/euclid-html/bookx/propX11.html",
+   "name": "propX11",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX110.html",
+   "repoPath": "view/euclid-html/bookx/propX110.html",
+   "name": "propX110",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX111.html",
+   "repoPath": "view/euclid-html/bookx/propX111.html",
+   "name": "propX111",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX112.html",
+   "repoPath": "view/euclid-html/bookx/propX112.html",
+   "name": "propX112",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX113.html",
+   "repoPath": "view/euclid-html/bookx/propX113.html",
+   "name": "propX113",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX114.html",
+   "repoPath": "view/euclid-html/bookx/propX114.html",
+   "name": "propX114",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX115.html",
+   "repoPath": "view/euclid-html/bookx/propX115.html",
+   "name": "propX115",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX12.html",
+   "repoPath": "view/euclid-html/bookx/propX12.html",
+   "name": "propX12",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX13.html",
+   "repoPath": "view/euclid-html/bookx/propX13.html",
+   "name": "propX13",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX14.html",
+   "repoPath": "view/euclid-html/bookx/propX14.html",
+   "name": "propX14",
+   "category": "euclid/bookX",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX15.html",
+   "repoPath": "view/euclid-html/bookx/propX15.html",
+   "name": "propX15",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX16.html",
+   "repoPath": "view/euclid-html/bookx/propX16.html",
+   "name": "propX16",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX17.html",
+   "repoPath": "view/euclid-html/bookx/propX17.html",
+   "name": "propX17",
+   "category": "euclid/bookX",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX18.html",
+   "repoPath": "view/euclid-html/bookx/propX18.html",
+   "name": "propX18",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX19.html",
+   "repoPath": "view/euclid-html/bookx/propX19.html",
+   "name": "propX19",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX2.html",
+   "repoPath": "view/euclid-html/bookx/propX2.html",
+   "name": "propX2",
+   "category": "euclid/bookX",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX20.html",
+   "repoPath": "view/euclid-html/bookx/propX20.html",
+   "name": "propX20",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX21.html",
+   "repoPath": "view/euclid-html/bookx/propX21.html",
+   "name": "propX21",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX22.html",
+   "repoPath": "view/euclid-html/bookx/propX22.html",
+   "name": "propX22",
+   "category": "euclid/bookX",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX23.html",
+   "repoPath": "view/euclid-html/bookx/propX23.html",
+   "name": "propX23",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX24.html",
+   "repoPath": "view/euclid-html/bookx/propX24.html",
+   "name": "propX24",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX25.html",
+   "repoPath": "view/euclid-html/bookx/propX25.html",
+   "name": "propX25",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX26.html",
+   "repoPath": "view/euclid-html/bookx/propX26.html",
+   "name": "propX26",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX27.html",
+   "repoPath": "view/euclid-html/bookx/propX27.html",
+   "name": "propX27",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX28.html",
+   "repoPath": "view/euclid-html/bookx/propX28.html",
+   "name": "propX28",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX29.html",
+   "repoPath": "view/euclid-html/bookx/propX29.html",
+   "name": "propX29",
+   "category": "euclid/bookX",
+   "applets": 3,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX3.html",
+   "repoPath": "view/euclid-html/bookx/propX3.html",
+   "name": "propX3",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX30.html",
+   "repoPath": "view/euclid-html/bookx/propX30.html",
+   "name": "propX30",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX31.html",
+   "repoPath": "view/euclid-html/bookx/propX31.html",
+   "name": "propX31",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX32.html",
+   "repoPath": "view/euclid-html/bookx/propX32.html",
+   "name": "propX32",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX33.html",
+   "repoPath": "view/euclid-html/bookx/propX33.html",
+   "name": "propX33",
+   "category": "euclid/bookX",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX34.html",
+   "repoPath": "view/euclid-html/bookx/propX34.html",
+   "name": "propX34",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX35.html",
+   "repoPath": "view/euclid-html/bookx/propX35.html",
+   "name": "propX35",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX36.html",
+   "repoPath": "view/euclid-html/bookx/propX36.html",
+   "name": "propX36",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX37.html",
+   "repoPath": "view/euclid-html/bookx/propX37.html",
+   "name": "propX37",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX38.html",
+   "repoPath": "view/euclid-html/bookx/propX38.html",
+   "name": "propX38",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX39.html",
+   "repoPath": "view/euclid-html/bookx/propX39.html",
+   "name": "propX39",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX4.html",
+   "repoPath": "view/euclid-html/bookx/propX4.html",
+   "name": "propX4",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX40.html",
+   "repoPath": "view/euclid-html/bookx/propX40.html",
+   "name": "propX40",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX41.html",
+   "repoPath": "view/euclid-html/bookx/propX41.html",
+   "name": "propX41",
+   "category": "euclid/bookX",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX42.html",
+   "repoPath": "view/euclid-html/bookx/propX42.html",
+   "name": "propX42",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX43.html",
+   "repoPath": "view/euclid-html/bookx/propX43.html",
+   "name": "propX43",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX44.html",
+   "repoPath": "view/euclid-html/bookx/propX44.html",
+   "name": "propX44",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX45.html",
+   "repoPath": "view/euclid-html/bookx/propX45.html",
+   "name": "propX45",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX46.html",
+   "repoPath": "view/euclid-html/bookx/propX46.html",
+   "name": "propX46",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX47.html",
+   "repoPath": "view/euclid-html/bookx/propX47.html",
+   "name": "propX47",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX48.html",
+   "repoPath": "view/euclid-html/bookx/propX48.html",
+   "name": "propX48",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX49.html",
+   "repoPath": "view/euclid-html/bookx/propX49.html",
+   "name": "propX49",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX5.html",
+   "repoPath": "view/euclid-html/bookx/propX5.html",
+   "name": "propX5",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX50.html",
+   "repoPath": "view/euclid-html/bookx/propX50.html",
+   "name": "propX50",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX51.html",
+   "repoPath": "view/euclid-html/bookx/propX51.html",
+   "name": "propX51",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX52.html",
+   "repoPath": "view/euclid-html/bookx/propX52.html",
+   "name": "propX52",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX53.html",
+   "repoPath": "view/euclid-html/bookx/propX53.html",
+   "name": "propX53",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX54.html",
+   "repoPath": "view/euclid-html/bookx/propX54.html",
+   "name": "propX54",
+   "category": "euclid/bookX",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX55.html",
+   "repoPath": "view/euclid-html/bookx/propX55.html",
+   "name": "propX55",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX56.html",
+   "repoPath": "view/euclid-html/bookx/propX56.html",
+   "name": "propX56",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX57.html",
+   "repoPath": "view/euclid-html/bookx/propX57.html",
+   "name": "propX57",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX58.html",
+   "repoPath": "view/euclid-html/bookx/propX58.html",
+   "name": "propX58",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX59.html",
+   "repoPath": "view/euclid-html/bookx/propX59.html",
+   "name": "propX59",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX6.html",
+   "repoPath": "view/euclid-html/bookx/propX6.html",
+   "name": "propX6",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX60.html",
+   "repoPath": "view/euclid-html/bookx/propX60.html",
+   "name": "propX60",
+   "category": "euclid/bookX",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX61.html",
+   "repoPath": "view/euclid-html/bookx/propX61.html",
+   "name": "propX61",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX62.html",
+   "repoPath": "view/euclid-html/bookx/propX62.html",
+   "name": "propX62",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX63.html",
+   "repoPath": "view/euclid-html/bookx/propX63.html",
+   "name": "propX63",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX64.html",
+   "repoPath": "view/euclid-html/bookx/propX64.html",
+   "name": "propX64",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX65.html",
+   "repoPath": "view/euclid-html/bookx/propX65.html",
+   "name": "propX65",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX66.html",
+   "repoPath": "view/euclid-html/bookx/propX66.html",
+   "name": "propX66",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX67.html",
+   "repoPath": "view/euclid-html/bookx/propX67.html",
+   "name": "propX67",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX68.html",
+   "repoPath": "view/euclid-html/bookx/propX68.html",
+   "name": "propX68",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX69.html",
+   "repoPath": "view/euclid-html/bookx/propX69.html",
+   "name": "propX69",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX7.html",
+   "repoPath": "view/euclid-html/bookx/propX7.html",
+   "name": "propX7",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX70.html",
+   "repoPath": "view/euclid-html/bookx/propX70.html",
+   "name": "propX70",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX71.html",
+   "repoPath": "view/euclid-html/bookx/propX71.html",
+   "name": "propX71",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX72.html",
+   "repoPath": "view/euclid-html/bookx/propX72.html",
+   "name": "propX72",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX73.html",
+   "repoPath": "view/euclid-html/bookx/propX73.html",
+   "name": "propX73",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX74.html",
+   "repoPath": "view/euclid-html/bookx/propX74.html",
+   "name": "propX74",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX75.html",
+   "repoPath": "view/euclid-html/bookx/propX75.html",
+   "name": "propX75",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX76.html",
+   "repoPath": "view/euclid-html/bookx/propX76.html",
+   "name": "propX76",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX77.html",
+   "repoPath": "view/euclid-html/bookx/propX77.html",
+   "name": "propX77",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX78.html",
+   "repoPath": "view/euclid-html/bookx/propX78.html",
+   "name": "propX78",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX79.html",
+   "repoPath": "view/euclid-html/bookx/propX79.html",
+   "name": "propX79",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX8.html",
+   "repoPath": "view/euclid-html/bookx/propX8.html",
+   "name": "propX8",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX80.html",
+   "repoPath": "view/euclid-html/bookx/propX80.html",
+   "name": "propX80",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX81.html",
+   "repoPath": "view/euclid-html/bookx/propX81.html",
+   "name": "propX81",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX82.html",
+   "repoPath": "view/euclid-html/bookx/propX82.html",
+   "name": "propX82",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX83.html",
+   "repoPath": "view/euclid-html/bookx/propX83.html",
+   "name": "propX83",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX84.html",
+   "repoPath": "view/euclid-html/bookx/propX84.html",
+   "name": "propX84",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX85.html",
+   "repoPath": "view/euclid-html/bookx/propX85.html",
+   "name": "propX85",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX86.html",
+   "repoPath": "view/euclid-html/bookx/propX86.html",
+   "name": "propX86",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX87.html",
+   "repoPath": "view/euclid-html/bookx/propX87.html",
+   "name": "propX87",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX88.html",
+   "repoPath": "view/euclid-html/bookx/propX88.html",
+   "name": "propX88",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX89.html",
+   "repoPath": "view/euclid-html/bookx/propX89.html",
+   "name": "propX89",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX9.html",
+   "repoPath": "view/euclid-html/bookx/propX9.html",
+   "name": "propX9",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX90.html",
+   "repoPath": "view/euclid-html/bookx/propX90.html",
+   "name": "propX90",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX91.html",
+   "repoPath": "view/euclid-html/bookx/propX91.html",
+   "name": "propX91",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX92.html",
+   "repoPath": "view/euclid-html/bookx/propX92.html",
+   "name": "propX92",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX93.html",
+   "repoPath": "view/euclid-html/bookx/propX93.html",
+   "name": "propX93",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX94.html",
+   "repoPath": "view/euclid-html/bookx/propX94.html",
+   "name": "propX94",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX95.html",
+   "repoPath": "view/euclid-html/bookx/propX95.html",
+   "name": "propX95",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX96.html",
+   "repoPath": "view/euclid-html/bookx/propX96.html",
+   "name": "propX96",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX97.html",
+   "repoPath": "view/euclid-html/bookx/propX97.html",
+   "name": "propX97",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX98.html",
+   "repoPath": "view/euclid-html/bookx/propX98.html",
+   "name": "propX98",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookx/propX99.html",
+   "repoPath": "view/euclid-html/bookx/propX99.html",
+   "name": "propX99",
+   "category": "euclid/bookX",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/defXI11.html",
+   "repoPath": "view/euclid-html/bookxi/defXI11.html",
+   "name": "defXI11",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/defXI12.html",
+   "repoPath": "view/euclid-html/bookxi/defXI12.html",
+   "name": "defXI12",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/defXI14.html",
+   "repoPath": "view/euclid-html/bookxi/defXI14.html",
+   "name": "defXI14",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/defXI18.html",
+   "repoPath": "view/euclid-html/bookxi/defXI18.html",
+   "name": "defXI18",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/defXI21.html",
+   "repoPath": "view/euclid-html/bookxi/defXI21.html",
+   "name": "defXI21",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/defXI24.html",
+   "repoPath": "view/euclid-html/bookxi/defXI24.html",
+   "name": "defXI24",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/defXI9.html",
+   "repoPath": "view/euclid-html/bookxi/defXI9.html",
+   "name": "defXI9",
+   "category": "euclid/bookXI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI1.html",
+   "repoPath": "view/euclid-html/bookxi/propXI1.html",
+   "name": "propXI1",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI10.html",
+   "repoPath": "view/euclid-html/bookxi/propXI10.html",
+   "name": "propXI10",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI11.html",
+   "repoPath": "view/euclid-html/bookxi/propXI11.html",
+   "name": "propXI11",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI12.html",
+   "repoPath": "view/euclid-html/bookxi/propXI12.html",
+   "name": "propXI12",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI13.html",
+   "repoPath": "view/euclid-html/bookxi/propXI13.html",
+   "name": "propXI13",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI14.html",
+   "repoPath": "view/euclid-html/bookxi/propXI14.html",
+   "name": "propXI14",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI15.html",
+   "repoPath": "view/euclid-html/bookxi/propXI15.html",
+   "name": "propXI15",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI16.html",
+   "repoPath": "view/euclid-html/bookxi/propXI16.html",
+   "name": "propXI16",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI17.html",
+   "repoPath": "view/euclid-html/bookxi/propXI17.html",
+   "name": "propXI17",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI18.html",
+   "repoPath": "view/euclid-html/bookxi/propXI18.html",
+   "name": "propXI18",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI19.html",
+   "repoPath": "view/euclid-html/bookxi/propXI19.html",
+   "name": "propXI19",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI2.html",
+   "repoPath": "view/euclid-html/bookxi/propXI2.html",
+   "name": "propXI2",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI20.html",
+   "repoPath": "view/euclid-html/bookxi/propXI20.html",
+   "name": "propXI20",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI21.html",
+   "repoPath": "view/euclid-html/bookxi/propXI21.html",
+   "name": "propXI21",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI22.html",
+   "repoPath": "view/euclid-html/bookxi/propXI22.html",
+   "name": "propXI22",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI23.html",
+   "repoPath": "view/euclid-html/bookxi/propXI23.html",
+   "name": "propXI23",
+   "category": "euclid/bookXI",
+   "applets": 4,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI24.html",
+   "repoPath": "view/euclid-html/bookxi/propXI24.html",
+   "name": "propXI24",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI25.html",
+   "repoPath": "view/euclid-html/bookxi/propXI25.html",
+   "name": "propXI25",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI26.html",
+   "repoPath": "view/euclid-html/bookxi/propXI26.html",
+   "name": "propXI26",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI27.html",
+   "repoPath": "view/euclid-html/bookxi/propXI27.html",
+   "name": "propXI27",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI28.html",
+   "repoPath": "view/euclid-html/bookxi/propXI28.html",
+   "name": "propXI28",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI29.html",
+   "repoPath": "view/euclid-html/bookxi/propXI29.html",
+   "name": "propXI29",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI3.html",
+   "repoPath": "view/euclid-html/bookxi/propXI3.html",
+   "name": "propXI3",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI30.html",
+   "repoPath": "view/euclid-html/bookxi/propXI30.html",
+   "name": "propXI30",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI31.html",
+   "repoPath": "view/euclid-html/bookxi/propXI31.html",
+   "name": "propXI31",
+   "category": "euclid/bookXI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI32.html",
+   "repoPath": "view/euclid-html/bookxi/propXI32.html",
+   "name": "propXI32",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI33.html",
+   "repoPath": "view/euclid-html/bookxi/propXI33.html",
+   "name": "propXI33",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI34.html",
+   "repoPath": "view/euclid-html/bookxi/propXI34.html",
+   "name": "propXI34",
+   "category": "euclid/bookXI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI35.html",
+   "repoPath": "view/euclid-html/bookxi/propXI35.html",
+   "name": "propXI35",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI36.html",
+   "repoPath": "view/euclid-html/bookxi/propXI36.html",
+   "name": "propXI36",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI37.html",
+   "repoPath": "view/euclid-html/bookxi/propXI37.html",
+   "name": "propXI37",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI38.html",
+   "repoPath": "view/euclid-html/bookxi/propXI38.html",
+   "name": "propXI38",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI39.html",
+   "repoPath": "view/euclid-html/bookxi/propXI39.html",
+   "name": "propXI39",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI4.html",
+   "repoPath": "view/euclid-html/bookxi/propXI4.html",
+   "name": "propXI4",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI5.html",
+   "repoPath": "view/euclid-html/bookxi/propXI5.html",
+   "name": "propXI5",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI6.html",
+   "repoPath": "view/euclid-html/bookxi/propXI6.html",
+   "name": "propXI6",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI7.html",
+   "repoPath": "view/euclid-html/bookxi/propXI7.html",
+   "name": "propXI7",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI8.html",
+   "repoPath": "view/euclid-html/bookxi/propXI8.html",
+   "name": "propXI8",
+   "category": "euclid/bookXI",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxi/propXI9.html",
+   "repoPath": "view/euclid-html/bookxi/propXI9.html",
+   "name": "propXI9",
+   "category": "euclid/bookXI",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII1.html",
+   "repoPath": "view/euclid-html/bookxii/propXII1.html",
+   "name": "propXII1",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII10.html",
+   "repoPath": "view/euclid-html/bookxii/propXII10.html",
+   "name": "propXII10",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII11.html",
+   "repoPath": "view/euclid-html/bookxii/propXII11.html",
+   "name": "propXII11",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII12.html",
+   "repoPath": "view/euclid-html/bookxii/propXII12.html",
+   "name": "propXII12",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII13.html",
+   "repoPath": "view/euclid-html/bookxii/propXII13.html",
+   "name": "propXII13",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII14.html",
+   "repoPath": "view/euclid-html/bookxii/propXII14.html",
+   "name": "propXII14",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII15.html",
+   "repoPath": "view/euclid-html/bookxii/propXII15.html",
+   "name": "propXII15",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII16.html",
+   "repoPath": "view/euclid-html/bookxii/propXII16.html",
+   "name": "propXII16",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII17.html",
+   "repoPath": "view/euclid-html/bookxii/propXII17.html",
+   "name": "propXII17",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII18.html",
+   "repoPath": "view/euclid-html/bookxii/propXII18.html",
+   "name": "propXII18",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII2.html",
+   "repoPath": "view/euclid-html/bookxii/propXII2.html",
+   "name": "propXII2",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII3.html",
+   "repoPath": "view/euclid-html/bookxii/propXII3.html",
+   "name": "propXII3",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII4.html",
+   "repoPath": "view/euclid-html/bookxii/propXII4.html",
+   "name": "propXII4",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII5.html",
+   "repoPath": "view/euclid-html/bookxii/propXII5.html",
+   "name": "propXII5",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII6.html",
+   "repoPath": "view/euclid-html/bookxii/propXII6.html",
+   "name": "propXII6",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII7.html",
+   "repoPath": "view/euclid-html/bookxii/propXII7.html",
+   "name": "propXII7",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII8.html",
+   "repoPath": "view/euclid-html/bookxii/propXII8.html",
+   "name": "propXII8",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxii/propXII9.html",
+   "repoPath": "view/euclid-html/bookxii/propXII9.html",
+   "name": "propXII9",
+   "category": "euclid/bookXII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII1.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII1.html",
+   "name": "propXIII1",
+   "category": "euclid/bookXIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII10.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII10.html",
+   "name": "propXIII10",
+   "category": "euclid/bookXIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII11.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII11.html",
+   "name": "propXIII11",
+   "category": "euclid/bookXIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII12.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII12.html",
+   "name": "propXIII12",
+   "category": "euclid/bookXIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII13.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII13.html",
+   "name": "propXIII13",
+   "category": "euclid/bookXIII",
+   "applets": 3,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII14.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII14.html",
+   "name": "propXIII14",
+   "category": "euclid/bookXIII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII15.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII15.html",
+   "name": "propXIII15",
+   "category": "euclid/bookXIII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII16.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII16.html",
+   "name": "propXIII16",
+   "category": "euclid/bookXIII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII17.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII17.html",
+   "name": "propXIII17",
+   "category": "euclid/bookXIII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII18.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII18.html",
+   "name": "propXIII18",
+   "category": "euclid/bookXIII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII2.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII2.html",
+   "name": "propXIII2",
+   "category": "euclid/bookXIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII3.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII3.html",
+   "name": "propXIII3",
+   "category": "euclid/bookXIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII4.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII4.html",
+   "name": "propXIII4",
+   "category": "euclid/bookXIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII5.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII5.html",
+   "name": "propXIII5",
+   "category": "euclid/bookXIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII6.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII6.html",
+   "name": "propXIII6",
+   "category": "euclid/bookXIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII7.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII7.html",
+   "name": "propXIII7",
+   "category": "euclid/bookXIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII8.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII8.html",
+   "name": "propXIII8",
+   "category": "euclid/bookXIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/propXIII9.html",
+   "repoPath": "view/euclid-html/bookxiii/propXIII9.html",
+   "name": "propXIII9",
+   "category": "euclid/bookXIII",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../euclid-html/bookxiii/temp.html",
+   "repoPath": "view/euclid-html/bookxiii/temp.html",
+   "name": "temp",
+   "category": "euclid/bookXIII",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/a.html",
+   "repoPath": "view/round_geometry/a.html",
+   "name": "a",
+   "category": "round",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/b.html",
+   "repoPath": "view/round_geometry/b.html",
+   "name": "b",
+   "category": "round",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/compass.html",
+   "repoPath": "view/round_geometry/compass.html",
+   "name": "compass",
+   "category": "round",
+   "applets": 5,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/conway.html",
+   "repoPath": "view/round_geometry/conway.html",
+   "name": "conway",
+   "category": "round",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/decagon.html",
+   "repoPath": "view/round_geometry/decagon.html",
+   "name": "decagon",
+   "category": "round",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/desargues.html",
+   "repoPath": "view/round_geometry/desargues.html",
+   "name": "desargues",
+   "category": "round",
+   "applets": 4,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/harmonic.html",
+   "repoPath": "view/round_geometry/harmonic.html",
+   "name": "harmonic",
+   "category": "round",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/menelaus.html",
+   "repoPath": "view/round_geometry/menelaus.html",
+   "name": "menelaus",
+   "category": "round",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/pappus.html",
+   "repoPath": "view/round_geometry/pappus.html",
+   "name": "pappus",
+   "category": "round",
+   "applets": 4,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/ptolemy.html",
+   "repoPath": "view/round_geometry/ptolemy.html",
+   "name": "ptolemy",
+   "category": "round",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/round1.html",
+   "repoPath": "view/round_geometry/round1.html",
+   "name": "round1",
+   "category": "round",
+   "applets": 4,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/round2.html",
+   "repoPath": "view/round_geometry/round2.html",
+   "name": "round2",
+   "category": "round",
+   "applets": 3,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/round2x.html",
+   "repoPath": "view/round_geometry/round2x.html",
+   "name": "round2x",
+   "category": "round",
+   "applets": 3,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/round3.html",
+   "repoPath": "view/round_geometry/round3.html",
+   "name": "round3",
+   "category": "round",
+   "applets": 3,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/round4.html",
+   "repoPath": "view/round_geometry/round4.html",
+   "name": "round4",
+   "category": "round",
+   "applets": 3,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/round6.html",
+   "repoPath": "view/round_geometry/round6.html",
+   "name": "round6",
+   "category": "round",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/seventen.html",
+   "repoPath": "view/round_geometry/seventen.html",
+   "name": "seventen",
+   "category": "round",
+   "applets": 2,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/sixeight.html",
+   "repoPath": "view/round_geometry/sixeight.html",
+   "name": "sixeight",
+   "category": "round",
+   "applets": 5,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/test.html",
+   "repoPath": "view/round_geometry/test.html",
+   "name": "test",
+   "category": "round",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/test1.html",
+   "repoPath": "view/round_geometry/test1.html",
+   "name": "test1",
+   "category": "round",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/test2.html",
+   "repoPath": "view/round_geometry/test2.html",
+   "name": "test2",
+   "category": "round",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/test3.html",
+   "repoPath": "view/round_geometry/test3.html",
+   "name": "test3",
+   "category": "round",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/testa.html",
+   "repoPath": "view/round_geometry/testa.html",
+   "name": "testa",
+   "category": "round",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/testb.html",
+   "repoPath": "view/round_geometry/testb.html",
+   "name": "testb",
+   "category": "round",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../round_geometry/twelvetwenty.html",
+   "repoPath": "view/round_geometry/twelvetwenty.html",
+   "name": "twelvetwenty",
+   "category": "round",
+   "applets": 1,
+   "inits": 0
+  },
+  {
+   "path": "../test/archive-viewer.html",
+   "repoPath": "view/test/archive-viewer.html",
+   "name": "archive-viewer",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/caption-phrase-ref.html",
+   "repoPath": "view/test/caption-phrase-ref.html",
+   "name": "caption-phrase-ref",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/circle/circle.html",
+   "repoPath": "view/test/circle/circle.html",
+   "name": "circle",
+   "category": "test/circle",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/circle/circumcircle.html",
+   "repoPath": "view/test/circle/circumcircle.html",
+   "name": "circumcircle",
+   "category": "test/circle",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/circle/intersection.html",
+   "repoPath": "view/test/circle/intersection.html",
+   "name": "intersection",
+   "category": "test/circle",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/circle/radius3pt.html",
+   "repoPath": "view/test/circle/radius3pt.html",
+   "name": "radius3pt",
+   "category": "test/circle",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/circumcenter_lineperp.html",
+   "repoPath": "view/test/circumcenter_lineperp.html",
+   "name": "circumcenter_lineperp",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/color-swatches.html",
+   "repoPath": "view/test/color-swatches.html",
+   "name": "color-swatches",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/cross-canvas-highlight.html",
+   "repoPath": "view/test/cross-canvas-highlight.html",
+   "name": "cross-canvas-highlight",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/curved-triangle.html",
+   "repoPath": "view/test/curved-triangle.html",
+   "name": "curved-triangle",
+   "category": "test",
+   "applets": 0,
+   "inits": 2
+  },
+  {
+   "path": "../test/deferred-point-reveal.html",
+   "repoPath": "view/test/deferred-point-reveal.html",
+   "name": "deferred-point-reveal",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/diagnostics-badge.html",
+   "repoPath": "view/test/diagnostics-badge.html",
+   "name": "diagnostics-badge",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/escape-exit.html",
+   "repoPath": "view/test/escape-exit.html",
+   "name": "escape-exit",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/highlight-event.html",
+   "repoPath": "view/test/highlight-event.html",
+   "name": "highlight-event",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/highlight-on-top.html",
+   "repoPath": "view/test/highlight-on-top.html",
+   "name": "highlight-on-top",
+   "category": "test",
+   "applets": 0,
+   "inits": 2
+  },
+  {
+   "path": "../test/icosahedron.html",
+   "repoPath": "view/test/icosahedron.html",
+   "name": "icosahedron",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/init-failure/index.html",
+   "repoPath": "view/test/init-failure/index.html",
+   "name": "index",
+   "category": "test/init-failure",
+   "applets": 0,
+   "inits": 7
+  },
+  {
+   "path": "../test/just-claim.html",
+   "repoPath": "view/test/just-claim.html",
+   "name": "just-claim",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/line/angleBisector.html",
+   "repoPath": "view/test/line/angleBisector.html",
+   "name": "angleBisector",
+   "category": "test/line",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/line/bichord.html",
+   "repoPath": "view/test/line/bichord.html",
+   "name": "bichord",
+   "category": "test/line",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/line/chord.html",
+   "repoPath": "view/test/line/chord.html",
+   "name": "chord",
+   "category": "test/line",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/line/cutoff.html",
+   "repoPath": "view/test/line/cutoff.html",
+   "name": "cutoff",
+   "category": "test/line",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/line/foot.html",
+   "repoPath": "view/test/line/foot.html",
+   "name": "foot",
+   "category": "test/line",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/line/parallel.html",
+   "repoPath": "view/test/line/parallel.html",
+   "name": "parallel",
+   "category": "test/line",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/line/perpendicular.html",
+   "repoPath": "view/test/line/perpendicular.html",
+   "name": "perpendicular",
+   "category": "test/line",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/line/planeFoot.html",
+   "repoPath": "view/test/line/planeFoot.html",
+   "name": "planeFoot",
+   "category": "test/line",
+   "applets": 1,
+   "inits": 1
+  },
+  {
+   "path": "../test/line/similar.html",
+   "repoPath": "view/test/line/similar.html",
+   "name": "similar",
+   "category": "test/line",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/mobile-3d.html",
+   "repoPath": "view/test/mobile-3d.html",
+   "name": "mobile-3d",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/mobile-scaling.html",
+   "repoPath": "view/test/mobile-scaling.html",
+   "name": "mobile-scaling",
+   "category": "test",
+   "applets": 0,
+   "inits": 2
+  },
+  {
+   "path": "../test/open-path.html",
+   "repoPath": "view/test/open-path.html",
+   "name": "open-path",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/plane/3points.html",
+   "repoPath": "view/test/plane/3points.html",
+   "name": "3points",
+   "category": "test/plane",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/plane/parallel.html",
+   "repoPath": "view/test/plane/parallel.html",
+   "name": "parallel",
+   "category": "test/plane",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/point/foot.html",
+   "repoPath": "view/test/point/foot.html",
+   "name": "foot",
+   "category": "test/point",
+   "applets": 1,
+   "inits": 1
+  },
+  {
+   "path": "../test/point/harmonic.html",
+   "repoPath": "view/test/point/harmonic.html",
+   "name": "harmonic",
+   "category": "test/point",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/point/intersection.html",
+   "repoPath": "view/test/point/intersection.html",
+   "name": "intersection",
+   "category": "test/point",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/point/invert.html",
+   "repoPath": "view/test/point/invert.html",
+   "name": "invert",
+   "category": "test/point",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/point/meanProportional.html",
+   "repoPath": "view/test/point/meanProportional.html",
+   "name": "meanProportional",
+   "category": "test/point",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/point/parallelogram.html",
+   "repoPath": "view/test/point/parallelogram.html",
+   "name": "parallelogram",
+   "category": "test/point",
+   "applets": 1,
+   "inits": 1
+  },
+  {
+   "path": "../test/point/pivot.html",
+   "repoPath": "view/test/point/pivot.html",
+   "name": "pivot",
+   "category": "test/point",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/point/planeFoot.html",
+   "repoPath": "view/test/point/planeFoot.html",
+   "name": "planeFoot",
+   "category": "test/point",
+   "applets": 1,
+   "inits": 1
+  },
+  {
+   "path": "../test/point/planeSlider.html",
+   "repoPath": "view/test/point/planeSlider.html",
+   "name": "planeSlider",
+   "category": "test/point",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/point/propI2-L-drag.html",
+   "repoPath": "view/test/point/propI2-L-drag.html",
+   "name": "propI2-L-drag",
+   "category": "test/point",
+   "applets": 1,
+   "inits": 1
+  },
+  {
+   "path": "../test/point/proportion.html",
+   "repoPath": "view/test/point/proportion.html",
+   "name": "proportion",
+   "category": "test/point",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/point/similar.html",
+   "repoPath": "view/test/point/similar.html",
+   "name": "similar",
+   "category": "test/point",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/point/sphereSlider.html",
+   "repoPath": "view/test/point/sphereSlider.html",
+   "name": "sphereSlider",
+   "category": "test/point",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/point/vertex.html",
+   "repoPath": "view/test/point/vertex.html",
+   "name": "vertex",
+   "category": "test/point",
+   "applets": 1,
+   "inits": 1
+  },
+  {
+   "path": "../test/poly/application.html",
+   "repoPath": "view/test/poly/application.html",
+   "name": "application",
+   "category": "test/poly",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/poly/equilateralTriangle.html",
+   "repoPath": "view/test/poly/equilateralTriangle.html",
+   "name": "equilateralTriangle",
+   "category": "test/poly",
+   "applets": 1,
+   "inits": 1
+  },
+  {
+   "path": "../test/poly/octagon.html",
+   "repoPath": "view/test/poly/octagon.html",
+   "name": "octagon",
+   "category": "test/poly",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/poly/parallelogram.html",
+   "repoPath": "view/test/poly/parallelogram.html",
+   "name": "parallelogram",
+   "category": "test/poly",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/poly/quadrilateral.html",
+   "repoPath": "view/test/poly/quadrilateral.html",
+   "name": "quadrilateral",
+   "category": "test/poly",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/poly/regularPolygon.html",
+   "repoPath": "view/test/poly/regularPolygon.html",
+   "name": "regularPolygon",
+   "category": "test/poly",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/poly/similar.html",
+   "repoPath": "view/test/poly/similar.html",
+   "name": "similar",
+   "category": "test/poly",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/poly/square.html",
+   "repoPath": "view/test/poly/square.html",
+   "name": "square",
+   "category": "test/poly",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/poly/triangle.html",
+   "repoPath": "view/test/poly/triangle.html",
+   "name": "triangle",
+   "category": "test/poly",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/polyhedron/prism.html",
+   "repoPath": "view/test/polyhedron/prism.html",
+   "name": "prism",
+   "category": "test/polyhedron",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/polyhedron/pyramid.html",
+   "repoPath": "view/test/polyhedron/pyramid.html",
+   "name": "pyramid",
+   "category": "test/polyhedron",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/present-centring-bounds.html",
+   "repoPath": "view/test/present-centring-bounds.html",
+   "name": "present-centring-bounds",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/propI23-transfer.html",
+   "repoPath": "view/test/propI23-transfer.html",
+   "name": "propI23-transfer",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/quad_line.html",
+   "repoPath": "view/test/quad_line.html",
+   "name": "quad_line",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/recenter-maximize.html",
+   "repoPath": "view/test/recenter-maximize.html",
+   "name": "recenter-maximize",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/sample_page/index.html",
+   "repoPath": "view/test/sample_page/index.html",
+   "name": "index",
+   "category": "test/sample_page",
+   "applets": 0,
+   "inits": 2
+  },
+  {
+   "path": "../test/sector/angle-marker.html",
+   "repoPath": "view/test/sector/angle-marker.html",
+   "name": "angle-marker",
+   "category": "test/sector",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/sector/arc.html",
+   "repoPath": "view/test/sector/arc.html",
+   "name": "arc",
+   "category": "test/sector",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/sector/sector.html",
+   "repoPath": "view/test/sector/sector.html",
+   "name": "sector",
+   "category": "test/sector",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/slide-to-point.html",
+   "repoPath": "view/test/slide-to-point.html",
+   "name": "slide-to-point",
+   "category": "test",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/slideshow/autoplace-probe.html",
+   "repoPath": "view/test/slideshow/autoplace-probe.html",
+   "name": "autoplace-probe",
+   "category": "test/slideshow",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/slideshow/propI1.html",
+   "repoPath": "view/test/slideshow/propI1.html",
+   "name": "propI1",
+   "category": "test/slideshow",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/slideshow/translate-slide.html",
+   "repoPath": "view/test/slideshow/translate-slide.html",
+   "name": "translate-slide",
+   "category": "test/slideshow",
+   "applets": 0,
+   "inits": 1
+  },
+  {
+   "path": "../test/transfer-animations.html",
+   "repoPath": "view/test/transfer-animations.html",
+   "name": "transfer-animations",
+   "category": "test",
+   "applets": 0,
+   "inits": 4
+  },
+  {
+   "path": "../test/two_canvas.html",
+   "repoPath": "view/test/two_canvas.html",
+   "name": "two_canvas",
+   "category": "test",
+   "applets": 0,
+   "inits": 2
+  }
+ ]
+}

--- a/view/test/archive-viewer.html
+++ b/view/test/archive-viewer.html
@@ -1,0 +1,374 @@
+<html>
+<head>
+<meta charset="utf-8">
+<title>Archive viewer — original applet pages, rendered by geomlib</title>
+<style>
+  body { font-family: sans-serif; margin: 0; color: #222; }
+  header { padding: 10px 16px; background: #f6f6f6; border-bottom: 1px solid #ddd;
+           position: sticky; top: 0; display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+  header input { font-family: ui-monospace, monospace; font-size: 13px; padding: 4px 6px;
+                 width: 42rem; max-width: 60vw; }
+  header button { padding: 4px 10px; }
+  .note { font-size: 12px; color: #666; padding: 6px 16px; background: #fffbe6;
+          border-bottom: 1px solid #f0e2a8; }
+  main { padding: 16px; max-width: 60rem; }
+  figure.applet { margin: 16px 0; }
+  figure.applet figcaption { font-size: 12px; color: #666; font-family: ui-monospace, monospace; }
+  .fail { background: #f8d7da; color: #721c24; padding: 8px 10px; border-radius: 4px;
+          font-family: ui-monospace, monospace; font-size: 12px; white-space: pre-wrap; }
+  #diag { font-family: ui-monospace, monospace; font-size: 12px; background: #f6f6f6;
+          padding: 10px; margin: 16px; white-space: pre-wrap; }
+  .panel { margin: 16px; padding: 12px; border: 1px solid #ddd; border-radius: 6px; }
+  .panel h3 { margin: 0 0 8px; font-size: 14px; }
+  .panel p.hint { margin: 0 0 8px; font-size: 12px; color: #666; }
+  textarea { width: 100%; height: 8rem; font-family: ui-monospace, monospace;
+             font-size: 12px; padding: 6px; box-sizing: border-box; }
+  ul.hits { list-style: none; padding: 0; margin: 10px 0 0; }
+  ul.hits li { padding: 6px 0; border-top: 1px solid #eee; }
+  ul.hits a { font-family: ui-monospace, monospace; font-size: 13px; }
+  ul.hits .msgs { font-family: ui-monospace, monospace; font-size: 11px; color: #666;
+                  margin: 4px 0 0 1rem; white-space: pre-wrap; }
+  .count { display: inline-block; background: #fff3cd; color: #7a5c00; font-weight: 600;
+           border-radius: 10px; padding: 0 7px; font-size: 11px; margin-left: 6px; }
+  .miss { color: #a33; font-size: 12px; }
+  #idxFilter { width: 22rem; font-family: ui-monospace, monospace; font-size: 13px; padding: 4px 6px; }
+  #idxList { max-height: 18rem; overflow-y: auto; margin-top: 8px; }
+  #idxList a { display: inline-block; font-family: ui-monospace, monospace; font-size: 12px; }
+  #idxList div { padding: 2px 0; }
+  #idxList .cat { color: #888; font-size: 11px; margin-left: 8px; }
+</style>
+</head>
+<body>
+
+<header>
+  <label for="path"><b>fixture</b></label>
+  <input id="path" value="../euclid-html/booki/defI20.html">
+  <button id="go">Load</button>
+  <span style="font-size:12px;color:#666">serve the repo root, e.g. <code>python3 -m http.server 8000</code>, then open this page</span>
+</header>
+
+<p class="note">
+These are Dr. Joyce's original 1996 pages, kept verbatim as snapshot-test input.
+They cannot load on their own in a modern browser for three separate reasons:
+<b>(1)</b> each figure is a Java <code>&lt;applet&gt;</code>;
+<b>(2)</b> <code>navigator.javaEnabled()</code> was removed from browsers, so the
+page's own <code>.gif</code> fallback never swaps in either;
+<b>(3)</b> <code>../elements.js</code> (Joyce's nav chrome) was never mirrored into
+this repo &mdash; only the HTML and its <code>.gif</code>s were, since that is all
+the snapshot parser needs.
+This viewer reads a page <i>without modifying it</i>, and rebuilds each applet as a
+geomlib canvas from that applet's own <code>&lt;param&gt;</code> tags.
+</p>
+
+<section class="panel">
+  <h3>Paste diagnostics &rarr; jump to the page</h3>
+  <p class="hint">Paste any <code>[geomlib]</code> output &mdash; a coverage run, a test
+  log, a browser console. Paths are pulled out, grouped, and turned into links that
+  load the fixture below. Absolute paths, repo-relative paths and bare filenames all
+  work; anything not in the index is listed so you know it was skipped.</p>
+  <textarea id="paste" placeholder="[geomlib] /path/to/view/euclid-html/booki/defI20.html: element 'A3' failed to construct: ..."></textarea>
+  <div style="margin-top:8px">
+    <button id="parse">Find pages</button>
+    <button id="clearPaste">Clear</button>
+  </div>
+  <ul class="hits" id="hits"></ul>
+</section>
+
+<section class="panel">
+  <h3>Index <span id="idxCount" style="font-weight:normal;color:#888;font-size:12px"></span></h3>
+  <p class="hint">Every fixture the snapshot suite discovers. Filter by name, book or
+  category &mdash; e.g. <code>propI4</code>, <code>bookiv</code>, <code>compass</code>.
+  Regenerate with <code>npm run archive:index</code> after adding fixtures.</p>
+  <input id="idxFilter" placeholder="filter...">
+  <div id="idxList"></div>
+</section>
+
+<main id="out"></main>
+<div id="diag"></div>
+
+<script src="../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+(function () {
+    var out = document.getElementById("out");
+    var diag = document.getElementById("diag");
+
+    // Joyce's param colours include the literal "random"; the snapshot parser
+    // substitutes a fixed palette so runs are deterministic. Same idea here so
+    // what you see matches what the goldens capture.
+    var PALETTE = ["200,70,90", "70,140,200", "90,170,90", "190,140,60",
+                   "150,90,180", "80,170,170"];
+    var paletteIdx = 0;
+    function substituteRandom(v) {
+        return v.replace(/random/g, function () {
+            return PALETTE[paletteIdx++ % PALETTE.length];
+        });
+    }
+
+    function appletParams(applet) {
+        // <param name=e[1] value="A;point;free;10,20">  (also plain eN)
+        var byIndex = [], meta = {};
+        var params = applet.getElementsByTagName("param");
+        for (var i = 0; i < params.length; i++) {
+            var name = (params[i].getAttribute("name") || "").trim();
+            var value = params[i].getAttribute("value");
+            if (value == null) continue;
+            var m = name.match(/^e\[?(\d+)\]?$/i);
+            if (m) byIndex.push([parseInt(m[1], 10), value]);
+            else meta[name.toLowerCase()] = value;
+        }
+        // Sort by the declared index, NOT document order — some pages are
+        // hand-numbered out of order, which is itself a real defect worth
+        // seeing (booki/propI4.html numbers 'a' as e[18] but references it
+        // from e[14], so 'a' is built after the elements that need it).
+        byIndex.sort(function (a, b) { return a[0] - b[0]; });
+        return { elements: byIndex.map(function (p) { return p[1]; }), meta: meta };
+    }
+
+    function render(html, base) {
+        out.innerHTML = "";
+        diag.textContent = "";
+        paletteIdx = 0;
+
+        var doc = new DOMParser().parseFromString(html, "text/html");
+        // Drop the page's own scripts: they call loadHeader()/loadFooter()
+        // from the un-mirrored elements.js, and navigator.javaEnabled().
+        var scripts = doc.getElementsByTagName("script");
+        while (scripts.length) scripts[0].parentNode.removeChild(scripts[0]);
+
+        // Rewrite relative image srcs so the .gif fallbacks still resolve.
+        var imgs = doc.getElementsByTagName("img");
+        for (var i = 0; i < imgs.length; i++) {
+            var src = imgs[i].getAttribute("src");
+            if (src && !/^(https?:)?\//.test(src)) imgs[i].setAttribute("src", base + src);
+        }
+
+        var applets = [].slice.call(doc.getElementsByTagName("applet"));
+        var specs = [];
+        applets.forEach(function (applet, n) {
+            var id = "arc_canvas_" + n;
+            var p = appletParams(applet);
+            var fig = doc.createElement("figure");
+            fig.className = "applet";
+            var cv = doc.createElement("canvas");
+            cv.id = id;
+            cv.setAttribute("tabindex", "0");
+            cv.style.width = (applet.getAttribute("width") || 400) + "px";
+            cv.style.height = (applet.getAttribute("height") || 300) + "px";
+            fig.appendChild(cv);
+            var cap = doc.createElement("figcaption");
+            cap.textContent = "applet " + (n + 1) + " — " + p.elements.length + " elements";
+            fig.appendChild(cap);
+            applet.parentNode.replaceChild(fig, applet);
+            specs.push({ id: id, p: p,
+                         w: parseInt(applet.getAttribute("width") || 400, 10),
+                         h: parseInt(applet.getAttribute("height") || 300, 10) });
+        });
+
+        out.appendChild(doc.body);
+
+        // Now that the nodes are in the live document, init each canvas.
+        specs.forEach(function (s) {
+            try {
+                geomlib.init({
+                    canvasid: s.id,
+                    width: s.w, height: s.h,
+                    background: s.p.meta.background || "0,0,100",
+                    title: s.p.meta.title || s.id,
+                    pivot: s.p.meta.pivot,
+                    elements: s.p.elements.map(substituteRandom),
+                });
+            } catch (err) {
+                var box = document.createElement("div");
+                box.className = "fail";
+                box.textContent = "geomlib.init failed for " + s.id + ":\n" + err;
+                var cv = document.getElementById(s.id);
+                if (cv && cv.parentNode) cv.parentNode.appendChild(box);
+            }
+        });
+
+        var d = geomlib.diagnostics();
+        diag.textContent = d.count
+            ? "geomlib.diagnostics() — " + d.count + " on this page:\n\n" +
+              d.slates.map(function (sl) {
+                  return sl.canvasid + "  [" + sl.severity + "]\n" +
+                      sl.entries.map(function (e) { return "    " + e.code + ": " + e.message; }).join("\n");
+              }).join("\n\n")
+            : "geomlib.diagnostics() — clean, nothing reported.";
+    }
+
+    function load() {
+        var path = document.getElementById("path").value.trim();
+        var base = path.replace(/[^\/]*$/, "");
+        fetch(path).then(function (r) {
+            if (!r.ok) throw new Error(r.status + " " + r.statusText + " for " + path);
+            return r.text();
+        }).then(function (html) { render(html, base); })
+          .catch(function (err) {
+            out.innerHTML = "";
+            var box = document.createElement("div");
+            box.className = "fail";
+            box.textContent = String(err);
+            out.appendChild(box);
+        });
+    }
+
+    // ---- index -------------------------------------------------------
+    var INDEX = [];
+    // Look-up keys for a pasted path: the viewer-relative path, the
+    // repo-relative path, and the bare filename.
+    var byKey = {};
+
+    function indexPage(pg) {
+        byKey[pg.repoPath] = pg;
+        byKey[pg.path] = pg;
+        var base = pg.repoPath.replace(/^.*\//, "");
+        // A bare filename can be ambiguous (propI4.html exists once, but
+        // guard anyway) — first one wins, and the full path always matches.
+        if (!(base in byKey)) byKey[base] = pg;
+    }
+
+    function resolvePath(raw) {
+        var cleaned = raw.trim().replace(/^["'(<]+|["')>]+$/g, "");
+        if (byKey[cleaned]) return byKey[cleaned];
+        // Absolute or otherwise-prefixed: keep from "view/" onward.
+        var i = cleaned.indexOf("view/");
+        if (i >= 0) {
+            var rel = cleaned.slice(i);
+            if (byKey[rel]) return byKey[rel];
+        }
+        var base = cleaned.replace(/^.*\//, "");
+        return byKey[base] || null;
+    }
+
+    function renderIndex(filter) {
+        var host = document.getElementById("idxList");
+        var f = (filter || "").toLowerCase();
+        var shown = INDEX.filter(function (pg) {
+            return !f || pg.repoPath.toLowerCase().indexOf(f) >= 0
+                      || pg.category.toLowerCase().indexOf(f) >= 0;
+        });
+        host.innerHTML = "";
+        shown.slice(0, 400).forEach(function (pg) {
+            var row = document.createElement("div");
+            var a = document.createElement("a");
+            a.href = "#";
+            a.textContent = pg.repoPath;
+            a.addEventListener("click", function (ev) {
+                ev.preventDefault();
+                document.getElementById("path").value = pg.path;
+                load();
+            });
+            row.appendChild(a);
+            var cat = document.createElement("span");
+            cat.className = "cat";
+            cat.textContent = pg.category + " \u00b7 " + pg.applets + " applet(s)";
+            row.appendChild(cat);
+            host.appendChild(row);
+        });
+        document.getElementById("idxCount").textContent =
+            shown.length + " of " + INDEX.length +
+            (shown.length > 400 ? " (showing first 400)" : "");
+    }
+
+    fetch("archive-index.json").then(function (r) { return r.json(); })
+        .then(function (d) {
+            INDEX = d.pages;
+            INDEX.forEach(indexPage);
+            renderIndex("");
+        })
+        .catch(function () {
+            document.getElementById("idxList").innerHTML =
+                '<span class="miss">archive-index.json not found \u2014 run ' +
+                '<code>npm run archive:index</code></span>';
+        });
+
+    document.getElementById("idxFilter").addEventListener("input", function (e) {
+        renderIndex(e.target.value);
+    });
+
+    // ---- paste diagnostics -> pages ------------------------------------
+    function parsePaste() {
+        var text = document.getElementById("paste").value;
+        var lines = text.split(/\r?\n/);
+        var groups = [];      // preserve first-seen order
+        var index = {};
+        var missing = {};
+        var pendingPath = null;
+
+        lines.forEach(function (line) {
+            // "[geomlib] <path>: <message>" — the message itself can contain
+            // colons, so split on the FIRST ": " after a .html path.
+            var m = line.match(/\[geomlib\]\s*(.*?\.html)\s*:\s*([\s\S]*)$/);
+            if (!m) {
+                // A param can carry a newline (booki/defI20.html), so a
+                // message may continue onto the next line — attach it.
+                if (pendingPath && line.trim() && index[pendingPath]) {
+                    var g = index[pendingPath];
+                    g.messages[g.messages.length - 1] += "\n" + line.trim();
+                }
+                return;
+            }
+            var pg = resolvePath(m[1]);
+            if (!pg) { missing[m[1]] = (missing[m[1]] || 0) + 1; pendingPath = null; return; }
+            pendingPath = pg.repoPath;
+            if (!index[pg.repoPath]) {
+                index[pg.repoPath] = { pg: pg, messages: [] };
+                groups.push(index[pg.repoPath]);
+            }
+            index[pg.repoPath].messages.push(m[2].trim());
+        });
+
+        var host = document.getElementById("hits");
+        host.innerHTML = "";
+        if (!groups.length && !Object.keys(missing).length) {
+            host.innerHTML = '<li class="miss">No [geomlib] lines with a .html path found.</li>';
+            return;
+        }
+        groups.forEach(function (g) {
+            var li = document.createElement("li");
+            var a = document.createElement("a");
+            a.href = "#";
+            a.textContent = g.pg.repoPath;
+            a.addEventListener("click", function (ev) {
+                ev.preventDefault();
+                document.getElementById("path").value = g.pg.path;
+                load();
+                document.getElementById("out").scrollIntoView({ behavior: "smooth" });
+            });
+            li.appendChild(a);
+            var badge = document.createElement("span");
+            badge.className = "count";
+            badge.textContent = g.messages.length;
+            li.appendChild(badge);
+            var msgs = document.createElement("div");
+            msgs.className = "msgs";
+            msgs.textContent = g.messages.join("\n");
+            li.appendChild(msgs);
+            host.appendChild(li);
+        });
+        Object.keys(missing).forEach(function (k) {
+            var li = document.createElement("li");
+            li.className = "miss";
+            li.textContent = "not in the index (skipped): " + k;
+            host.appendChild(li);
+        });
+    }
+
+    document.getElementById("parse").addEventListener("click", parsePaste);
+    document.getElementById("clearPaste").addEventListener("click", function () {
+        document.getElementById("paste").value = "";
+        document.getElementById("hits").innerHTML = "";
+    });
+
+    document.getElementById("go").addEventListener("click", load);
+    document.getElementById("path").addEventListener("keydown", function (e) {
+        if (e.key === "Enter") load();
+    });
+    // ?p=... lets you deep-link a fixture.
+    var q = new URLSearchParams(location.search).get("p");
+    if (q) document.getElementById("path").value = q;
+    load();
+})();
+</script>
+</body>
+</html>

--- a/view/test/diagnostics-badge.html
+++ b/view/test/diagnostics-badge.html
@@ -1,0 +1,134 @@
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test View — #154 diagnostic badge</title>
+</head>
+<body>
+<h3 style="font-family: sans-serif;">On-canvas diagnostic badge (#154)</h3>
+<p style="font-family: sans-serif; max-width: 760px; color: #444;">
+geomlib skips what it cannot resolve and keeps rendering — the right call,
+but it used to mean the only evidence was a console line nobody has open.
+A canvas that reported anything now carries a small mark in its
+<b>upper-left</b> corner. Hover it for the tooltip.
+</p>
+<ul style="font-family: sans-serif; max-width: 760px; color: #444;">
+<li><b>Clean</b> — no badge at all, and no extra DOM node is even created.</li>
+<li><b>Warning</b> — amber triangle. This deck animates <code>GHOST</code>,
+    which no element or alias resolves to.</li>
+<li><b>Error</b> — red X. Same figure, but something reported at error
+    severity; error supersedes warning when both are present.</li>
+</ul>
+<p style="font-family: sans-serif; max-width: 760px; color: #444;">
+Things worth checking by hand:
+<b>(1)</b> the badge is visible <i>without</i> hovering — unlike the
+reset/maximize controls, which fade in on hover (#69);
+<b>(2)</b> press <b>p</b> to present, or maximize: the badge rides along to
+the viewport's upper-left and does not collide with the caption or nav;
+<b>(3)</b> press <b>r</b> (reset) — the badge clears, because reset is the
+deliberate "I've seen it" gesture;
+<b>(4)</b> the warning canvas and the clean canvas are independent: a
+warning on one must never badge the other.
+</p>
+
+<table style="font-family: sans-serif; border-collapse: collapse;">
+<tr>
+  <td style="padding:0 12px 6px 0; color:#666;">clean — no badge</td>
+  <td style="padding:0 12px 6px 0; color:#666;">warning</td>
+  <td style="padding:0 0 6px 12px; color:#666;">error</td>
+</tr>
+<tr>
+  <td style="padding-right:12px;"><canvas id="cClean" style="width:240px; height:200px;" tabindex="0"></canvas></td>
+  <td style="padding-right:12px;"><canvas id="cWarn"  style="width:240px; height:200px;" tabindex="0"></canvas></td>
+  <td style="padding-left:12px;"><canvas id="cErr"   style="width:240px; height:200px;" tabindex="0"></canvas></td>
+</tr>
+</table>
+
+<p style="font-family: sans-serif; max-width: 760px; color: #444;">
+Page-wide, for a consumer (or you, in the console):
+<code>geomlib.diagnostics()</code> — the result is printed below on load.
+</p>
+<pre id="out" style="font-family: ui-monospace, monospace; font-size: 12px;
+     background:#f6f6f6; padding:10px; max-width:740px; overflow-x:auto;"></pre>
+
+<script src="../../dist/bundle.js" type="text/javascript"></script>
+<script type="text/javascript">
+    let E = geomlib.E, A = geomlib.A;
+
+    function triangle(canvasid, slides) {
+        geomlib.init({
+            background: '35,19,100',
+            title: canvasid,
+            canvasid: canvasid,
+            elements: [
+                { name: "A", construction: E.Point.free, params: [60, 40] },
+                { name: "B", construction: E.Point.free, params: [40, 160] },
+                { name: "C", construction: E.Point.free, params: [200, 160] },
+                { name: "AB", construction: E.Line.connect, params: ["A", "B"],
+                  nameColor: 0, vertexColor: 0, edgeColor: "black" },
+                { name: "BC", construction: E.Line.connect, params: ["B", "C"],
+                  nameColor: 0, vertexColor: 0, edgeColor: "black" },
+                { name: "AC", construction: E.Line.connect, params: ["A", "C"],
+                  nameColor: 0, vertexColor: 0, edgeColor: "black" },
+            ],
+            slides: slides,
+        });
+    }
+
+    // 1. Clean: nothing resolves badly, so nothing is reported.
+    triangle("cClean", [
+        { text: "A clean figure reports nothing.", visible: ["AB", "BC", "AC"] },
+        { text: "Join {AC}.", visible: ["AB", "BC", "AC"], highlighted: ["AC"] },
+    ]);
+
+    // 2. Warning: an animation target that no element or alias resolves to —
+    //    the shape of a stale target left behind by a figure refactor.
+    triangle("cWarn", [
+        { text: "This deck animates an element that no longer exists.",
+          visible: ["AB", "BC", "AC"] },
+        { text: "Advance to trigger it.", visible: ["AB", "BC", "AC"],
+          transition: { animations: [
+              { elem: "GHOST", name: A.Line.straightEdgeConnect },
+          ] } },
+    ]);
+
+    // 3. Error: reported directly at error severity on the third slate.
+    triangle("cErr", [
+        { text: "This one reports at error severity.", visible: ["AB", "BC", "AC"] },
+    ]);
+    (function () {
+        var errSlate = geomlib.slates[geomlib.slates.length - 1];
+        errSlate.reportDiagnostic({
+            code: "demo-error",
+            message: "demo: something failed at error severity",
+            severity: "error",
+        });
+        // A warning too, to show that error supersedes it.
+        errSlate.reportDiagnostic({
+            code: "demo-warning",
+            message: "demo: a warning alongside the error",
+        });
+    })();
+
+    // Page-wide view, the call a build-time checker would make.
+    window.addEventListener("load", function () {
+        var d = geomlib.diagnostics();
+        document.getElementById("out").textContent = JSON.stringify({
+            severity: d.severity,
+            count: d.count,
+            slates: d.slates.map(function (s) {
+                return { canvasid: s.canvasid, severity: s.severity,
+                         messages: s.entries.map(function (e) { return e.code; }) };
+            }),
+        }, null, 2);
+    });
+
+    // The push-style hook a consuming page would use.
+    document.addEventListener("geomlib:diagnostic", function (ev) {
+        if (ev.detail && ev.detail.diagnostic) {
+            console.log("[page] geomlib:diagnostic ->",
+                ev.detail.severity, ev.detail.diagnostic.code);
+        }
+    });
+</script>
+</body>
+</html>

--- a/view/test/diagnostics-badge.html
+++ b/view/test/diagnostics-badge.html
@@ -14,9 +14,13 @@ A canvas that reported anything now carries a small mark in its
 <ul style="font-family: sans-serif; max-width: 760px; color: #444;">
 <li><b>Clean</b> — no badge at all, and no extra DOM node is even created.</li>
 <li><b>Warning</b> — amber triangle. This deck animates <code>GHOST</code>,
-    which no element or alias resolves to.</li>
-<li><b>Error</b> — red X. Same figure, but something reported at error
-    severity; error supersedes warning when both are present.</li>
+    which no element or alias resolves to. The badge appears
+    <b>on load</b>: decks are checked when the figure is built, so a dead
+    target does not stay hidden until someone happens to advance to the
+    slide that uses it.</li>
+<li><b>Error</b> — a red stop-sign octagon. Same figure, but something
+    reported at error severity; error supersedes warning when both are
+    present (this canvas reports one of each).</li>
 </ul>
 <p style="font-family: sans-serif; max-width: 760px; color: #444;">
 Things worth checking by hand:
@@ -85,7 +89,8 @@ Page-wide, for a consumer (or you, in the console):
     triangle("cWarn", [
         { text: "This deck animates an element that no longer exists.",
           visible: ["AB", "BC", "AC"] },
-        { text: "Advance to trigger it.", visible: ["AB", "BC", "AC"],
+        { text: "The target is checked at load, so the badge is already showing.",
+          visible: ["AB", "BC", "AC"],
           transition: { animations: [
               { elem: "GHOST", name: A.Line.straightEdgeConnect },
           ] } },

--- a/view/test/overview.html
+++ b/view/test/overview.html
@@ -77,6 +77,8 @@ individually.</p>
       <td>Caption token forms side by side: bare <code>{AB}</code>, single-word override <code>{ABC|angA}</code>, and the new phrase form <code>{the side from A to C|AC}</code> — plus the one-keyword workaround it replaces.</td><td>#136</td></tr>
   <tr><td><a href="just-claim.html">just-claim.html</a></td>
       <td><code>ISlideJust.claim</code> — a justification states the step (<i>"angle EGB = angle AGH — I.15"</i>) instead of only citing it. Bare / claimed / mixed slides show the row-vs-stacked layout rule. I.28's figure.</td><td>#146</td></tr>
+  <tr><td><a href="diagnostics-badge.html">diagnostics-badge.html</a></td>
+      <td>The on-canvas diagnostic badge: clean / warning / error side by side, visible without hover, surviving presentation, cleared by <kbd>r</kbd>. Also prints <code>geomlib.diagnostics()</code> and listens for <code>geomlib:diagnostic</code>.</td><td>#154</td></tr>
 </table>
 
 <h2>Responsive / 3D</h2>

--- a/view/test/overview.html
+++ b/view/test/overview.html
@@ -41,6 +41,13 @@ individually.</p>
       <td>The <b>real I.23 guide deck</b> (copy an angle), with its two hand-built transfer rigs replaced by two <code>compassTransfer</code> calls. Uses <code>keepCircles</code> so slide 9's "ten circles" count still works.</td></tr>
 </table>
 
+<h2>Tools</h2>
+<table>
+  <tr><th>Page</th><th>Shows</th><th>Issue</th></tr>
+  <tr><td><a href="archive-viewer.html">archive-viewer.html</a></td>
+      <td><b>View any original applet page, rendered by geomlib.</b> Dr. Joyce's 1996 pages can't load on their own (dead Java <code>&lt;applet&gt;</code>, <code>navigator.javaEnabled()</code> removed, and <code>elements.js</code> was never mirrored) — this rebuilds each applet from its own <code>&lt;param&gt;</code> tags without touching the file. <b>Paste <code>[geomlib]</code> diagnostics into it</b> and it picks out the fixtures and links straight to them; plus a filterable index of all 616 pages.</td><td>#154</td></tr>
+</table>
+
 <h2>Construction / element features</h2>
 <table>
   <tr><th>Page</th><th>Shows</th><th>Issue</th></tr>


### PR DESCRIPTION
Closes #154.

geomlib skips what it cannot resolve and keeps rendering — the right call, a
deck with one bad name should still draw. The cost is that the only evidence
was a `console.warn`, and a deck author has no reason to have devtools open.
That is how **33 inert alias names across 17 canvases** sat unnoticed for
months (#151), and how **I.23 has been animating 8 targets deleted by the
#127 `compassTransfer` swap** ever since.

This makes a diagnostic impossible to miss at the moment it happens, and
gives a consumer the hooks to check decks at build time.

## The badge

A canvas that has reported anything carries a small mark in its **upper-left**
corner: an amber `!` triangle for warnings, a red stop-sign octagon when
anything reached error severity (error supersedes warning). Tooltip:
`geomlib generated warnings - check console`. **A clean diagram shows nothing
and does not even create the element.**

Three decisions worth a reviewer's eye:

- **It is a `<div>`, not a `<button>`.** `ensureControlsStyle()` injects
  `.geomlib-wrapper>button{opacity:0}` with hover/focus revealing (#69), so a
  `<button>` badge would have been invisible until hovered — precisely
  backwards for a diagnostic.
- **The icons are drawn, not glyphs.** A `⚠` in a string literal is the
  mojibake class #142 exists to prevent, and a text glyph would add a
  font-metric dependency the rest of the icon set doesn't have. Prod bundle
  re-verified all-ASCII.
- **It latches, and clears on the reset control — not on `Slate.reset()`.**
  `minimize()` and presentation-exit both call `reset()` internally, and
  construction-time diagnostics never fire again, so clearing there would have
  silently discarded exactly the warnings worth keeping. Clearing happens in
  `onReset()`, the deliberate viewer gesture.

## Decks are validated at load

Originally a dead animation target only reported when the animator reached it
— so it stayed invisible until someone advanced to the offending slide, which
is exactly the case nobody notices. It would also have left a build-time
checker seeing a clean page.

`validateSlides()` now resolves every `visible` / `highlighted` name and every
animation `elem:` when the figure is built. Aliases resolve, consistent with
#151, so a valid alias is not falsely flagged.

## Diagnostics API

```typescript
class Slate {
    reportDiagnostic(input): void;
    get diagnostics(): IDiagnostic[];
    get diagnosticSeverity(): "warning" | "error" | null;
    clearDiagnostics(): void;
    onDiagnosticsChanged(fn): () => void;
}

geomlib.diagnostics(opts?): { severity, count, slates[], init[] }
// plus a bubbling `geomlib:diagnostic` CustomEvent, mirroring geomlib:highlight
```

`geomlib.diagnostics()` is the call a static-site generator makes to gate a
build; it already found a live defect (see below). `init()` failures cannot
belong to a slate — a wrong `canvasid` makes the Slate constructor throw — so
they collect in `geomlib.initDiagnostics` and place an error mark next to
where the diagram would have been.

## Two latent bugs fixed on the way

**Per-canvas attribution was broken.** `Animations.ts` `warnedUnknown` and
`GroupAnimations.ts` `warnedUnsupported` were **module-global** dedupe flags:
on a page of many figures, the first canvas to hit a bad name silenced every
other canvas for the rest of the page load. Warnings arrived attributed to the
wrong figure, or not at all. Both are gone, replaced by per-slate dedupe, with
a regression test named for it.

**`PointAnimations.ts:100` had no `typeof console` guard** — the only such
site. The guard now lives once, inside `reportDiagnostic`.

## Snapshot report

`ReportEntry` gains `warnings?`, with a Warn column, a summary count, and the
`errorColspan` bumped so error rows still align. Report-only: CI runs
`test:unit` and never reaches the snapshot suite, so this gates nothing.

It would have read zero forever, because the `<applet>` fixtures have no
slides or animations. But `buildScene` was **silently swallowing** unparseable
params and construction failures — routing those surfaced **4 scenes** whose
figures render with holes, previously invisible. Each diagnostic names its
fixture, so `[geomlib] view/euclid-html/booki/propI4.html: element 'b' failed
to construct…` is actionable rather than a mystery in a coverage log.

## Archive viewer (`view/test/archive-viewer.html`)

Those 4 scenes raised an obvious question — how do you *look* at the page? You
couldn't: the archival pages are Dr. Joyce's verbatim 1996 originals and
cannot load in a modern browser (Java `<applet>`, `navigator.javaEnabled()`
removed so even the `.gif` fallback never swaps in, and `elements.js` was
never mirrored). The snapshot suite doesn't care — it scrapes `<param>` tags
as text and renders through node-canvas.

The viewer does the same translation in the browser, reading each page
**without modifying it**. **Paste `[geomlib]` output into it** and it extracts
the paths, groups the messages per page, and links to each one — absolute,
repo-relative and bare filenames all resolve, and an unrecognised path is
reported as skipped rather than dropped. Plus a filterable index of all 616
fixtures (`npm run archive:index` regenerates the manifest).

## Verification

- `tsc --noEmit` clean; **705 snapshot + 385 unit passing** (up from 358).
- **No golden moved** — safe by construction: the snapshot suites build
  `Slate` directly and never call `createControls`, so the badge cannot reach
  the render path.
- Prod bundle `check:bundle` → all ASCII.
- New `tests/DiagnosticsTest.ts` (added to `test:unit`, `coverage` and
  `coverage:unit` — and folds in the pre-existing omission of
  `SourceHygieneTest.ts` from both coverage lists).
- `view/test/diagnostics-badge.html` — clean / warning / error side by side,
  with the hand-checks listed on the page.
- Documented in `api.md`; the viewer workflow in `AGENTS.md`.

## It has already earned its keep

Running `geomlib.diagnostics()` across the whole lektor site — 524 pages, 634
canvases — found **propIV3's figure has not rendered since conversion**
(`CK` declared before `C`; `init()` throws and the page falls back to its
static `.gif`). Checking Joyce's original showed he had the order right, so it
is a conversion regression, not an inherited defect. Filed as
brownnrl/euclids-elements-lektor#12.

## For the slideshow session

**I.23 `canvas_1` will badge on page load** after the pin bump — its 8 stale
`t1*`/`t2*` names. That is the feature working, but worth fixing first so the
first sight of it isn't on a shipped Book I page. Recorded in the coordination
doc.

## Not in scope

#155 (numeric-looking element names coerced to numbers — a port gap) and
#156 (three archival fixtures with defects inherited from the 1996 originals)
were both found by this work and filed separately. Neither affects a live
deck.
