### PR TITLE
README badges; publish coverage + snapshot reports on npm publish (#67)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,12 @@ tests/snapshots/report.html
 .idea/
 dist/
 *.js
+# ...but the repo's own tooling is source, not build output. Without this
+# the blanket *.js above silently swallowed scripts/, so `check:bundle`
+# (which prepublishOnly runs) and `archive:index` pointed at files that
+# were never committed — a fresh clone could not publish.
+!scripts/*.js
+!webpack.config.js
 *.map
 *.swp
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # geomlib
 
+[![tests](https://github.com/brownnrl/euclid/actions/workflows/test.yml/badge.svg)](https://github.com/brownnrl/euclid/actions/workflows/test.yml)
+[![CodeQL](https://github.com/brownnrl/euclid/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/brownnrl/euclid/actions/workflows/github-code-scanning/codeql)
+[![npm](https://img.shields.io/npm/v/@brownnrl/geomlib.svg)](https://www.npmjs.com/package/@brownnrl/geomlib)
+
 A TypeScript port of Dr. David E. Joyce's *Geometry Applet* (Clark
 University, 1996, Java version 2.2). `geomlib` renders interactive
 Euclidean geometry diagrams on an HTML5 `<canvas>`: drag a point, and
@@ -107,7 +111,7 @@ npm install              # install dependencies (once)
 npm run build            # compile TypeScript (no emit; type-check only)
 npm test                 # run the full Mocha suite (unit + snapshot)
 npm run test:unit        # unit tests only
-npm run test:snapshot    # 700 rendered-pixel snapshot tests
+npm run test:snapshot    # 705 rendered-pixel snapshot tests
 npm run coverage         # tests + c8 code coverage report
 npm run bundle           # webpack dev-mode bundle to dist/bundle.js
 npm run bundle:prod      # webpack production (minified) bundle
@@ -117,6 +121,23 @@ python3 -m http.server   # serve view/test/* pages in a browser
 `npm publish` runs `test:unit` + `bundle:prod` via `prepublishOnly`,
 so the tarball always contains a fresh production-built bundle. Run
 `npm publish --dry-run` to preview what would ship without publishing.
+
+## Reports
+
+Regenerated and republished on each `npm publish`, so they track the
+released version rather than whatever was last run by hand.
+
+| Report | What it shows |
+|---|---|
+| [Code coverage](https://brownnrl.github.io/geomlib-reports/coverage/) | `c8` line/branch coverage of the TypeScript source. |
+| [Snapshot regression](https://brownnrl.github.io/geomlib-reports/snapshots/report.html) | Every construction scene the library renders, with drag interactions. Click a thumbnail for a live, draggable slate. |
+
+Both are generated locally (`npm run reports:build`) and pushed to
+[brownnrl/geomlib-reports](https://github.com/brownnrl/geomlib-reports),
+which GitHub Pages serves. They live in their own repository on purpose:
+the snapshot report is ~42 MB of PNGs, several times the size of this
+repository's entire history, and `git clone` fetches every branch by
+default — keeping it out means a clone of `euclid` stays small.
 
 ## Origin
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,10 @@
     "coverage:report": "c8 report --reporter=html",
     "snapshots:clean": "rm -rf tests/snapshots && mkdir -p tests/snapshots && touch tests/snapshots/.gitkeep",
     "prepublishOnly": "npm run test:unit && npm run bundle:prod && npm run check:bundle",
-    "archive:index": "node scripts/build-archive-index.js"
+    "archive:index": "node scripts/build-archive-index.js",
+    "reports:build": "npm run coverage && npm run test:snapshot",
+    "reports:publish": "node scripts/publish-reports.js",
+    "postpublish": "npm run reports:publish"
   },
   "repository": {
     "type": "git",

--- a/scripts/build-archive-index.js
+++ b/scripts/build-archive-index.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// Build the fixture index consumed by view/test/archive-viewer.html.
+//
+// A browser cannot list a directory, so the viewer needs a manifest of the
+// archival pages to offer lookup over. This walks the same four directories
+// the snapshot suite discovers (tests/HtmlParamParser.ts discoverAllHtmlFiles)
+// and records, per page, the path, its category, and how many <applet>
+// blocks it holds.
+//
+// Regenerate with `npm run archive:index` after adding or removing fixtures.
+
+const fs = require("fs");
+const path = require("path");
+
+const REPO = path.join(__dirname, "..");
+const ROOTS = [
+    "view/euclid-html",
+    "view/compass_geometry",
+    "view/round_geometry",
+    "view/test",
+];
+const OUT = path.join(REPO, "view/test/archive-index.json");
+
+function walk(dir, acc) {
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); }
+    catch (_) { return acc; }
+    for (const e of entries) {
+        const p = path.join(dir, e.name);
+        if (e.isDirectory()) walk(p, acc);
+        else if (e.name.endsWith(".html")) acc.push(p);
+    }
+    return acc;
+}
+
+// Mirror HtmlParamParser's category rules so the viewer groups pages the
+// same way the snapshot report does.
+function categoryOf(rel) {
+    if (rel.includes("compass_geometry")) return "compass";
+    if (rel.includes("round_geometry")) return "round";
+    if (rel.includes("view/test")) {
+        const m = rel.match(/view\/test\/([^/]+)\//);
+        return m ? `test/${m[1]}` : "test";
+    }
+    const m = rel.match(/book(\w+)/i);
+    return m ? `euclid/book${m[1].toUpperCase()}` : "euclid/other";
+}
+
+const pages = [];
+for (const root of ROOTS) {
+    for (const abs of walk(path.join(REPO, root), [])) {
+        const rel = path.relative(REPO, abs).split(path.sep).join("/");
+        let html = "";
+        try { html = fs.readFileSync(abs, "utf-8"); } catch (_) { continue; }
+        // view/test pages keep the original applet block commented out
+        // beside the TS init() call; the parser un-comments it, so count both.
+        const uncommented = html.replace(/<!--(applet[\s\S]*?<\/applet)-->/gi, "<$1>");
+        const applets = (uncommented.match(/<applet[^>]*>/gi) || []).length;
+        const inits = (html.match(/geomlib\.init\s*\(/g) || []).length;
+        if (applets === 0 && inits === 0) continue;
+        pages.push({
+            // Relative to view/test/, which is where the viewer lives.
+            path: "../" + rel.replace(/^view\//, ""),
+            repoPath: rel,
+            name: path.basename(rel, ".html"),
+            category: categoryOf(rel),
+            applets,
+            inits,
+        });
+    }
+}
+
+pages.sort((a, b) => a.repoPath.localeCompare(b.repoPath));
+fs.writeFileSync(OUT, JSON.stringify({ generated: pages.length, pages }, null, 1) + "\n");
+console.log(`build-archive-index: ${pages.length} pages -> ${path.relative(REPO, OUT)}`);

--- a/scripts/check-bundle-ascii.js
+++ b/scripts/check-bundle-ascii.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// #142 — fail the publish if the bundle carries raw non-ASCII bytes.
+//
+// A <script src> with no charset of its own is decoded using the INCLUDING
+// document's encoding. A consumer page that omits <meta charset> therefore
+// renders any literal UTF-8 in our bundle as mojibake — geomlib's own
+// presentation controls ("< Prev", "Next >", "X Exit") turn to gibberish
+// because of the host page's markup, which we cannot fix from their side.
+//
+// webpack.config.js sets terser's `ascii_only` so those characters are
+// emitted as escape sequences instead. This checks the actual artifact,
+// because the obvious-looking fix does NOT work: escaping the characters in
+// the TypeScript source is undone by tsc (which decodes the escape) and by
+// the minifier (which re-normalises string escapes to the shortest form).
+// Only the emit step decides, so only the emitted file is worth testing.
+
+const fs = require("fs");
+const path = require("path");
+
+const bundle = path.join(__dirname, "..", "dist", "bundle.js");
+
+if (!fs.existsSync(bundle)) {
+    console.error(`check-bundle-ascii: ${bundle} not found — run \`npm run bundle:prod\` first.`);
+    process.exit(1);
+}
+
+const buf = fs.readFileSync(bundle);
+const offenders = [];
+for (let i = 0; i < buf.length && offenders.length < 5; i++) {
+    if (buf[i] > 127) {
+        const line = buf.slice(0, i).toString("utf8").split("\n").length;
+        const context = buf.slice(Math.max(0, i - 40), i + 40).toString("utf8");
+        offenders.push(`  byte 0x${buf[i].toString(16)} at line ${line}: …${context}…`);
+    }
+}
+
+if (offenders.length > 0) {
+    console.error("check-bundle-ascii: bundle contains raw non-ASCII bytes.");
+    console.error("Consumer pages without <meta charset> will render these as mojibake.");
+    console.error("Check that `ascii_only` is still set on the minifier in webpack.config.js.\n");
+    console.error(offenders.join("\n"));
+    process.exit(1);
+}
+
+console.log(`check-bundle-ascii: OK — ${buf.length} bytes, all ASCII.`);

--- a/scripts/publish-reports.js
+++ b/scripts/publish-reports.js
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+// Publish the coverage and snapshot reports to their own repo, which
+// GitHub Pages serves (#67).
+//
+// Why a separate repo rather than a gh-pages branch here: the snapshot
+// report is ~42 MB of PNGs — roughly three times the entire history of
+// this repository — and `git clone` fetches every ref by default. Putting
+// it on a branch of this repo would make every contributor download
+// artifacts they never need. `--single-branch` avoids that but is not the
+// default and cannot be imposed on anyone.
+//
+// Publishing is a single ORPHAN commit, force-pushed: the reports repo
+// replaces its contents each time instead of accumulating a 42 MB delta
+// per release.
+//
+// Run via `npm run reports:publish`, or automatically from `postpublish`
+// after a successful `npm publish`.
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { execFileSync } = require("child_process");
+
+const REPO = path.join(__dirname, "..");
+const REPORTS_REMOTE = process.env.GEOMLIB_REPORTS_REMOTE
+    || "git@github.com:brownnrl/geomlib-reports.git";
+const REPORTS_BRANCH = process.env.GEOMLIB_REPORTS_BRANCH || "main";
+
+const argv = process.argv.slice(2);
+const noSnapshots = argv.includes("--no-snapshots");
+const dryRun = argv.includes("--dry-run")
+    // npm sets this for `npm publish --dry-run`; without the check the
+    // postpublish hook would force-push on a rehearsal.
+    || process.env.npm_config_dry_run === "true";
+
+function log(msg) { console.log("publish-reports: " + msg); }
+
+// A publish that already succeeded must not be reported as failed because
+// the report push didn't work. Say so loudly, exit 0.
+function bail(msg) {
+    console.error("publish-reports: " + msg);
+    console.error("publish-reports: reports NOT published (the npm publish itself was unaffected).");
+    process.exit(0);
+}
+
+function git(args, cwd) {
+    return execFileSync("git", args, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+// Recursive copy that skips names we never want to ship.
+function copyTree(src, dest, skip) {
+    const stat = fs.statSync(src);
+    if (stat.isDirectory()) {
+        const base = path.basename(src);
+        if (skip && skip.has(base)) return 0;
+        fs.mkdirSync(dest, { recursive: true });
+        let n = 0;
+        for (const entry of fs.readdirSync(src)) {
+            n += copyTree(path.join(src, entry), path.join(dest, entry), skip);
+        }
+        return n;
+    }
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+    return 1;
+}
+
+function humanSize(bytes) {
+    if (bytes > 1024 * 1024) return (bytes / 1024 / 1024).toFixed(1) + " MB";
+    if (bytes > 1024) return Math.round(bytes / 1024) + " KB";
+    return bytes + " B";
+}
+
+function treeSize(dir, skip) {
+    let total = 0;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (skip && skip.has(entry.name)) continue;
+        const p = path.join(dir, entry.name);
+        total += entry.isDirectory() ? treeSize(p, skip) : fs.statSync(p).size;
+    }
+    return total;
+}
+
+// ---- what we're shipping ---------------------------------------------
+const coverageDir = path.join(REPO, "coverage");
+const snapshotDir = path.join(REPO, "tests", "snapshots");
+const reportHtml = path.join(snapshotDir, "report.html");
+const bundle = path.join(REPO, "dist", "bundle.js");
+
+if (!fs.existsSync(path.join(coverageDir, "index.html"))) {
+    bail("no coverage report found — run `npm run coverage` first.");
+}
+if (!noSnapshots && !fs.existsSync(reportHtml)) {
+    bail("no snapshot report found — run `npm run test:snapshot` first, "
+       + "or pass --no-snapshots.");
+}
+if (!noSnapshots && !fs.existsSync(bundle)) {
+    bail("dist/bundle.js is missing — run `npm run bundle` first "
+       + "(the report needs it for the live-slate modal).");
+}
+
+const version = require(path.join(REPO, "package.json")).version;
+
+if (dryRun) {
+    log("dry run — nothing will be pushed.");
+    log("would publish geomlib " + version + " reports to "
+        + REPORTS_REMOTE + " (" + REPORTS_BRANCH + ")");
+    log("  coverage/            " + humanSize(treeSize(coverageDir, new Set(["tmp"]))) + " (tmp/ excluded)");
+    if (!noSnapshots) {
+        log("  snapshots/report.html " + humanSize(fs.statSync(reportHtml).size));
+        log("  snapshots/ PNG tree   " + humanSize(treeSize(snapshotDir)));
+    } else {
+        log("  snapshots/           skipped (--no-snapshots)");
+    }
+    process.exit(0);
+}
+
+// ---- assemble ---------------------------------------------------------
+const work = fs.mkdtempSync(path.join(os.tmpdir(), "geomlib-reports-"));
+let pushed = false;
+try {
+    log("assembling in " + work);
+    git(["init", "--quiet", "-b", REPORTS_BRANCH], work);
+    git(["remote", "add", "origin", REPORTS_REMOTE], work);
+
+    // coverage/ — skip tmp/, which is raw c8 V8 JSON, not part of the report.
+    const covFiles = copyTree(coverageDir, path.join(work, "coverage"), new Set(["tmp"]));
+    log("coverage: " + covFiles + " files");
+
+    let snapFiles = 0;
+    if (!noSnapshots) {
+        const outSnap = path.join(work, "snapshots");
+        // The PNG tree, preserving <category>/<file>/slateN/ — report.html
+        // references those paths relative to itself.
+        snapFiles += copyTree(snapshotDir, outSnap, new Set([".git"]));
+        // The bundle, beside report.html, so the directory is self-contained.
+        fs.copyFileSync(bundle, path.join(outSnap, "bundle.js"));
+        snapFiles++;
+        // The report's <script src> must match where we just put it. It is
+        // baked in at generate time, so rewrite rather than regenerate.
+        const target = path.join(outSnap, "report.html");
+        const html = fs.readFileSync(target, "utf-8");
+        const fixed = html.replace(/(<script src=")[^"]*bundle\.js(")/, "$1bundle.js$2");
+        if (fixed === html && html.indexOf('src="bundle.js"') === -1) {
+            log("WARNING: could not rewrite the report's bundle path — "
+              + "the live-slate modal may not work.");
+        }
+        fs.writeFileSync(target, fixed);
+        log("snapshots: " + snapFiles + " files");
+    }
+
+    fs.writeFileSync(path.join(work, "index.html"), landingPage(version, !noSnapshots));
+    fs.writeFileSync(path.join(work, ".nojekyll"), "");   // serve _-prefixed paths verbatim
+
+    git(["add", "-A"], work);
+    git(["-c", "user.name=geomlib", "-c", "user.email=noreply@example.com",
+         "commit", "--quiet", "-m", "reports for geomlib " + version], work);
+    log("pushing to " + REPORTS_REMOTE + " (" + REPORTS_BRANCH + ")");
+    git(["push", "--force", "origin", REPORTS_BRANCH], work);
+    pushed = true;
+} catch (err) {
+    const detail = (err.stderr && err.stderr.toString().trim()) || String(err);
+    bail("push failed: " + detail);
+} finally {
+    try { fs.rmSync(work, { recursive: true, force: true }); } catch (_) {}
+}
+
+if (pushed) {
+    log("published geomlib " + version + " reports.");
+    log("  https://brownnrl.github.io/geomlib-reports/coverage/");
+    if (!noSnapshots) log("  https://brownnrl.github.io/geomlib-reports/snapshots/report.html");
+}
+
+function landingPage(version, withSnapshots) {
+    return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<title>geomlib reports</title>
+<style>
+ body{font-family:sans-serif;max-width:44rem;margin:3rem auto;padding:0 1rem;color:#222;line-height:1.5}
+ h1{margin-bottom:.2rem} .v{color:#666;font-size:.9rem}
+ li{margin:.6rem 0} code{background:#f3f3f3;padding:0 3px;border-radius:3px}
+</style></head><body>
+<h1>geomlib reports</h1>
+<p class="v">Generated from <a href="https://github.com/brownnrl/euclid">brownnrl/euclid</a>
+at version <b>${version}</b>. Republished on each <code>npm publish</code>.</p>
+<ul>
+<li><a href="coverage/"><b>Code coverage</b></a> — <code>c8</code> output for the TypeScript source.</li>
+${withSnapshots ? '<li><a href="snapshots/report.html"><b>Snapshot regression report</b></a> — every construction scene the library renders, with drag interactions. Click a thumbnail for a live, draggable slate.</li>' : ""}
+</ul>
+</body></html>
+`;
+}

--- a/tests/SnapshotHelper.ts
+++ b/tests/SnapshotHelper.ts
@@ -352,6 +352,15 @@ export interface ReportEntry {
 }
 
 export function generateReport(entries: ReportEntry[]): void {
+    // #67 — where the report should load geomlib from. The default is
+    // relative to tests/snapshots/, which is the only place the report
+    // normally lives. When the report is PUBLISHED somewhere else that path
+    // no longer resolves (on the site today it points at /dist/bundle.js,
+    // which 404s, so the live-slate modal silently fails), hence the
+    // override: the publish step ships a copy of the bundle beside
+    // report.html and sets this to "bundle.js".
+    const bundleSrc = process.env.GEOMLIB_REPORT_BUNDLE_SRC || "../../dist/bundle.js";
+
     // Group by category
     let categories: {[key: string]: ReportEntry[]} = {};
     for (let entry of entries) {
@@ -553,7 +562,7 @@ details { margin: 5px 0; }
   <img id="lightboxImg" alt="">
 </div>
 
-<script src="../../dist/bundle.js"></script>
+<script src="${bundleSrc}"></script>
 <script>
 const CONFIGS = ${JSON.stringify(configMap)};
 const ENTRIES = ${JSON.stringify(entries.map(e => ({


### PR DESCRIPTION
Closes #67.

Adds the badge row and Reports links the issue asks for, and makes the reports
republish themselves on `npm publish` so they stop going stale.

## Where the reports live: a separate repo, not a branch here

#67 offered two options — GitHub Pages off this repo, or the existing mirror on
euclids-elements.org. Neither survives contact with the facts:

- **The `.org` copies are about to be deleted.** The lektor site will replace
  that repo's `main`, and `deploy-preview.sh` does `git checkout --orphan` +
  `git rm -rf .` + `cp -a build/. ./`, preserving only three Cloudflare files.
  Nothing else lives through a deploy.
- **A `gh-pages` branch here would weigh down every clone.** The snapshot
  payload is **42 MB** of PNGs against a **16 MB** repo — roughly three times
  this project's entire 418-commit history. `git clone` fetches every ref by
  default, so contributors would pay for artifacts they never need.
  `--single-branch` dodges it but is not the default and can't be imposed.

So the reports go to **`brownnrl/geomlib-reports`**, served by Pages:

```
https://brownnrl.github.io/geomlib-reports/coverage/
https://brownnrl.github.io/geomlib-reports/snapshots/report.html
```

`euclid` clones stay at 16 MB. Publishing is a **single orphan commit,
force-pushed**, so even the reports repo never accumulates a 42 MB delta per
release — verified below.

## Fixes a defect that is live right now

The snapshot report hard-codes `<script src="../../dist/bundle.js">`, which
only resolves from `tests/snapshots/`. On the current site it resolves to
`/dist/bundle.js` — and the site has no `dist/`, confirmed **404**. So the
hosted report's click-a-thumbnail live-slate modal has never worked.

`generateReport()` now reads `GEOMLIB_REPORT_BUNDLE_SRC`, defaulting to the
existing literal so local runs are unchanged. The publish step ships
`bundle.js` next to `report.html` and rewrites the reference, making that
directory self-contained wherever it is served.

## `scripts/publish-reports.js`

Assembles a temp tree and force-pushes one orphan commit. Two guards:

- **No-op on dry runs.** `npm publish --dry-run` sets `npm_config_dry_run`;
  without that check the `postpublish` hook would force-push on a rehearsal.
- **Fail soft.** A publish that already succeeded must not report failure
  because the report push didn't. It logs loudly and exits 0.

`coverage/tmp/` (raw c8 V8 JSON, 1.6 MB) is excluded — the `.org` repo already
had a `.gitignore` rule for exactly that. `--no-snapshots` publishes coverage
alone if the 42 MB ever becomes awkward.

```jsonc
"reports:build":   "npm run coverage && npm run test:snapshot",
"reports:publish": "node scripts/publish-reports.js",
"postpublish":     "npm run reports:publish"
```

## Also: `scripts/` has never been committed

Found while adding the third script. `.gitignore` line 7 is a blanket `*.js`,
which silently swallowed the whole directory. On `main` today:

```
$ git ls-tree -r --name-only origin/main | grep '^scripts/'
(nothing)
```

So `npm run check:bundle` and `npm run archive:index` point at files that are
not in the repository — and **`prepublishOnly` runs `check:bundle`**, meaning a
fresh clone could not publish at all. `webpack.config.js` survived only because
it was force-added in #148.

Fixed with targeted negations (`!scripts/*.js`, `!webpack.config.js`) and all
three scripts committed. This is a bug I introduced across #142 and #154 by
adding scripts that were referenced but never shipped.

## Verification

Rehearsed the whole publish against a local bare repo:

```
commits: 1                        <- orphan discipline
coverage/index.html: yes
coverage/tmp excluded: yes
snapshots/bundle.js: yes (204232 bytes)
report bundle ref: <script src="bundle.js"
a referenced PNG resolves: yes (animation/line_progress_0/slate1/before.png)
total files: 2522
```

- Republished — still **1 commit**.
- `--no-snapshots` → 88 files, coverage only.
- Missing-remote case → clear message, **exit 0**, "the npm publish itself was
  unaffected".
- Local `tests/snapshots/report.html` still emits `../../dist/bundle.js`, so
  the dev workflow is untouched.
- `tsc --noEmit` clean; **705 snapshot + 385 unit passing**.
- All three badge URLs verified **200** live, including the CodeQL one — that
  is a *dynamic* default-setup workflow with no file in the repo, so its badge
  path drops the `dynamic/` prefix.
- Also corrected README's "700 rendered-pixel snapshot tests" → 705.

## Two follow-ups, not in this PR

1. **The reports repo must exist and have Pages enabled** before the first
   real publish — it does not yet. Until then `postpublish` fails soft with a
   clear message rather than breaking a release.
2. **The lektor site links to the old paths.** `content/geomlib/contents.lr`
   points at `/geomlib/coverage/` and `/geomlib/snapshots/report.html`, which
   are already broken on every lektor preview (the build produces no such
   directories). That is the slideshow session's repo — filing separately.
