### PR TITLE
Centring skips elements with runaway extent (#162)

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -574,12 +574,28 @@ inflates the box until the centre transform pushes the real geometry off
 canvas (a blank slideshow; hit on I.35, I.42 and I.43).
 
 `captureCentringBounds()` measures only elements that actually **paint**,
-and stores the result; `centringBounds` reads it back and
+skips those with **runaway extent** (#162 — see below), and stores the
+result; `centringBounds` reads it back and
 `clearCentringBounds()` drops it. The test is per element type, because a
 colour slot an element never uses tells you nothing — `PointElement`'s
 `drawEdge`/`drawFace` are no-ops, so a point's `edgeColor` (which defaults
 to black when the author omits the field) is not ink. It falls back to the
 all-elements box if nothing paints at all.
+
+**Runaway elements are skipped (#162, 0.15.0+).** An element can paint *and*
+have unbounded extent: a circumcircle through near-collinear points grows
+without limit, and on the hyperbolic Desargues figure one reached a radius of
+~11,300 on a 500×320 canvas — a bounding box of roughly 22,600 × 23,100, so
+maximizing translated the figure into blank space. Only the sliver crossing
+the canvas is ever seen, so an element wider or taller than **10×** the
+authored canvas is left out of the centring measurement. The threshold is
+deliberately generous: real figures spill past their canvas by 2–4× and
+centre exactly as before. `figureBounds()` is **unchanged** — it still
+reports what the model contains; only the centring measurement is
+opinionated. `slate.centringOutliers` names what was left out, so a deck
+checker can surface a near-degenerate construction; nothing is reported as a
+diagnostic, because after this the figure centres correctly and badging it
+would flag a page that works.
 
 The box is captured **once** on entering the maximized view rather than
 recomputed: a resize mid-walk must re-centre on the frame the walk started

--- a/src/Slate.ts
+++ b/src/Slate.ts
@@ -110,6 +110,11 @@ export class Slate {
     // can't drift as slides reveal and hide elements, and so cloneAside's
     // centre phase (#99) eases to exactly the same target.
     private _centringBounds : { minX: number, maxX: number, minY: number, maxY: number } | null = null;
+    // #162 — an element wider or taller than this many canvases is treated
+    // as unbounded for centring purposes. Generous on purpose: real figures
+    // spill past their canvas by ~2x and must be unaffected.
+    private static readonly CENTRING_OUTLIER_FACTOR = 10;
+    private _centringOutliers : string[] = [];
     private _viewOffsetX : number = 0;
     private _viewOffsetY : number = 0;
     private _viewScale : number = 1;
@@ -496,9 +501,61 @@ export class Slate {
     // all (a figure built entirely from helpers), so the caller always gets
     // the same shape of answer as before.
     captureCentringBounds() : { minX: number, maxX: number, minY: number, maxY: number } | null {
-        const inked = this._bounds(false, (e) => this._paintsInk(e));
-        this._centringBounds = inked != null ? inked : this._bounds(false);
+        this._centringOutliers = [];
+        const inked = this._bounds(false, (e) => {
+            if (!this._paintsInk(e)) return false;
+            if (this._isCentringOutlier(e)) {
+                if (e.name != null) this._centringOutliers.push(e.name);
+                return false;
+            }
+            return true;
+        });
+        // Everything was an outlier (or nothing paints) — better to centre on
+        // a runaway figure than to refuse to centre at all.
+        this._centringBounds = inked != null
+            ? inked
+            : (this._bounds(false, (e) => this._paintsInk(e)) || this._bounds(false));
         return this._centringBounds;
+    }
+
+    /**
+     * Should this element be left out of the centring box (#162)?
+     *
+     * #138 stopped an element that paints *nothing* from dragging the centre
+     * off-canvas. This is the other half: an element that legitimately paints
+     * but has runaway extent. A circumcircle through near-collinear points is
+     * unbounded, and on the hyperbolic Desargues figure one reached a radius
+     * of ~11,300 on a 500x320 canvas — bounds of roughly 22,600 x 23,100, so
+     * maximizing translated the whole figure into blank space.
+     *
+     * That is not an authoring mistake: Desargues' theorem is *about*
+     * collinearity, so constructions of that kind keep producing
+     * near-degenerate circles. Only the sliver crossing the canvas is ever
+     * seen, so such an element should not decide where the centre is.
+     *
+     * The threshold is deliberately generous — figures legitimately spill
+     * past their canvas (a Book I deck runs to ~2x) and must keep centring
+     * exactly as before. This only catches the pathological case.
+     */
+    private _isCentringOutlier(elem: GeomElement) : boolean {
+        const w = this._logicalWidth, h = this._logicalHeight;
+        if (!(w > 0) || !(h > 0)) return false;   // no frame of reference
+        const b = this._elementBounds(elem);
+        if (b == null) return false;
+        return (b.maxX - b.minX) > w * Slate.CENTRING_OUTLIER_FACTOR
+            || (b.maxY - b.minY) > h * Slate.CENTRING_OUTLIER_FACTOR;
+    }
+
+    /**
+     * Names of elements left out of the last centring measurement (#162).
+     *
+     * Exposed rather than reported: after this fix the figure centres
+     * correctly, so badging it would flag a page that now works. A deck
+     * checker can still surface these to point at a near-degenerate
+     * construction the author may want to know about.
+     */
+    get centringOutliers() : string[] {
+        return this._centringOutliers.slice();
     }
 
     get centringBounds() : { minX: number, maxX: number, minY: number, maxY: number } | null {
@@ -509,29 +566,44 @@ export class Slate {
         this._centringBounds = null;
     }
 
-    private _bounds(visibleOnly: boolean,
-                    accept?: (e: GeomElement) => boolean) : { minX: number, maxX: number, minY: number, maxY: number } | null {
+    // One element's axis-aligned extent, or null when it contributes none.
+    // Split out of _bounds (#162) so an element can be judged on its own
+    // size before it is allowed to influence the figure's centre.
+    private _elementBounds(elem: GeomElement) : { minX: number, maxX: number, minY: number, maxY: number } | null {
         let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
         const add = (x: number, y: number) => {
             if (x < minX) minX = x; if (x > maxX) maxX = x;
             if (y < minY) minY = y; if (y > maxY) maxY = y;
         };
+        if (elem instanceof PolygonElement) {
+            for (let v of elem.V) add(v.x, v.y);
+        } else if (elem instanceof CircleElement) {
+            const r = elem.radius;
+            add(elem.Center.x - r, elem.Center.y - r);
+            add(elem.Center.x + r, elem.Center.y + r);
+        } else if (elem instanceof LineElement) {
+            add(elem.A.x, elem.A.y);
+            add(elem.B.x, elem.B.y);
+        } else if (elem instanceof PointElement) {
+            add(elem.x, elem.y);
+        }
+        if (minX === Infinity) return null;
+        return { minX, maxX, minY, maxY };
+    }
+
+    private _bounds(visibleOnly: boolean,
+                    accept?: (e: GeomElement) => boolean) : { minX: number, maxX: number, minY: number, maxY: number } | null {
+        let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
         for (let elem of this._elements) {
             if (elem.name == null || elem.name.startsWith("screen")) continue;
             if (visibleOnly && !elem.visible) continue;
             if (accept != null && !accept(elem)) continue;
-            if (elem instanceof PolygonElement) {
-                for (let v of elem.V) add(v.x, v.y);
-            } else if (elem instanceof CircleElement) {
-                const r = elem.radius;
-                add(elem.Center.x - r, elem.Center.y - r);
-                add(elem.Center.x + r, elem.Center.y + r);
-            } else if (elem instanceof LineElement) {
-                add(elem.A.x, elem.A.y);
-                add(elem.B.x, elem.B.y);
-            } else if (elem instanceof PointElement) {
-                add(elem.x, elem.y);
-            }
+            const b = this._elementBounds(elem);
+            if (b == null) continue;
+            if (b.minX < minX) minX = b.minX;
+            if (b.maxX > maxX) maxX = b.maxX;
+            if (b.minY < minY) minY = b.minY;
+            if (b.maxY > maxY) maxY = b.maxY;
         }
         if (minX === Infinity) return null;
         return { minX, maxX, minY, maxY };

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -332,6 +332,135 @@ describe("slate", () => {
         });
     });
 
+
+    // #162 — an element can PAINT and still be pathologically large.
+    //
+    // #138 stopped an inkless off-canvas helper from dragging the centre
+    // away. This is the other half: a circumcircle through near-collinear
+    // points is unbounded, and on the hyperbolic Desargues figure one
+    // reached radius ~11,300 on a 500x320 canvas — bounds of roughly
+    // 22,600 x 23,100, so maximizing translated the figure into blank space.
+    // Only the sliver crossing the canvas is ever seen, so such an element
+    // must not decide where the centre is.
+    describe("centring outliers (#162)", () => {
+
+        // A small figure plus one runaway circle, in a 500x320 frame.
+        function scene(runawayRadius: number | null): Slate {   // arg only toggles the degenerate circle
+            const slate = new Slate(createCanvas(500, 320));
+            slate.inTest = true;
+            (slate as any)._logicalWidth = 500;
+            (slate as any)._logicalHeight = 320;
+            const mk = (spec: string) => {
+                const i = parseParam(spec);
+                const el = slate.createElement(i.construction, i.params, i.name);
+                el.nameColor = parseColor(i.nameColor, "black", "white");
+                el.vertexColor = parseColor(i.vertexColor, "red", "white");
+                el.edgeColor = parseColor(i.edgeColor, "black", "white");
+                return el;
+            };
+            mk("A;point;free;100,100");
+            mk("B;point;free;300,200");
+            mk("AB;line;connect;A,B");
+            if (runawayRadius != null) {
+                // The real shape of the bug: a circumcircle through THREE
+                // NEAR-COLLINEAR points. Its centre is computed internally
+                // (not a painted element), so the only thing that grows is
+                // the circle's own extent — which is exactly what #162 has
+                // to notice. The nearer to collinear, the larger the radius.
+                mk("N1;point;free;120,100");
+                mk("N2;point;free;260,100");
+                mk("N3;point;free;400,101");     // ~0.4 degrees off the line
+                mk("BIG;circle;circumcircle;N1,N2,N3");
+            }
+            slate.update();
+            return slate;
+        }
+
+        it("excludes an element far larger than the canvas", () => {
+            const slate = scene(12000);
+            const b = slate.captureCentringBounds()!;
+            assert.ok(b.maxX - b.minX < 500 * 10,
+                `centring box should not follow the runaway circle, got ` +
+                `${Math.round(b.maxX - b.minX)} wide`);
+            assert.ok(slate.centringOutliers.indexOf("BIG") >= 0,
+                "and it should say which element it left out");
+        });
+
+        it("leaves figureBounds() untouched", () => {
+            // The public bounds API still reports what the model contains;
+            // only the CENTRING measurement is opinionated.
+            const slate = scene(12000);
+            slate.captureCentringBounds();
+            const fb = slate.figureBounds()!;
+            assert.ok(fb.maxX - fb.minX > 500 * 10,
+                "figureBounds must still see the whole model");
+        });
+
+        it("does NOT exclude a figure that merely spills past its canvas", () => {
+            // Real decks run to ~2-4x their canvas and must centre exactly as
+            // before — the threshold is deliberately generous.
+            const slate = scene(null);
+            const mk = (spec: string) => {
+                const i = parseParam(spec);
+                const el = slate.createElement(i.construction, i.params, i.name);
+                el.edgeColor = "black"; el.nameColor = null; el.vertexColor = null;
+                return el;
+            };
+            mk("Wide;point;free;-600,-400");
+            mk("Wide2;point;free;1100,700");
+            mk("WW;line;connect;Wide,Wide2");
+            slate.update();
+            const b = slate.captureCentringBounds()!;
+            assert.deepEqual(slate.centringOutliers, [],
+                "a 1700x1100 figure on a 500x320 canvas is normal, not pathological");
+            assert.ok(b.minX <= -600 && b.maxX >= 1100,
+                "so it must still be measured in full");
+        });
+
+        it("reports no outliers on an ordinary figure", () => {
+            const slate = scene(null);
+            slate.captureCentringBounds();
+            assert.deepEqual(slate.centringOutliers, []);
+        });
+
+        it("still centres when EVERY element is an outlier", () => {
+            // Refusing to centre would be worse than centring on a runaway
+            // figure, so the fallback must always produce a box.
+            const slate = new Slate(createCanvas(500, 320));
+            slate.inTest = true;
+            (slate as any)._logicalWidth = 500;
+            (slate as any)._logicalHeight = 320;
+            const i = parseParam("P;point;free;0,0");
+            const p = slate.createElement(i.construction, i.params, i.name);
+            p.vertexColor = "red";
+            const j = parseParam("Q;point;free;99999,99999");
+            const q = slate.createElement(j.construction, j.params, j.name);
+            q.vertexColor = "red";
+            const k = parseParam("PQ;line;connect;P,Q");
+            const l = slate.createElement(k.construction, k.params, k.name);
+            l.edgeColor = "black"; l.nameColor = null; l.vertexColor = null;
+            slate.update();
+            const b = slate.captureCentringBounds();
+            assert.ok(b != null, "must never refuse to produce a centring box");
+        });
+
+        it("outliers are recomputed on each capture", () => {
+            const slate = scene(12000);
+            slate.captureCentringBounds();
+            assert.equal(slate.centringOutliers.length, 1);
+            slate.captureCentringBounds();
+            assert.equal(slate.centringOutliers.length, 1,
+                "a second capture must not accumulate duplicates");
+        });
+
+        it("centringOutliers hands back a copy", () => {
+            const slate = scene(12000);
+            slate.captureCentringBounds();
+            slate.centringOutliers.length = 0;
+            assert.equal(slate.centringOutliers.length, 1);
+        });
+    });
+
     describe("drag coordinates: 2D pivot scene", () => {
 
         it("should rotate non-pivot elements around F when dragging a derived point", () => {


### PR DESCRIPTION
Closes #162.

#138 stopped an element that paints **nothing** from dragging the centre
off-canvas. This is the other half: an element that legitimately paints but
has **unbounded extent**. Maximizing still translated the figure thousands of
pixels away and left a blank canvas.

## Reproduced against the real page

The live deck no longer shows it — the slideshow session nudged a free point
as an interim. So I tested the **pre-nudge** version from their git history
(`857b44d^`), which is the configuration the issue reported:

```
figureBounds (raw, unchanged) : x[-14507, 8092] y[-902, 22234]  (22599x23136)
centring bounds (#162)        : x[-732, 1311]   y[-902, 1074]   (2043x1975)
excluded as outliers          : ["BP"]
centre would be at            : (289, 86)   [canvas centre is (250, 160)]
```

Those raw bounds match the ticket exactly, `BP` is precisely the element it
named, and the centre moves from roughly **(-3207, 10666)** to **(289, 86)**.

## The fix

An element wider or taller than **10x** the authored canvas is left out of the
centring measurement. Only the sliver crossing the canvas is ever seen, so
such an element should not decide where the centre is.

The ticket preferred option 3 (clip each element to the visible region). I
went with option 1 (clamp outliers) because clipping would change centring for
every figure that legitimately spills past its canvas — and they are common:
that same Desargues page has canvases at 774x656 and 1496x1609 against
500x320, and a Book I deck runs to ~2x. A clamp leaves all of those untouched
and catches only the pathological case. There is a test asserting a 1700x1100
figure on a 500x320 canvas is still measured in full.

**`figureBounds()` is unchanged** — it still reports what the model contains.
Only the centring measurement is opinionated, and there is a test pinning
that.

## On reporting it

`slate.centringOutliers` names what was left out, but **nothing is emitted as
a diagnostic**. After this fix the figure centres correctly, so badging it
would flag a page that works — the #159 lesson. The accessor is there so
`check-decks.js` can surface a near-degenerate construction if the authors
want it, which is the "expose a guard" the ticket asked about.

## Why this keeps happening

Worth recording: it is not an authoring slip. Desargues' theorem is *about*
collinearity, so constructions of that kind keep producing near-degenerate
circumcircles. Any circle through points a theorem asserts are collinear has
the same exposure.

## Verification

- `tsc --noEmit` clean; **705 snapshot + 426 unit passing** (7 new).
- The test scene builds a genuine circumcircle through points ~0.4 degrees off
  collinear, rather than a contrived huge circle — my first attempt used a
  painted centre point 12,000px away, which failed for the wrong reason
  (position, not extent) and would have tested nothing real.
- Also covered: `figureBounds()` untouched, an ordinary figure reports no
  outliers, a merely-large figure is not excluded, the fallback still produces
  a box when *every* element is an outlier, and repeated captures do not
  accumulate.
- Documented in `api.md`.

## For the slideshow session

The deck-side nudge on `desargues-theorem` `canvas_2` can be reverted once
this releases — though their placement is fine to keep, since it also makes
the figure read better.