### PR TITLE
0.14.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Library is **post-porting, publish-ready**. There is no longer a
 "next construction to port" backlog or session-startup ritual.
 
 - All 69 construction methods (with 19 3D variants) are implemented.
-- 315 unit tests + 700 snapshot tests pass.
+- 385 unit tests + 705 snapshot tests pass.
 - 0.4.0 shipped cross-highlighting (`emphasized` / `emphasisAmount`
   + `lookupElement`); 0.5.0 shipped the slideshow surface
   (`slides`, `setVisibleNames`, `addAlias`, `resolveJustification`,
@@ -96,8 +96,8 @@ dist/                     Webpack output (gitignored, shipped to npm)
 ```sh
 npm install              # one-time
 npm run build            # tsc --noEmit (typecheck only)
-npm run test:unit        # 315 unit tests (~110 ms)
-npm run test:snapshot    # 700 snapshot tests; auto-creates goldens on first run
+npm run test:unit        # 385 unit tests (~140 ms)
+npm run test:snapshot    # 705 snapshot tests; auto-creates goldens on first run
 npm test                 # both
 npm run bundle           # dev-mode bundle to dist/bundle.js
 npm run bundle:prod      # production (minified) bundle, ~125 kB

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ That's it.
 ## Running tests
 
 ```sh
-npm run test:unit      # 315 unit tests — fast (~100 ms)
+npm run test:unit      # 385 unit tests — fast (~140 ms)
 npm run test:snapshot  # 700 visual-regression tests against snapshot goldens
 npm test               # both (snapshot then unit)
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brownnrl/geomlib",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.13.0",
-  "description": "Interactive Euclidean geometry constructions in the browser \u2014 a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
+  "version": "0.14.0",
+  "description": "Interactive Euclidean geometry constructions in the browser — a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
   "keywords": [
     "euclid",
     "elements",


### PR DESCRIPTION
Version bump for **0.14.0**, following the same shape as the 0.13.0 release
commit (`package.json` + `package-lock.json`), plus a refresh of the test
counts stated in `AGENTS.md` and `CONTRIBUTING.md`, which had drifted from
315/700 to the current **385 unit + 705 snapshot**.

Minor bump rather than major: everything is additive apart from two
deliberate behaviour changes (below), and nothing was removed.

## What's in it

Thirteen merged PRs since `v0.13.0`.

**For the slideshow session — the three standing asks, all closed:**

| Issue | What it unblocks |
|---|---|
| **#138** | Present-centring measures only elements that **paint**, so an invisible off-canvas helper no longer blanks a slideshow. The deck-side workarounds in I.35, I.42 and I.44 can be reverted. |
| **#136** | The caption display override takes a **phrase**: `{the side from D to A\|sideDA}`. The one-keyword workaround can be unwound. |
| **#146** | `ISlideJust.claim` — a justification states its step (`∠EGB = ∠AGH — I.15`) instead of only citing it. I.28's per-statement sub-slide split stops being forced. |

**Behaviour changes worth knowing about:**

- **#140** — a highlighted or mid-animation element now draws **on top** of
  its neighbours instead of in declaration order. Promotion is *within* a
  draw pass, so a promoted face still stays under every edge; static figures
  are bit-for-bit unchanged. Opt out with `init({ highlightOnTop: false })`.
- **#139** — `Esc` peels off one layer of takeover per press: out of the
  slideshow (staying maximized, #115 unchanged), then out of the maximized
  view. Bound on `document`, so it fires with focus on a control button too.

**Also in:**

- **#122** `A.Point.slide` glides to a target element, not just a numeric
  parameter — the I.31 "A slides across DC" case.
- **#125** the full CSS named-colour set in `parseColor` (the 13 Java AWT
  names keep their historical values).
- **#151** aliases resolve in slide `visible` / `highlighted` sets, and a name
  matching nothing is **reported** rather than silently ignored. That last
  part is what surfaced 33 inert names across 17 canvases.
- **#154** the on-canvas diagnostic badge, per-slate diagnostics API,
  `geomlib.diagnostics()`, and the `geomlib:diagnostic` event. Decks are
  validated **at load**, so a stale name reports when the figure is built.
- **#141 / #142** hygiene: the `#108` sentinel is an escape rather than a raw
  NUL (so `Slate.ts` stops looking binary to `grep` *and* `git diff`), and the
  emitted bundle is ASCII-only so a consumer page without `<meta charset>`
  can no longer mangle geomlib's own controls.

## Verified before cutting

Ran the full publish gate on this branch:

```
tsc --noEmit          clean
test:unit             385 passing        <- the prepublishOnly gate
test:snapshot         705 passing, 0 errors
bundle:prod           ok
check:bundle          OK — 204232 bytes, all ASCII
npm publish --dry-run @brownnrl/geomlib@0.14.0, 6 files, 220.4 kB
```

## After merging

1. Tag `v0.14.0` on `main` and `npm publish`.
2. 🔔 **Before the lektor pin bump**, the slideshow session should fix two
   things — both recorded in the coordination doc:
   - **lektor#12** — propIV3's figure has not rendered since conversion
     (`CK` declared before `C`; `init()` throws and the page falls back to its
     static `.gif`). Joyce's original had the order right, so it is a
     conversion regression.
   - **I.23's 8 stale `t1*`/`t2*` names** — harmless today, but #154
     validates decks at load, so `canvas_1` will badge as soon as the page
     opens. Better to fix first than to meet the feature on a shipped page.
3. Re-run the site-wide sweep (`deck-sweep-prototype.js`, saved at the
   persistent geometry root) to confirm all 634 canvases are clean.

## Not in this release

**#137** (point follows a path) — the slideshow session's remaining ask.
**#155** (numeric-looking element names coerced to numbers) and **#156**
(three archival fixtures carrying defects inherited from Joyce's 1996
originals) were both found by #154's diagnostics and filed separately;
neither affects a live deck. **#128**, **#70**, **#67**, **#57** unchanged.
