### PR TITLE
0.15.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Library is **post-porting, publish-ready**. There is no longer a
 "next construction to port" backlog or session-startup ritual.
 
 - All 69 construction methods (with 19 3D variants) are implemented.
-- 385 unit tests + 705 snapshot tests pass.
+- 437 unit tests + 705 snapshot tests pass.
 - 0.4.0 shipped cross-highlighting (`emphasized` / `emphasisAmount`
   + `lookupElement`); 0.5.0 shipped the slideshow surface
   (`slides`, `setVisibleNames`, `addAlias`, `resolveJustification`,
@@ -96,7 +96,7 @@ dist/                     Webpack output (gitignored, shipped to npm)
 ```sh
 npm install              # one-time
 npm run build            # tsc --noEmit (typecheck only)
-npm run test:unit        # 385 unit tests (~140 ms)
+npm run test:unit        # 437 unit tests (~170 ms)
 npm run test:snapshot    # 705 snapshot tests; auto-creates goldens on first run
 npm test                 # both
 npm run bundle           # dev-mode bundle to dist/bundle.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ That's it.
 ## Running tests
 
 ```sh
-npm run test:unit      # 385 unit tests — fast (~140 ms)
+npm run test:unit      # 437 unit tests — fast (~170 ms)
 npm run test:snapshot  # 700 visual-regression tests against snapshot goldens
 npm test               # both (snapshot then unit)
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brownnrl/geomlib",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@brownnrl/geomlib",
-  "version": "0.14.0",
-  "description": "Interactive Euclidean geometry constructions in the browser \u2014 a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
+  "version": "0.15.0",
+  "description": "Interactive Euclidean geometry constructions in the browser — a TypeScript port of David E. Joyce's 1996 Java Geometry Applet.",
   "keywords": [
     "euclid",
     "elements",


### PR DESCRIPTION
Version bump only — the four files the 0.14.0 cut touched: `package.json`, `package-lock.json`, and the test counts in `AGENTS.md` / `CONTRIBUTING.md` (385 → 437 unit; snapshots stay 705).

### What 0.15.0 ships

| Issue | Change |
|---|---|
| **#137** | **`A.Point.followPath`** — a point travels a path (`via` / `along` / `arc`) and by default returns exactly to its start. The slideshow session's last remaining ask; unblocks euclids-elements-lektor#13 (I.31). |
| **#164** | **`centerOn`** — name the element the maximized / presentation view centres on, instead of deriving it from figure bounds. |
| **#162**, #168 | Centring skips elements with runaway extent, so a near-degenerate circumcircle can't translate a figure off-screen. |
| **#159** | Deck validation exempts names a macro animation creates at run time — no more false warning badge on I.23's ten-circle slide. |
| **#161** | `getConstructionName` gained its missing Circle branch. |
| **#67** | README badges; coverage + snapshot reports publish to GitHub Pages on `npm publish`. |

`followPath` and `centerOn` are new public API, hence the minor bump. Everything else is a fix, and every change is additive or default-off — no existing deck renders differently.

### State

437 unit + 705/705 snapshot tests pass, no golden moved. No open PRs behind this one.

After merge: publish, then the `v0.15.0` tag gets pushed and the coordination doc updated so the slideshow session can bump its pin.