### PR TITLE
getConstructionName: add the missing Circle branch (#161)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@brownnrl/geomlib",
   "version": "0.14.0",
-  "description": "Interactive Euclidean geometry constructions in the browser — a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
+  "description": "Interactive Euclidean geometry constructions in the browser \u2014 a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
   "keywords": [
     "euclid",
     "elements",
@@ -29,9 +29,9 @@
     "check:bundle": "node scripts/check-bundle-ascii.js",
     "test": "npm run test:snapshot && npm run test:unit",
     "test:snapshot": "npm run bundle && mocha --reporter min tests/SnapshotTest.ts tests/HighlightSnapshotTest.ts tests/VisibilitySnapshotTest.ts tests/AnimationSnapshotTest.ts",
-    "test:unit": "mocha tests/AnimationTest.ts tests/CircleTest.ts tests/DiagnosticsTest.ts tests/ColorsTest.ts tests/HighlightByNameTest.ts tests/HighlightTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateAnimatorTest.ts tests/SlateTest.ts tests/SlideTest.ts tests/SourceHygieneTest.ts tests/SphereTest.ts tests/VisibilityTest.ts",
-    "coverage": "c8 mocha --reporter min tests/SnapshotTest.ts tests/AnimationTest.ts tests/CircleTest.ts tests/DiagnosticsTest.ts tests/ColorsTest.ts tests/HighlightByNameTest.ts tests/HighlightTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateAnimatorTest.ts tests/SlateTest.ts tests/SlideTest.ts tests/SourceHygieneTest.ts tests/SphereTest.ts tests/VisibilityTest.ts",
-    "coverage:unit": "c8 mocha --reporter min tests/AnimationTest.ts tests/CircleTest.ts tests/DiagnosticsTest.ts tests/ColorsTest.ts tests/HighlightByNameTest.ts tests/HighlightTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateAnimatorTest.ts tests/SlateTest.ts tests/SlideTest.ts tests/SourceHygieneTest.ts tests/SphereTest.ts tests/VisibilityTest.ts",
+    "test:unit": "mocha tests/AnimationTest.ts tests/CircleTest.ts tests/DiagnosticsTest.ts tests/ColorsTest.ts tests/ConstructionNameTest.ts tests/HighlightByNameTest.ts tests/HighlightTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateAnimatorTest.ts tests/SlateTest.ts tests/SlideTest.ts tests/SourceHygieneTest.ts tests/SphereTest.ts tests/VisibilityTest.ts",
+    "coverage": "c8 mocha --reporter min tests/SnapshotTest.ts tests/AnimationTest.ts tests/CircleTest.ts tests/DiagnosticsTest.ts tests/ColorsTest.ts tests/ConstructionNameTest.ts tests/HighlightByNameTest.ts tests/HighlightTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateAnimatorTest.ts tests/SlateTest.ts tests/SlideTest.ts tests/SourceHygieneTest.ts tests/SphereTest.ts tests/VisibilityTest.ts",
+    "coverage:unit": "c8 mocha --reporter min tests/AnimationTest.ts tests/CircleTest.ts tests/DiagnosticsTest.ts tests/ColorsTest.ts tests/ConstructionNameTest.ts tests/HighlightByNameTest.ts tests/HighlightTest.ts tests/LineTest.ts tests/ParseParamTest.ts tests/PlaneTest.ts tests/PointTest.ts tests/PolygonTest.ts tests/PolyhedronTest.ts tests/SectorTest.ts tests/SlateAnimatorTest.ts tests/SlateTest.ts tests/SlideTest.ts tests/SourceHygieneTest.ts tests/SphereTest.ts tests/VisibilityTest.ts",
     "coverage:report": "c8 report --reporter=html",
     "snapshots:clean": "rm -rf tests/snapshots && mkdir -p tests/snapshots && touch tests/snapshots/.gitkeep",
     "prepublishOnly": "npm run test:unit && npm run bundle:prod && npm run check:bundle",

--- a/src/elements/Constructions.ts
+++ b/src/elements/Constructions.ts
@@ -130,6 +130,8 @@ export function getConstructionName(cm: AllConstructions) : String {
         return "Point." + PointConstructions[cm];
     } else if (100 < cm && cm < 200) {
         return "Line." + LineConstructions[cm];
+    } else if (200 < cm && cm < 300) {
+        return "Circle." + CircleConstructions[cm];
     } else if (300 < cm && cm < 400) {
         return "Polygon." + PolygonConstructions[cm];
     } else if (400 < cm && cm < 500) {

--- a/tests/ConstructionNameTest.ts
+++ b/tests/ConstructionNameTest.ts
@@ -1,0 +1,102 @@
+// getConstructionName round-trip (#161).
+//
+// The function maps a construction's numeric enum value back to a
+// "Type.name" string, and is reached on exactly one path: the TypeError
+// Slate.createElement throws when no construction matches the supplied
+// params (src/Slate.ts). Because nothing but an error path calls it, a
+// whole element type went unnamed for a long time without anyone noticing
+// — Circle constructions (201-204) had no branch at all, so every circle
+// was reported as "<Not Valid Construction>" in a message whose entire job
+// is to tell you what you got wrong.
+//
+// These tests walk every enum rather than spot-checking, so the next range
+// added cannot repeat it.
+
+import "mocha";
+import * as assert from "assert";
+import {
+    getConstructionName,
+    PointConstructions, LineConstructions, CircleConstructions,
+    PolygonConstructions, SectorConstructions, PlaneConstructions,
+    SphereConstructions, PolyhedraConstructions,
+} from "../src/elements/Constructions";
+
+// Numeric members only — a TS numeric enum also carries reverse string keys.
+function members(e: any): [string, number][] {
+    return Object.keys(e)
+        .filter((k) => typeof e[k] === "number")
+        .map((k) => [k, e[k] as number] as [string, number]);
+}
+
+const ENUMS: [string, any][] = [
+    ["Point", PointConstructions],
+    ["Line", LineConstructions],
+    ["Circle", CircleConstructions],
+    ["Polygon", PolygonConstructions],
+    ["Sector", SectorConstructions],
+    ["Plane", PlaneConstructions],
+    ["Sphere", SphereConstructions],
+    ["Polyhedra", PolyhedraConstructions],
+];
+
+describe("getConstructionName (#161)", () => {
+
+    it("names every construction in every enum", () => {
+        const unnamed: string[] = [];
+        for (const [type, e] of ENUMS) {
+            for (const [key, value] of members(e)) {
+                const got = getConstructionName(value);
+                if (got !== type + "." + key) {
+                    unnamed.push(`${type}.${key} (${value}) -> ${got}`);
+                }
+            }
+        }
+        assert.deepEqual(unnamed, [],
+            "every construction must round-trip to Type.name — this message is " +
+            "the only thing a caller sees when a construction fails to match");
+    });
+
+    it("names Circle constructions", () => {
+        // The specific regression: the range chain jumped from 100-200
+        // straight to 300-400, skipping 201-204 entirely.
+        assert.equal(getConstructionName(CircleConstructions.radius), "Circle.radius");
+        assert.equal(getConstructionName(CircleConstructions.circumcircle), "Circle.circumcircle");
+        assert.equal(getConstructionName(CircleConstructions.invert), "Circle.invert");
+        assert.equal(getConstructionName(CircleConstructions.intersection), "Circle.intersection");
+    });
+
+    it("leaves no gap between the type ranges", () => {
+        // Ranges are hand-written as `N00 < cm && cm < N00+100`, so a whole
+        // decade can be omitted silently. Assert each enum sits inside its
+        // own hundred and that the hundreds are contiguous from 0.
+        const spans = ENUMS.map(([type, e]) => {
+            const vals = members(e).map(([, v]) => v);
+            return { type, lo: Math.min(...vals), hi: Math.max(...vals) };
+        });
+        for (let i = 0; i < spans.length; i++) {
+            const { type, lo, hi } = spans[i];
+            const hundred = i * 100;
+            assert.ok(lo > hundred && hi < hundred + 100,
+                `${type} spans ${lo}-${hi}, outside its ${hundred}-${hundred + 100} band`);
+        }
+    });
+
+    it("reports a value outside every range as invalid", () => {
+        assert.equal(getConstructionName(99999 as any), "<Not Valid Construction>");
+    });
+
+    it("would catch a value sitting exactly on a range boundary", () => {
+        // The comparisons are strict on both sides, so a member defined as
+        // exactly 100/200/300/... would fall through to the invalid string.
+        // Nothing does today (every enum starts at x01) — this pins that.
+        const onBoundary: string[] = [];
+        for (const [type, e] of ENUMS) {
+            for (const [key, value] of members(e)) {
+                if (value % 100 === 0) onBoundary.push(`${type}.${key} = ${value}`);
+            }
+        }
+        assert.deepEqual(onBoundary, [],
+            "a construction defined on a multiple of 100 would be unnamed, " +
+            "because both range bounds are strict");
+    });
+});


### PR DESCRIPTION
Closes #161.

`getConstructionName()` had no branch for the 200-range, so **every Circle
construction reported as `"<Not Valid Construction>"`** — the chain jumped
from `100 < cm && cm < 200` straight to `300 < cm && cm < 400`, and
`CircleConstructions` occupies 201-204.

```
Circle.radius        (201)  ->  <Not Valid Construction>
Circle.circumcircle  (202)  ->  <Not Valid Construction>
Circle.invert        (203)  ->  <Not Valid Construction>
Circle.intersection  (204)  ->  <Not Valid Construction>
```

## It made diagnostics lie

The function has one caller — `Slate.createElement` (`src/Slate.ts:670`),
which builds the `TypeError` thrown when no construction matches the supplied
params. Rendering is unaffected; what breaks is the message whose entire job is
to tell you what went wrong.

It already cost debugging time. Sweeping the archival fixtures for #154,
`round_geometry/seventen.html` reported:

```
element 'B'' failed to construct: Construction not found for "B'" <Not Valid Construction> with params P=[] E=[] N=[1,3,5]
```

`B'` is `circle;circumcircle` — perfectly valid. That `<Not Valid
Construction>` was this gap, not a bad construction name; the real fault was
numeric-looking element names being coerced to numbers (#155). Two defects
stacked, and this one hid the other.

## A port regression, not an inherited defect

The Java applet cannot have this bug. `geom_applet/source/Slate.java:79` uses
a 2-D table indexed by element class — circles are just the third row, with no
range arithmetic to get wrong:

```java
static String constructionName[][] =
  { { /* points  */ "free", "midpoint", ... },
    { /* lines   */ "connect", ... },
    { /* circles */ "radius", "circumcircle", "invert", "intersection"},
    ...
```

The port turned that into eight hand-written hundred-blocks and dropped one.

## The fix, and why it was invisible

Four lines. Coverage is what surfaced it: `getConstructionName` ran 7 times in
the last coverage run — 1 `Point.`, 3 `Line.`, and **3 falling through to the
invalid string** — with `Polygon.` through `Polyhedra.` never executed. It is
only reachable on an error path, so nothing exercised it.

`tests/ConstructionNameTest.ts` walks **every member of every enum** and
asserts a `Type.name` round-trip, rather than spot-checking Circle. Also
included: that each enum sits inside its own hundred-band with no gaps, and
that nothing is defined on a multiple of 100 (both range bounds are strict, so
such a value would silently fall through — nothing does today).

**Verified the guard is real:** removing the fix takes the suite from 390 to
388, with both Circle assertions failing; restoring it brings them back.

## Verification

- `tsc --noEmit` clean; **705 snapshot + 390 unit passing** (5 new).
- Test file added to `test:unit`, `coverage` and `coverage:unit`.

## Not in scope

Restoring the table-driven lookup the Java original used would be less fragile
than eight hand-maintained ranges, but it is a larger change than this bug
warrants. The round-trip test protects either shape.