### PR TITLE
Centring outliers: use the logical-size getters, not the private fields

### DIFF
--- a/src/Slate.ts
+++ b/src/Slate.ts
@@ -538,7 +538,11 @@ export class Slate {
      * exactly as before. This only catches the pathological case.
      */
     private _isCentringOutlier(elem: GeomElement) : boolean {
-        const w = this._logicalWidth, h = this._logicalHeight;
+        // The GETTERS, not the private fields: _logicalWidth is 0 until
+        // init() sets it, and the getters fall back to the canvas bitmap.
+        // Reading the fields made this a silent no-op on any slate built
+        // without an explicit size — including the whole snapshot path.
+        const w = this.logicalWidth, h = this.logicalHeight;
         if (!(w > 0) || !(h > 0)) return false;   // no frame of reference
         const b = this._elementBounds(elem);
         if (b == null) return false;

--- a/tests/SlateTest.ts
+++ b/tests/SlateTest.ts
@@ -346,10 +346,10 @@ describe("slate", () => {
 
         // A small figure plus one runaway circle, in a 500x320 frame.
         function scene(runawayRadius: number | null): Slate {   // arg only toggles the degenerate circle
+            // Deliberately NOT setting _logicalWidth/_logicalHeight: a
+            // 500x320 canvas is the frame of reference via the getters.
             const slate = new Slate(createCanvas(500, 320));
             slate.inTest = true;
-            (slate as any)._logicalWidth = 500;
-            (slate as any)._logicalHeight = 320;
             const mk = (spec: string) => {
                 const i = parseParam(spec);
                 const el = slate.createElement(i.construction, i.params, i.name);
@@ -451,6 +451,20 @@ describe("slate", () => {
             slate.captureCentringBounds();
             assert.equal(slate.centringOutliers.length, 1,
                 "a second capture must not accumulate duplicates");
+        });
+
+
+        it("works on a slate with no explicitly-set logical size", () => {
+            // The private _logicalWidth is 0 until init() sets it; the
+            // GETTER falls back to the canvas bitmap. Reading the field made
+            // this whole check a silent no-op on any slate built without an
+            // explicit size — which is every scene the snapshot suite builds.
+            const slate = scene(12000);
+            assert.equal((slate as any)._logicalWidth, 0,
+                "precondition: nothing set the logical size");
+            slate.captureCentringBounds();
+            assert.ok(slate.centringOutliers.indexOf("BIG") >= 0,
+                "the canvas bitmap must serve as the frame of reference");
         });
 
         it("centringOutliers hands back a copy", () => {


### PR DESCRIPTION
Follow-up to #162 / #167.

`_isCentringOutlier` read the private `_logicalWidth`/`_logicalHeight` fields. Those are `0` until `init()` sets them; the public `logicalWidth`/`logicalHeight` getters fall back to the canvas bitmap. So on any slate built without an explicit size the check bailed at `if (!(w > 0))` and the whole #162 fix was a silent no-op.

That covers every scene the snapshot suite builds, and any consumer that doesn't set a size. It worked in the browser only because `init()` happens to set the fields.

Caught by measuring the archival fixture `view/round_geometry/desargues.html` — Joyce's original positions, which are the degenerate ones the lektor copy was later nudged away from:

```
applet 2  canvas 500x320   before: centring 22599x23136  outliers []
                            after: centring  2043x1975   outliers ["BP"]
```

The other three applets on the page are unaffected, as are 705/705 snapshots.

Adds a regression test that asserts `_logicalWidth === 0` as a precondition and then requires the outlier to be found anyway, so this can't silently revert.